### PR TITLE
support date subtract date and date subtract year month duration

### DIFF
--- a/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
@@ -383,6 +383,7 @@ class FeelInterpreter {
       case ValYearMonthDuration(y) => ValYearMonthDuration( x.plus(y).normalized )
       case ValLocalDateTime(y) => ValLocalDateTime( y.plus(x) )
       case ValDateTime(y) => ValDateTime( y.plus(x) )
+      case ValDate(y) => ValDate( y.plus(x) )
       case _ => error(y, s"expect Date-Time, or Year-Month-Duration but found '$x'")
     }
     case ValDayTimeDuration(x) => y match {
@@ -391,7 +392,12 @@ class FeelInterpreter {
       case ValDateTime(y) => ValDateTime( y.plus(x) )
       case ValLocalTime(y) => ValLocalTime( y.plus(x) )
       case ValTime(y) => ValTime( y.plus(x) )
+      case ValDate(y) => ValDate( y.atStartOfDay().plus(x).toLocalDate() )
       case _ => error(y, s"expect Date-Time, Time, or Day-Time-Duration but found '$x'")
+    }
+    case ValDate(x) => y match {
+      case ValDayTimeDuration(y) => ValDate( x.atStartOfDay().plus(y).toLocalDate() )
+      case ValYearMonthDuration(y) => ValDate( x.plus(y) )
     }
     case _ => error(x, s"expected Number, String, Date, Time or Duration but found '$x'")
   }
@@ -421,8 +427,9 @@ class FeelInterpreter {
       case _ => error(y, s"expect Time, or Year-Month-/Day-Time-Duration but found '$x'")
     }
     case ValDate(x) => y match {
-      case ValDate(y) => ValYearMonthDuration( Period.between(x, y) )
+      case ValDate(y) => ValDayTimeDuration( Duration.between(y.atStartOfDay, x.atStartOfDay) )
       case ValYearMonthDuration(y) => ValDate( x.minus(y) )
+      case ValDayTimeDuration(y) => ValDate( x.atStartOfDay.minus(y).toLocalDate() )
       case _ => error(y, s"expect Date, or Year-Month-Duration but found '$x'")
     }
     case ValYearMonthDuration(x) => withYearMonthDuration(y, y => ValYearMonthDuration( x.minus(y).normalized ))

--- a/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
@@ -384,7 +384,7 @@ class FeelInterpreter {
       case ValLocalDateTime(y) => ValLocalDateTime( y.plus(x) )
       case ValDateTime(y) => ValDateTime( y.plus(x) )
       case ValDate(y) => ValDate( y.plus(x) )
-      case _ => error(y, s"expect Date-Time, or Year-Month-Duration but found '$x'")
+      case _ => error(y, s"expect Date-Time, Date, or Year-Month-Duration but found '$x'")
     }
     case ValDayTimeDuration(x) => y match {
       case ValDayTimeDuration(y) => ValDayTimeDuration( x.plus(y) )
@@ -393,11 +393,12 @@ class FeelInterpreter {
       case ValLocalTime(y) => ValLocalTime( y.plus(x) )
       case ValTime(y) => ValTime( y.plus(x) )
       case ValDate(y) => ValDate( y.atStartOfDay().plus(x).toLocalDate() )
-      case _ => error(y, s"expect Date-Time, Time, or Day-Time-Duration but found '$x'")
+      case _ => error(y, s"expect Date-Time, Date, Time, or Day-Time-Duration but found '$x'")
     }
     case ValDate(x) => y match {
       case ValDayTimeDuration(y) => ValDate( x.atStartOfDay().plus(y).toLocalDate() )
       case ValYearMonthDuration(y) => ValDate( x.plus(y) )
+      case _ => error(y, s"expect Year-Month-/Day-Time-Duration but found '$x'")
     }
     case _ => error(x, s"expected Number, String, Date, Time or Duration but found '$x'")
   }
@@ -430,7 +431,7 @@ class FeelInterpreter {
       case ValDate(y) => ValDayTimeDuration( Duration.between(y.atStartOfDay, x.atStartOfDay) )
       case ValYearMonthDuration(y) => ValDate( x.minus(y) )
       case ValDayTimeDuration(y) => ValDate( x.atStartOfDay.minus(y).toLocalDate() )
-      case _ => error(y, s"expect Date, or Year-Month-Duration but found '$x'")
+      case _ => error(y, s"expect Date, or Year-Month-/Day-Time-Duration but found '$x'")
     }
     case ValYearMonthDuration(x) => withYearMonthDuration(y, y => ValYearMonthDuration( x.minus(y).normalized ))
     case ValDayTimeDuration(x) => withDayTimeDuration(y, y => ValDayTimeDuration( x.minus(y) ))

--- a/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/interpreter/FeelInterpreter.scala
@@ -420,6 +420,11 @@ class FeelInterpreter {
       case ValDayTimeDuration(y) => ValDateTime( x.minus(y) )
       case _ => error(y, s"expect Time, or Year-Month-/Day-Time-Duration but found '$x'")
     }
+    case ValDate(x) => y match {
+      case ValDate(y) => ValYearMonthDuration( Period.between(x, y) )
+      case ValYearMonthDuration(y) => ValDate( x.minus(y) )
+      case _ => error(y, s"expect Date, or Year-Month-Duration but found '$x'")
+    }
     case ValYearMonthDuration(x) => withYearMonthDuration(y, y => ValYearMonthDuration( x.minus(y).normalized ))
     case ValDayTimeDuration(x) => withDayTimeDuration(y, y => ValDayTimeDuration( x.minus(y) ))
     case _ => error(x, s"expected Number, Date, Time or Duration but found '$x'")

