### PR TITLE
chore(engine): escape names with ` instead of '

### DIFF
--- a/docs/feel-expression.md
+++ b/docs/feel-expression.md
@@ -54,10 +54,10 @@ Inside a context, the previous values can be accessed.
 }
 ```
 
-If the name or path contains any special character (e.g. whitespace, dash, etc.) then the name needs to be wrapped into single quotes `'foo bar'`.
+If the name or path contains any special character (e.g. whitespace, dash, etc.) then the name needs to be wrapped into single backquotes/backtick `` `foo bar` ``.
 
 ```js
-'name with whitespace'.'name+operator'
+`name with whitespace`.`name+operator`
 ```
 
 ### Addition

--- a/feel-engine/src/main/scala/org/camunda/feel/parser/FeelParser.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/parser/FeelParser.scala
@@ -213,7 +213,7 @@ object FeelParser extends JavaTokenParsers {
     : Parser[String] = escapedIdentifier | "time offset" | identifier
 
   private lazy val escapedIdentifier
-    : Parser[String] = ("'" ~> """([^'"\x00-\x1F\x7F\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*""".r <~ "'")
+    : Parser[String] = ("`" ~> """([^`"\x00-\x1F\x7F\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*""".r <~ "`")
 
   // FEEL name definition
   private lazy val feelName: Parser[String] = nameStart ~! rep(

--- a/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/interpreter/InterpreterExpressionTest.scala
@@ -5,9 +5,12 @@ import org.scalatest.Matchers
 import org.camunda.feel._
 
 /**
- * @author Philipp Ossler
- */
-class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrationTest {
+  * @author Philipp Ossler
+  */
+class InterpreterExpressionTest
+    extends FlatSpec
+    with Matchers
+    with FeelIntegrationTest {
 
   "An expression" should "be an if-then-else" in {
 
@@ -15,15 +18,17 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
 
     eval(exp, Map("x" -> 2)) should be(ValString("low"))
     eval(exp, Map("x" -> 7)) should be(ValString("high"))
-    
+
     eval(exp, Map("x" -> "foo")) should be(ValString("high"))
   }
 
   it should "be a simple positive unary test" in {
 
-    eval("< 3", Map(RootContext.defaultInputVariable -> 2)) should be(ValBoolean(true))
+    eval("< 3", Map(RootContext.defaultInputVariable -> 2)) should be(
+      ValBoolean(true))
 
-    eval("(2 .. 4)", Map(RootContext.defaultInputVariable -> 5)) should be(ValBoolean(false))
+    eval("(2 .. 4)", Map(RootContext.defaultInputVariable -> 5)) should be(
+      ValBoolean(false))
   }
 
   it should "be an instance of" in {
@@ -37,14 +42,14 @@ class InterpreterExpressionTest extends FlatSpec with Matchers with FeelIntegrat
     eval("x instance of string", Map("x" -> "yes")) should be(ValBoolean(true))
     eval("x instance of string", Map("x" -> 0)) should be(ValBoolean(false))
   }
-  
+
   it should "be an escaped identifier" in {
     // regular identifier
-    eval(" 'x' ", Map("x" -> "foo")) should be(ValString("foo"))
+    eval(" `x` ", Map("x" -> "foo")) should be(ValString("foo"))
     // with whitespace
-    eval(" 'a b' ", Map("a b" -> "foo")) should be(ValString("foo"))
+    eval(" `a b` ", Map("a b" -> "foo")) should be(ValString("foo"))
     // with operator
-    eval(" 'a-b' ", Map("a-b" -> 3)) should be(ValNumber(3))
+    eval(" `a-b` ", Map("a-b" -> 3)) should be(ValNumber(3))
   }
 
   "Null" should "compare to null" in {

--- a/feel-engine/src/test/scala/org/camunda/feel/parser/ParseExpressionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/parser/ParseExpressionTest.scala
@@ -7,8 +7,8 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
 /**
- * @author Philipp Ossler
- */
+  * @author Philipp Ossler
+  */
 class ParseExpressionTest extends FlatSpec with Matchers {
 
   "An expression" should "be a name" in {
@@ -20,19 +20,19 @@ class ParseExpressionTest extends FlatSpec with Matchers {
     parse("before") should be(Ref("before"))
   }
 
-  it should "be a quoted name 'a'" in {
+  it should "be a quoted name `a`" in {
 
-    parse(" 'a' ") should be(Ref("a"))
+    parse(" `a` ") should be(Ref("a"))
   }
 
-  it should "be a quoted name 'a b'" in {
+  it should "be a quoted name `a b`" in {
 
-    parse(" 'a b' ") should be(Ref("a b"))
+    parse(" `a b` ") should be(Ref("a b"))
   }
 
-  it should "be a quoted name 'a-b'" in {
+  it should "be a quoted name `a-b`" in {
 
-    parse(" 'a-b' ") should be(Ref("a-b"))
+    parse(" `a-b` ") should be(Ref("a-b"))
   }
   it should "parse null" in {
 
@@ -51,7 +51,8 @@ class ParseExpressionTest extends FlatSpec with Matchers {
 
   it should "ignore an one line comment '// ...'" in {
 
-    parse("""duration("P1D") // one day""") should be(ConstDayTimeDuration("P1D"))
+    parse("""duration("P1D") // one day""") should be(
+      ConstDayTimeDuration("P1D"))
   }
 
   it should "ignore a multi line comment '/* ... */'" in {
@@ -65,9 +66,8 @@ class ParseExpressionTest extends FlatSpec with Matchers {
 
     // numeric addition
     parse("2+3") should be(Addition(ConstNumber(2), ConstNumber(3)))
-    parse("2+3+4") should be(Addition(Addition(
-      ConstNumber(2),
-      ConstNumber(3)), ConstNumber(4)))
+    parse("2+3+4") should be(
+      Addition(Addition(ConstNumber(2), ConstNumber(3)), ConstNumber(4)))
   }
 
   it should "parse a substraction" in {
@@ -98,80 +98,78 @@ class ParseExpressionTest extends FlatSpec with Matchers {
 
   it should "parse a function definition" in {
 
-    parse("function() 42") should be(FunctionDefinition(
-      parameters = List(),
-      body = ConstNumber(42)))
+    parse("function() 42") should be(
+      FunctionDefinition(parameters = List(), body = ConstNumber(42)))
 
-    parse("function(a,b) a + b") should be(FunctionDefinition(
-      parameters = List("a", "b"),
-      body = Addition(Ref("a"), Ref("b"))))
+    parse("function(a,b) a + b") should be(
+      FunctionDefinition(parameters = List("a", "b"),
+                         body = Addition(Ref("a"), Ref("b"))))
   }
 
   it should "parse a function invocation without parameters" in {
 
-    parse("f()") should be(FunctionInvocation(
-      "f",
-      params = PositionalFunctionParameters(List())))
+    parse("f()") should be(
+      FunctionInvocation("f", params = PositionalFunctionParameters(List())))
   }
 
   it should "parse a function invocation with positional parameters" in {
 
-    parse("fib(1)") should be(FunctionInvocation(
-      "fib",
-      params = PositionalFunctionParameters(List(ConstNumber(1)))))
+    parse("fib(1)") should be(
+      FunctionInvocation("fib",
+                         params =
+                           PositionalFunctionParameters(List(ConstNumber(1)))))
 
-    parse("""concat("in", x)""") should be(FunctionInvocation(
-      "concat",
-      params = PositionalFunctionParameters(List(
-        ConstString("in"),
-        Ref("x")))))
+    parse("""concat("in", x)""") should be(
+      FunctionInvocation("concat",
+                         params = PositionalFunctionParameters(
+                           List(ConstString("in"), Ref("x")))))
   }
 
   it should "parse a function invocation with named parameters" in {
 
-    parse("f(a:1)") should be(FunctionInvocation(
-      "f",
-      params = NamedFunctionParameters(Map("a" -> ConstNumber(1)))))
+    parse("f(a:1)") should be(
+      FunctionInvocation("f",
+                         params =
+                           NamedFunctionParameters(Map("a" -> ConstNumber(1)))))
 
-    parse("f(a:1, b:true)") should be(FunctionInvocation(
-      "f",
-      params = NamedFunctionParameters(Map(
-        "a" -> ConstNumber(1),
-        "b" -> ConstBool(true)))))
+    parse("f(a:1, b:true)") should be(
+      FunctionInvocation("f",
+                         params = NamedFunctionParameters(
+                           Map("a" -> ConstNumber(1), "b" -> ConstBool(true)))))
   }
 
   it should "parse a function invocation with escaped name" in {
 
-    parse(" 'a b'(1) ") should be(FunctionInvocation(
-      "a b",
-      params = PositionalFunctionParameters(List(ConstNumber(1)))))
+    parse(" `a b`(1) ") should be(
+      FunctionInvocation("a b",
+                         params =
+                           PositionalFunctionParameters(List(ConstNumber(1)))))
   }
 
   it should "parse a function invocation with ? argument" in {
 
-    parse("f(?, 21)") should be(FunctionInvocation(
-      "f",
-      params = PositionalFunctionParameters(List(
-        ConstInputValue,
-        ConstNumber(21)))))
+    parse("f(?, 21)") should be(
+      FunctionInvocation("f",
+                         params = PositionalFunctionParameters(
+                           List(ConstInputValue, ConstNumber(21)))))
   }
 
   it should "parse an if-then-else condition" in {
 
-    parse(""" if (x < 5) then "low" else "high" """) should be(If(
-      condition = LessThan(Ref("x"), ConstNumber(5)),
-      statement = ConstString("low"),
-      elseStatement = ConstString("high")))
+    parse(""" if (x < 5) then "low" else "high" """) should be(
+      If(condition = LessThan(Ref("x"), ConstNumber(5)),
+         statement = ConstString("low"),
+         elseStatement = ConstString("high")))
   }
 
   it should "parse a disjunction" in {
 
-    parse("true or false") should be(Disjunction(
-      ConstBool(true), ConstBool(false)))
+    parse("true or false") should be(
+      Disjunction(ConstBool(true), ConstBool(false)))
 
-    parse("(a < 5) or (b < 10)") should be(Disjunction(
-      LessThan(Ref("a"), ConstNumber(5)),
-      LessThan(Ref("b"), ConstNumber(10))))
+    parse("(a < 5) or (b < 10)") should be(
+      Disjunction(LessThan(Ref("a"), ConstNumber(5)),
+                  LessThan(Ref("b"), ConstNumber(10))))
   }
 
   it should "parse a conjunction" in {
@@ -184,9 +182,8 @@ class ParseExpressionTest extends FlatSpec with Matchers {
     parse("< 3") should be(InputLessThan(ConstNumber(3)))
 
     parse("[2..4]") should be(
-      Interval(
-        start = ClosedIntervalBoundary(ConstNumber(2)),
-        end = ClosedIntervalBoundary(ConstNumber(4))))
+      Interval(start = ClosedIntervalBoundary(ConstNumber(2)),
+               end = ClosedIntervalBoundary(ConstNumber(4))))
   }
 
   it should "parse a 'instance of'" in {
@@ -196,81 +193,76 @@ class ParseExpressionTest extends FlatSpec with Matchers {
 
   it should "parse a 'some' expression" in {
 
-    parse("some x in [1,2] satisfies x < 3") should be(SomeItem(
-      List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
-      LessThan(Ref("x"), ConstNumber(3))))
+    parse("some x in [1,2] satisfies x < 3") should be(
+      SomeItem(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
+               LessThan(Ref("x"), ConstNumber(3))))
 
-    parse("some x in [1,2], y in [3,4] satisfies x < y") should be(SomeItem(
-      List(
-        "x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
-        "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
-      LessThan(Ref("x"), Ref("y"))))
+    parse("some x in [1,2], y in [3,4] satisfies x < y") should be(
+      SomeItem(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
+                    "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
+               LessThan(Ref("x"), Ref("y"))))
   }
 
   it should "parse an 'every' expression" in {
 
-    parse("every x in [1,2] satisfies x < 3") should be(EveryItem(
-      List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
-      LessThan(Ref("x"), ConstNumber(3))))
+    parse("every x in [1,2] satisfies x < 3") should be(
+      EveryItem(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
+                LessThan(Ref("x"), ConstNumber(3))))
 
-    parse("every x in [1,2], y in [3,4] satisfies x < y") should be(EveryItem(
-      List(
-        "x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
-        "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
-      LessThan(Ref("x"), Ref("y"))))
+    parse("every x in [1,2], y in [3,4] satisfies x < y") should be(
+      EveryItem(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
+                     "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
+                LessThan(Ref("x"), Ref("y"))))
   }
 
   it should "parse a 'for' expression" in {
 
-    parse("for x in [1,2] return x") should be(For(
-      List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
-      Ref("x")))
+    parse("for x in [1,2] return x") should be(
+      For(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2)))),
+          Ref("x")))
 
-    parse("for x in [1,2], y in [3,4] return x + y") should be(For(
-      List(
-        "x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
-        "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
-      Addition(Ref("x"), Ref("y"))))
+    parse("for x in [1,2], y in [3,4] return x + y") should be(
+      For(List("x" -> ConstList(List(ConstNumber(1), ConstNumber(2))),
+               "y" -> ConstList(List(ConstNumber(3), ConstNumber(4)))),
+          Addition(Ref("x"), Ref("y"))))
   }
 
   it should "parse a 'for' expression with range" in {
 
-    parse("for x in 1..5 return x") should be(For(
-      List("x" -> Range(ConstNumber(1), ConstNumber(5))),
-      Ref("x")))
+    parse("for x in 1..5 return x") should be(
+      For(List("x" -> Range(ConstNumber(1), ConstNumber(5))), Ref("x")))
 
-    parse("for x in 1..5, y in a..b return x + y") should be(For(
-      List(
-        "x" -> Range(ConstNumber(1), ConstNumber(5)),
-        "y" -> Range(Ref("a"), Ref("b"))),
-      Addition(Ref("x"), Ref("y"))))
+    parse("for x in 1..5, y in a..b return x + y") should be(
+      For(List("x" -> Range(ConstNumber(1), ConstNumber(5)),
+               "y" -> Range(Ref("a"), Ref("b"))),
+          Addition(Ref("x"), Ref("y"))))
   }
 
   it should "parse a 'filter' expression" in {
 
-    parse("[1,2][item < 1]") should be(Filter(
-      ConstList(List(ConstNumber(1), ConstNumber(2))),
-      LessThan(Ref("item"), ConstNumber(1))))
+    parse("[1,2][item < 1]") should be(
+      Filter(ConstList(List(ConstNumber(1), ConstNumber(2))),
+             LessThan(Ref("item"), ConstNumber(1))))
   }
 
   it should "parse a path expression" in {
 
     parse("a.b") should be(PathExpression(Ref("a"), "b"))
 
-    parse("a.b.c") should be(PathExpression(
-      PathExpression(
-        Ref("a"), "b"), "c"))
+    parse("a.b.c") should be(PathExpression(PathExpression(Ref("a"), "b"), "c"))
   }
 
   it should "parse a path expression with escaped name" in {
 
-    parse(" 'a b'.'c d'") should be(PathExpression(Ref("a b"), "c d"))
+    parse(" `a b`.`c d`") should be(PathExpression(Ref("a b"), "c d"))
   }
 
   private def parse(expression: String): Exp =
     FeelParser.parseExpression(expression) match {
       case Success(exp, _) => exp
-      case e: NoSuccess    => throw new RuntimeException(s"failed to parse expression '$expression':\n$e")
+      case e: NoSuccess =>
+        throw new RuntimeException(
+          s"failed to parse expression '$expression':\n$e")
     }
 
 }

--- a/feel-engine/src/test/scala/org/camunda/feel/parser/ParseUnaryTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/parser/ParseUnaryTest.scala
@@ -7,8 +7,8 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
 /**
- * @author Philipp Ossler
- */
+  * @author Philipp Ossler
+  */
 class ParserUnaryTest extends FlatSpec with Matchers {
 
   "The input value" should "be equal to a number" in {
@@ -31,39 +31,48 @@ class ParserUnaryTest extends FlatSpec with Matchers {
 
   it should "be equal to a date" in {
 
-    parse("""date("2015-09-18")""") should be(InputEqualTo(ConstDate("2015-09-18")))
+    parse("""date("2015-09-18")""") should be(
+      InputEqualTo(ConstDate("2015-09-18")))
   }
 
   it should "be equal to a time" in {
 
-    parse("""time("10:31:10")""") should be(InputEqualTo(ConstLocalTime("10:31:10")))
+    parse("""time("10:31:10")""") should be(
+      InputEqualTo(ConstLocalTime("10:31:10")))
   }
 
   it should "be equal to a time with offset" in {
 
-    parse("""time("10:31:10+01:00")""") should be(InputEqualTo(ConstTime("10:31:10+01:00")))
-    parse("""time("10:31:10-02:00")""") should be(InputEqualTo(ConstTime("10:31:10-02:00")))
+    parse("""time("10:31:10+01:00")""") should be(
+      InputEqualTo(ConstTime("10:31:10+01:00")))
+    parse("""time("10:31:10-02:00")""") should be(
+      InputEqualTo(ConstTime("10:31:10-02:00")))
   }
 
   it should "be equal to a date-time" in {
 
-    parse("""date and time("2015-09-18T10:31:10")""") should be(InputEqualTo(ConstLocalDateTime("2015-09-18T10:31:10")))
+    parse("""date and time("2015-09-18T10:31:10")""") should be(
+      InputEqualTo(ConstLocalDateTime("2015-09-18T10:31:10")))
   }
 
   it should "be equal to a date-time with offset" in {
 
-    parse("""date and time("2015-09-18T10:31:10+01:00")""") should be(InputEqualTo(ConstDateTime("2015-09-18T10:31:10+01:00")))
-    parse("""date and time("2015-09-18T10:31:10-02:00")""") should be(InputEqualTo(ConstDateTime("2015-09-18T10:31:10-02:00")))
+    parse("""date and time("2015-09-18T10:31:10+01:00")""") should be(
+      InputEqualTo(ConstDateTime("2015-09-18T10:31:10+01:00")))
+    parse("""date and time("2015-09-18T10:31:10-02:00")""") should be(
+      InputEqualTo(ConstDateTime("2015-09-18T10:31:10-02:00")))
   }
 
   it should "be equal to a day-time-duration" in {
 
-    parse("""duration("P4DT2H")""") should be(InputEqualTo(ConstDayTimeDuration("P4DT2H")))
+    parse("""duration("P4DT2H")""") should be(
+      InputEqualTo(ConstDayTimeDuration("P4DT2H")))
   }
 
   it should "be equal to a year-month-duration" in {
 
-    parse("""duration("P2Y1M")""") should be(InputEqualTo(ConstYearMonthDuration("P2Y1M")))
+    parse("""duration("P2Y1M")""") should be(
+      InputEqualTo(ConstYearMonthDuration("P2Y1M")))
   }
 
   it should "be less than a number" in {
@@ -83,72 +92,69 @@ class ParserUnaryTest extends FlatSpec with Matchers {
   }
 
   it should "be less than a date" in {
-    parse("""< date("2015-09-18")""") should be(InputLessThan(ConstDate("2015-09-18")))
+    parse("""< date("2015-09-18")""") should be(
+      InputLessThan(ConstDate("2015-09-18")))
   }
 
   it should "be less than a time" in {
-    parse("""< time("15:41:10")""") should be(InputLessThan(ConstLocalTime("15:41:10")))
+    parse("""< time("15:41:10")""") should be(
+      InputLessThan(ConstLocalTime("15:41:10")))
   }
 
   it should "be less than a duration" in {
-    parse("""< duration("P1D")""") should be(InputLessThan(ConstDayTimeDuration("P1D")))
+    parse("""< duration("P1D")""") should be(
+      InputLessThan(ConstDayTimeDuration("P1D")))
   }
 
   it should "be in open interval '(2..4)'" in {
 
     parse("(2..4)") should be(
-      Interval(
-        start = OpenIntervalBoundary(ConstNumber(2)),
-        end = OpenIntervalBoundary(ConstNumber(4))))
+      Interval(start = OpenIntervalBoundary(ConstNumber(2)),
+               end = OpenIntervalBoundary(ConstNumber(4))))
   }
 
   it should "be in open interval ']2..4['" in {
 
     parse("]2..4[") should be(
-      Interval(
-        start = OpenIntervalBoundary(ConstNumber(2)),
-        end = OpenIntervalBoundary(ConstNumber(4))))
+      Interval(start = OpenIntervalBoundary(ConstNumber(2)),
+               end = OpenIntervalBoundary(ConstNumber(4))))
   }
 
   it should "be in closed interval '[2..4]'" in {
 
     parse("[2..4]") should be(
-      Interval(
-        start = ClosedIntervalBoundary(ConstNumber(2)),
-        end = ClosedIntervalBoundary(ConstNumber(4))))
+      Interval(start = ClosedIntervalBoundary(ConstNumber(2)),
+               end = ClosedIntervalBoundary(ConstNumber(4))))
   }
 
   it should "be in open date interval" in {
 
     parse("""(date("2015-09-17")..date("2015-09-19"))""") should be(
-      Interval(
-        start = OpenIntervalBoundary(ConstDate("2015-09-17")),
-        end = OpenIntervalBoundary(ConstDate("2015-09-19"))))
+      Interval(start = OpenIntervalBoundary(ConstDate("2015-09-17")),
+               end = OpenIntervalBoundary(ConstDate("2015-09-19"))))
   }
 
   it should "be in closed date interval" in {
 
     parse("""[date("2015-09-17")..date("2015-09-19")]""") should be(
-      Interval(
-        start = ClosedIntervalBoundary(ConstDate("2015-09-17")),
-        end = ClosedIntervalBoundary(ConstDate("2015-09-19"))))
+      Interval(start = ClosedIntervalBoundary(ConstDate("2015-09-17")),
+               end = ClosedIntervalBoundary(ConstDate("2015-09-19"))))
   }
 
   it should "match one of the tests '2,3,4'" in {
 
     parse("2,3,4") should be(
-      AtLeastOne(List(
-        InputEqualTo(ConstNumber(2)),
-        InputEqualTo(ConstNumber(3)),
-        InputEqualTo(ConstNumber(4)))))
+      AtLeastOne(
+        List(InputEqualTo(ConstNumber(2)),
+             InputEqualTo(ConstNumber(3)),
+             InputEqualTo(ConstNumber(4)))))
   }
 
   it should """match one of the tests '"a","b"'""" in {
 
     parse(""" "a","b" """) should be(
-      AtLeastOne(List(
-        InputEqualTo(ConstString("a")),
-        InputEqualTo(ConstString("b")))))
+      AtLeastOne(
+        List(InputEqualTo(ConstString("a")), InputEqualTo(ConstString("b")))))
   }
 
   it should "be equal to 'null'" in {
@@ -158,96 +164,102 @@ class ParserUnaryTest extends FlatSpec with Matchers {
 
   it should "be not equal to test" in {
 
-    parse("not(3)") should be(
-      Not(
-        InputEqualTo(ConstNumber(3))))
+    parse("not(3)") should be(Not(InputEqualTo(ConstNumber(3))))
   }
 
   it should "be equal to a qualified name 'var'" in {
 
-    parse("var") should be (InputEqualTo(Ref("var")))
+    parse("var") should be(InputEqualTo(Ref("var")))
   }
 
   it should "be equal to a qualified name 'qualified.var'" in {
 
-    parse("qualified.var") should be (InputEqualTo(Ref( List("qualified","var") )))
+    parse("qualified.var") should be(
+      InputEqualTo(Ref(List("qualified", "var"))))
   }
-  
+
   it should "be less than a qualified name" in {
 
-    parse("< var") should be (InputLessThan(Ref("var")))
+    parse("< var") should be(InputLessThan(Ref("var")))
   }
-  
-  it should "be equal to an escaped name 'a b'" in {
 
-    parse("'a b'") should be (InputEqualTo(Ref( List("a b") )))
-  }
-  
-  it should "be equal to an escaped name 'a-b'" in {
+  it should "be equal to an escaped name `a b`" in {
 
-    parse("'a-b'") should be (InputEqualTo(Ref( List("a-b") )))
+    parse("`a b`") should be(InputEqualTo(Ref(List("a b"))))
   }
-  
+
+  it should "be equal to an escaped name `a-b`" in {
+
+    parse("`a-b`") should be(InputEqualTo(Ref(List("a-b"))))
+  }
+
   it should "be equal to an escaped name 'a b'.'c d'" in {
-    
-    parse("'a b'.'c d'") should be (InputEqualTo(Ref( List("a b", "c d") )))
+
+    parse("`a b`.`c d`") should be(InputEqualTo(Ref(List("a b", "c d"))))
   }
-  
-  
+
   "An unary test" should "be '-'" in {
 
     parse("-") should be(ConstBool(true))
   }
-  
+
   it should "be a function invocation without parameters" in {
 
-    parse("f()") should be(FunctionInvocation("f",
-      params = PositionalFunctionParameters( List())) )
+    parse("f()") should be(
+      FunctionInvocation("f", params = PositionalFunctionParameters(List())))
   }
 
   it should "be a function invocation with positional parameters" in {
 
-    parse("fib(1)") should be(FunctionInvocation("fib",
-      params = PositionalFunctionParameters( List(ConstNumber(1)))) )
+    parse("fib(1)") should be(
+      FunctionInvocation("fib",
+                         params =
+                           PositionalFunctionParameters(List(ConstNumber(1)))))
 
-    parse("""concat("in", x)""") should be(FunctionInvocation("concat",
-      params = PositionalFunctionParameters( List(
-        ConstString("in"),
-        Ref("x")))) )
+    parse("""concat("in", x)""") should be(
+      FunctionInvocation("concat",
+                         params = PositionalFunctionParameters(
+                           List(ConstString("in"), Ref("x")))))
   }
 
   it should "be a function invocation with named parameters" in {
 
-    parse("f(a:1)") should be(FunctionInvocation("f",
-      params = NamedFunctionParameters( Map("a" -> ConstNumber(1)))) )
+    parse("f(a:1)") should be(
+      FunctionInvocation("f",
+                         params =
+                           NamedFunctionParameters(Map("a" -> ConstNumber(1)))))
 
-    parse("f(a:1, b:true)") should be(FunctionInvocation("f",
-      params = NamedFunctionParameters( Map(
-          "a" -> ConstNumber(1),
-          "b" -> ConstBool(true)))) )
+    parse("f(a:1, b:true)") should be(
+      FunctionInvocation("f",
+                         params = NamedFunctionParameters(
+                           Map("a" -> ConstNumber(1), "b" -> ConstBool(true)))))
   }
-  
+
   it should "be a function invocation with ? (input value)" in {
 
-    parse("""starts with(?, "f")""") should be(FunctionInvocation("starts with",
-      params = PositionalFunctionParameters( List(
-        ConstInputValue,
-        ConstString("f")))) )
+    parse("""starts with(?, "f")""") should be(
+      FunctionInvocation("starts with",
+                         params = PositionalFunctionParameters(
+                           List(ConstInputValue, ConstString("f")))))
   }
-  
-  it should "has an expression as endpoint" in {
-    
-    parse("< (2 + 3)") should be (InputLessThan(
-      Addition(
-        ConstNumber(2),
-        ConstNumber(3)
-      )                                          
-    ))
-  }  
 
-  private def parse(expression: String): Exp = FeelParser.parseUnaryTests(expression) match {
-      case Success(exp, _) => exp
-      case e: NoSuccess => throw new RuntimeException(s"failed to parse expression '$expression':\n$e")
+  it should "has an expression as endpoint" in {
+
+    parse("< (2 + 3)") should be(
+      InputLessThan(
+        Addition(
+          ConstNumber(2),
+          ConstNumber(3)
+        )
+      ))
   }
+
+  private def parse(expression: String): Exp =
+    FeelParser.parseUnaryTests(expression) match {
+      case Success(exp, _) => exp
+      case e: NoSuccess =>
+        throw new RuntimeException(
+          s"failed to parse expression '$expression':\n$e")
+    }
 
 }


### PR DESCRIPTION
closes #58