--- a/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
@@ -445,8 +445,19 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval(""" time("08:30:00+01:00") between time("08:00:00+01:00") and time("10:00:00+01:00") """) should be (ValBoolean(true))
     eval(""" time("08:30:00+01:00") between time("09:00:00+01:00") and time("10:00:00+01:00") """) should be (ValBoolean(false))
   }
+  
+  
+  "A date" should "subtract from another date" in {
 
-  "A date" should "compare with '='" in {
+    eval(""" date("2012-12-25") - date("2012-12-24") """) should be(ValYearMonthDuration("P-1D"))
+
+    eval(""" date("2012-12-24") - date("2012-12-25") """) should be(ValYearMonthDuration("P1D"))
+
+    eval(""" date("2013-02-25") - date("2012-12-24") """) should be(ValYearMonthDuration("P-2M-1D"))
+  }
+
+
+  it should "compare with '='" in {
 
     eval(""" date("2017-01-10") = date("2017-01-10") """) should be(ValBoolean(true))
     eval(""" date("2017-01-10") = date("2017-01-11") """) should be(ValBoolean(false))
@@ -586,6 +597,15 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval(""" date and time("2017-01-10T10:30:00") - duration("P1M") """) should be(ValLocalDateTime("2016-12-10T10:30:00"))
 
     eval(""" date and time("2017-01-10T10:30:00+01:00") - duration("P1M") """) should be(ValDateTime("2016-12-10T10:30:00+01:00"))
+  }
+  
+  it should "subtract from date" in {
+
+    eval(""" date("2017-01-10") - duration("P1M") """) should be(ValDate("2016-12-10"))
+
+    eval(""" date("2017-01-10") - duration("P1Y") """) should be(ValDate("2016-01-10"))
+
+    eval(""" date("2017-01-10") - duration("P1Y1M") """) should be(ValDate("2015-12-10"))
   }
 
   it should "multiply by '3'" in {

--- a/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
@@ -449,11 +449,11 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
   
   "A date" should "subtract from another date" in {
 
-    eval(""" date("2012-12-25") - date("2012-12-24") """) should be(ValYearMonthDuration("P-1D"))
+    eval(""" date("2012-12-25") - date("2012-12-24") """) should be(ValDayTimeDuration("P1D"))
 
-    eval(""" date("2012-12-24") - date("2012-12-25") """) should be(ValYearMonthDuration("P1D"))
+    eval(""" date("2012-12-24") - date("2012-12-25") """) should be(ValDayTimeDuration("P-1D"))
 
-    eval(""" date("2013-02-25") - date("2012-12-24") """) should be(ValYearMonthDuration("P-2M-1D"))
+    eval(""" date("2013-02-25") - date("2012-12-24") """) should be(ValDayTimeDuration("P63D"))
   }
 
 
@@ -585,6 +585,12 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval(""" duration("P1M") + date and time("2017-01-10T10:30:00+01:00") """) should be(ValDateTime("2017-02-10T10:30:00+01:00"))
     eval(""" date and time("2017-01-10T10:30:00+01:00") + duration("P1Y") """) should be(ValDateTime("2018-01-10T10:30:00+01:00"))
   }
+  
+  it should "add to date" in {
+
+    eval(""" duration("P1M") + date("2017-01-10") """) should be(ValDate("2017-02-10"))
+    eval(""" date("2017-01-10") + duration("P1Y") """) should be(ValDate("2018-01-10"))
+  }
 
   it should "subtract from year-month-duration" in {
 
@@ -675,6 +681,14 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval(""" duration("PT1H") + date and time("2017-01-10T10:30:00+01:00") """) should be(ValDateTime("2017-01-10T11:30:00+01:00"))
     eval(""" date and time("2017-01-10T10:30:00+01:00") + duration("P1D") """) should be(ValDateTime("2017-01-11T10:30:00+01:00"))
   }
+  
+   it should "add to date" in {
+
+    eval(""" duration("PT1H") + date("2017-01-10") """) should be(ValDate("2017-01-10"))
+    eval(""" duration("P1D") + date("2017-01-10") """) should be(ValDate("2017-01-11"))
+    eval(""" date("2017-01-10") + duration("PT1M") """) should be(ValDate("2017-01-10"))
+    eval(""" date("2017-01-10") + duration("P1D") """) should be(ValDate("2017-01-11"))
+  }
 
   it should "add to time" in {
 
@@ -698,6 +712,13 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval(""" date and time("2017-01-10T10:30:00+01:00") - duration("PT1H") """) should be(ValDateTime("2017-01-10T09:30:00+01:00"))
   }
 
+  it should "subtract from date" in {
+
+    eval(""" date("2017-01-10") - duration("PT1H") """) should be(ValDate("2017-01-09"))
+
+    eval(""" date("2017-01-10") - duration("P1DT1H") """) should be(ValDate("2017-01-08"))
+  }
+  
   it should "subtract from time" in {
 
     eval(""" time("10:30:00") - duration("PT1H") """) should be(ValLocalTime("09:30:00"))


### PR DESCRIPTION
Associated to #40 - My initial attempt supports `ValDate - ValDate` and `ValDate - ValYearMonthDuration`. I cannot figure out how to implement `ValDate - ValDayTimeDuration` (which would be required to do something like `date("2012-12-25") - duration("1D")`.

I also am slightly confused as to why the date subtraction produces negatives where I would expect positive and vice-versa. `time("10:00:00") - time("09:00:00")` returns `PT1H`, whereas `date("2012-12-25") - date("2012-12-24")` returns `P-1D`.