### PR TITLE
CAM-11259: add back the examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# FEEL Scala Examples
+
+This module contains examples which shows how to use the FEEL engine.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,126 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.camunda.feel</groupId>
+  <artifactId>feel-engine-examples</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>FEEL Engine Examples</name>
+
+  <properties>
+    <version.java>1.8</version.java>
+    <version.feel-engine>1.11.0-SNAPSHOT</version.feel-engine>
+    <version.camunda>7.13.0-SNAPSHOT</version.camunda>
+    <version.scalatest>3.0.8</version.scalatest>
+    <version.log4j>2.9.0</version.log4j>
+    <scala.version>2.13.0</scala.version>
+    <scala.binary.version>2.13.0</scala.binary.version>
+    <plugin.version.compiler>3.1</plugin.version.compiler>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-scala</artifactId>
+      <version>${version.camunda}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>${version.camunda}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.13</artifactId>
+      <version>${version.scalatest}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${version.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${version.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${version.log4j}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${plugin.version.compiler}</version>
+        <configuration>
+          <source>${version.java}</source>
+          <target>${version.java}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
+          <scalaVersion>${scala.version}</scalaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>add-source</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-doc</id>
+            <phase>package</phase>
+            <goals>
+              <goal>doc-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/project/build.properties
+++ b/examples/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/examples/project/plugins.sbt
+++ b/examples/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")

--- a/examples/src/main/java/org/camunda/feel/example/spi/CustomJavaFunctionProvider.java
+++ b/examples/src/main/java/org/camunda/feel/example/spi/CustomJavaFunctionProvider.java
@@ -1,0 +1,52 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.example.spi;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.camunda.feel.interpreter.impl.ValNumber;
+import org.camunda.feel.impl.spi.JavaFunction;
+import org.camunda.feel.impl.spi.JavaFunctionProvider;
+import scala.math.BigDecimal;
+
+public class CustomJavaFunctionProvider extends JavaFunctionProvider {
+
+  private static final Map<String, JavaFunction> functions = new HashMap<>();
+
+  static {
+
+    final JavaFunction function = new JavaFunction(Arrays.asList("x"), args -> {
+      final ValNumber arg = (ValNumber) args.get(0);
+
+      int x = arg.value().intValue();
+
+      return new ValNumber(BigDecimal.valueOf(x - 1));
+    });
+
+    functions.put("bar", function);
+  }
+
+  @Override
+  public Optional<JavaFunction> resolveFunction(String functionName) {
+    return Optional.ofNullable(functions.get(functionName));
+  }
+
+  @Override
+  public Collection<String> getFunctionNames() {
+    return functions.keySet();
+  }
+}

--- a/examples/src/main/java/org/camunda/feel/example/spi/CustomJavaValueMapper.java
+++ b/examples/src/main/java/org/camunda/feel/example/spi/CustomJavaValueMapper.java
@@ -1,0 +1,43 @@
+package org.camunda.feel.example.spi;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.camunda.feel.interpreter.impl.Val;
+import org.camunda.feel.interpreter.impl.ValNumber;
+import org.camunda.feel.interpreter.impl.ValString;
+import org.camunda.feel.impl.spi.JavaCustomValueMapper;
+
+public class CustomJavaValueMapper extends JavaCustomValueMapper {
+
+  @Override
+  public Optional<Val> toValue(Object x, Function<Object, Val> innerValueMapper) {
+    if (x instanceof Custom) {
+      final Custom c = (Custom) x;
+      return Optional.of(new ValString(c.getName()));
+
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public Optional<Object> unpackValue(Val value, Function<Val, Object> innerValueMapper) {
+    if (value instanceof ValNumber) {
+      final ValNumber number = (ValNumber) value;
+      return Optional.of(number.value().doubleValue()); // map BigDecimal to Double
+
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public int priority() {
+    return 1;
+  }
+
+  interface Custom {
+
+    String getName();
+  }
+}

--- a/examples/src/main/scala/org/camunda/feel/example/spi/CustomScalaFunctionProvider.scala
+++ b/examples/src/main/scala/org/camunda/feel/example/spi/CustomScalaFunctionProvider.scala
@@ -1,0 +1,27 @@
+package org.camunda.feel.example.spi
+
+import scala.math.BigDecimal.int2bigDecimal
+import org.camunda.feel.interpreter.impl._
+import org.camunda.feel.impl.spi.CustomFunctionProvider
+
+class CustomScalaFunctionProvider extends CustomFunctionProvider {
+
+  def getFunction(name: String): Option[ValFunction] = functions.get(name)
+
+  override def functionNames: Iterable[String] = functions.keys
+
+  val functions: Map[String, ValFunction] = Map(
+    "foo" -> ValFunction(
+      params = List("x"),
+      invoke = { case List(ValNumber(x)) => ValNumber(x + 1) }
+    ),
+    "isBlack" -> ValFunction(
+      params = List("s"),
+      invoke = {
+        case List(ValString(s)) =>
+          if (s == "black") ValBoolean(true) else ValBoolean(false)
+      },
+    )
+  )
+
+}

--- a/examples/src/test/java/org/camunda/feel/example/FeelEngineJavaTest.java
+++ b/examples/src/test/java/org/camunda/feel/example/FeelEngineJavaTest.java
@@ -1,0 +1,33 @@
+package org.camunda.feel.example;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.camunda.feel.FeelEngine;
+import org.camunda.feel.impl.spi.SpiServiceLoader;
+import scala.util.Either;
+
+public class FeelEngineJavaTest {
+
+    public static void main(String[] args) {
+
+        final FeelEngine engine =
+                new FeelEngine.Builder()
+                        .valueMapper(SpiServiceLoader.loadValueMapper())
+                        .functionProvider(SpiServiceLoader.loadFunctionProvider())
+                        .build();
+
+        final Map<String, Object> variables = Collections.singletonMap("x", 2);
+        final Either<FeelEngine.Failure, Object> result = engine.evalExpression("x + 1", variables);
+
+        if (result.isRight()) {
+            final Object value = result.right().get();
+            System.out.println("result is " + value);
+        } else {
+            final FeelEngine.Failure failure = result.left().get();
+            throw new RuntimeException(failure.message());
+        }
+
+    }
+
+}

--- a/examples/src/test/resources/META-INF/services/org.camunda.feel.impl.spi.CustomFunctionProvider
+++ b/examples/src/test/resources/META-INF/services/org.camunda.feel.impl.spi.CustomFunctionProvider
@@ -1,0 +1,2 @@
+org.camunda.feel.example.spi.CustomScalaFunctionProvider
+org.camunda.feel.example.spi.CustomJavaFunctionProvider

--- a/examples/src/test/resources/basic/literalExpression.dmn
+++ b/examples/src/test/resources/basic/literalExpression.dmn
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions" name="Definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="decision">
+    <extensionElements>
+      <biodi:bounds x="406" y="164" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_00t4djw" name="result" typeRef="integer" />
+    <literalExpression id="LiteralExpression_1fmje14" expressionLanguage="">    <text>a + b</text>
+</literalExpression>
+  </decision>
+</definitions>

--- a/examples/src/test/resources/basic/outputExpression.dmn
+++ b/examples/src/test/resources/basic/outputExpression.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_17o2x8m" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Op">
+        <inputExpression id="inputExpression1" typeRef="string">        <text>op</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="Out" name="out" typeRef="integer" />
+      <rule id="row-405452957-5">
+        <inputEntry id="UnaryTests_0uznulu">        <text><![CDATA["add"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0nfcnfg">        <text>a + b</text>
+</outputEntry>
+      </rule>
+      <rule id="row-405452957-6">
+        <inputEntry id="UnaryTests_03xrgrd">        <text><![CDATA["sub"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_08qb2eo">        <text>a - b</text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/examples/src/test/resources/basic/simpleUnaryTest.dmn
+++ b/examples/src/test/resources/basic/simpleUnaryTest.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_0lzths2" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Score">
+        <inputExpression id="inputExpression1" typeRef="integer">        <text>score</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="Result" name="Result" typeRef="string" />
+      <rule id="row-405452957-1">
+        <inputEntry id="UnaryTests_0e8cnl6">        <text>(90..100]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1wuu58j">        <text><![CDATA["cool"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-405452957-2">
+        <inputEntry id="UnaryTests_1almndn">        <text>(75..90]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0dotlm8">        <text><![CDATA["good"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-405452957-3">
+        <inputEntry id="UnaryTests_1cgt1nj">        <text>(50..75]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0ci2lwc">        <text><![CDATA["ok"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-405452957-4">
+        <inputEntry id="UnaryTests_1jqsxer">        <text><![CDATA[<= 50]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_13r7qno">        <text><![CDATA["bad"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/examples/src/test/resources/function/outputEntryWithFunction.dmn
+++ b/examples/src/test/resources/function/outputEntryWithFunction.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_1ngf2ri" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="status" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="string">        <text>status</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="code" name="" typeRef="integer" />
+      <rule id="row-235432293-1">
+        <inputEntry id="UnaryTests_1iwn8ps">        <text><![CDATA["green"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0oxjeu5">        <text>foo(2)</text>
+</outputEntry>
+      </rule>
+      <rule id="row-235432293-2">
+        <inputEntry id="UnaryTests_15dxdq0">        <text><![CDATA["yellow"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1bgqqc7">        <text>bar(3)</text>
+</outputEntry>
+      </rule>
+      <rule id="row-235432293-3">
+        <inputEntry id="UnaryTests_02ifx5x">        <text><![CDATA["red"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_13ceko0">        <text>10</text>
+</outputEntry>
+      </rule>
+      <rule id="row-159369097-1">
+        <inputEntry id="UnaryTests_11y0oj9">        <text>isBlack(?)</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0t89co6">        <text>14</text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/examples/src/test/resources/log4j2.xml
+++ b/examples/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="DEBUG">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/examples/src/test/resources/spec/SpecExample.dmn
+++ b/examples/src/test/resources/spec/SpecExample.dmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1q6665r" name="Decision" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="yearly_income" name="yearly income">
+    <extensionElements>
+      <biodi:bounds x="200" y="200" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_190xn7d" name="income" />
+    <literalExpression id="LiteralExpression_12298k9">    <text>applicant.monthly.income * 12</text>
+</literalExpression>
+  </decision>
+  <decision id="marital_status_check" name="marital status check">
+    <extensionElements>
+      <biodi:bounds x="271" y="326" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_1755pfb" name="isValid" />
+    <literalExpression id="LiteralExpression_0sruqgz">    <text><![CDATA[if applicant.maritalStatus in ("M","S") then "valid" else "not valid"]]></text>
+</literalExpression>
+  </decision>
+  <decision id="total_expenses" name="total expenses">
+    <extensionElements>
+      <biodi:bounds x="614" y="391" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_15ipzj5" name="expenses" />
+    <literalExpression id="LiteralExpression_1y9qvhr">    <text>sum( [applicant.monthly.repayments, applicant.monthly.expenses] )</text>
+</literalExpression>
+  </decision>
+  <decision id="sum_credit" name="sum of recent credit weights">
+    <extensionElements>
+      <biodi:bounds x="726" y="269" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_1yfutit" name="sum" />
+    <literalExpression id="LiteralExpression_1k74kj4">    <text><![CDATA[sum( credit_history[record_date > date("2011-01-01")].weight )]]></text>
+</literalExpression>
+  </decision>
+  <decision id="bankruptcy_check" name="bankruptcy check">
+    <extensionElements>
+      <biodi:bounds x="368" y="457" width="180" height="80" />
+    </extensionElements>
+    <variable id="InformationItem_1huic61" name="hasBankruptcy" />
+    <literalExpression id="LiteralExpression_06mrnl2">    <text><![CDATA[some ch in credit_history satisfies ch.event = "bankruptcy"]]></text>
+</literalExpression>
+  </decision>
+</definitions>

--- a/examples/src/test/scala/org/camunda/feel/example/BasicFeelEngineFactoryTest.scala
+++ b/examples/src/test/scala/org/camunda/feel/example/BasicFeelEngineFactoryTest.scala
@@ -1,0 +1,50 @@
+package org.camunda.feel.example
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class BasicFeelEngineFactoryTest
+    extends FlatSpec
+    with Matchers
+    with DmnEvaluationTest {
+
+  val DMN_DT_SIMPLE_UNARY_TEST = "/basic/simpleUnaryTest.dmn"
+  val DMN_DT_OUTPUT_EXPRESSION = "/basic/outputExpression.dmn"
+  val DMN_LITERAL_EXPRESSION = "/basic/literalExpression.dmn"
+
+  "The DMN engine" should "evaluate a decision table with a simple unary test" in {
+
+    val result =
+      evaluateDecision(DMN_DT_SIMPLE_UNARY_TEST, "decision", Map("score" -> 92))
+
+    result.size should be(1)
+    result.getSingleResult.getSingleEntry.asInstanceOf[String] should be("cool")
+  }
+
+  it should "evaluate a decision table with an output expression" in {
+
+    val result = evaluateDecision(DMN_DT_OUTPUT_EXPRESSION,
+                                  "decision",
+                                  Map(
+                                    "op" -> "add",
+                                    "a" -> 2,
+                                    "b" -> 3
+                                  ))
+
+    result.size should be(1)
+    result.getSingleResult.getSingleEntry.asInstanceOf[Int] should be(5)
+  }
+
+  it should "evaluate a decision literal expression" in {
+
+    val result = evaluateDecision(DMN_LITERAL_EXPRESSION,
+                                  "decision",
+                                  Map(
+                                    "a" -> 4,
+                                    "b" -> 5
+                                  ))
+
+    result.size should be(1)
+    result.getSingleResult.getSingleEntry.asInstanceOf[Int] should be(9)
+  }
+
+}

--- a/examples/src/test/scala/org/camunda/feel/example/DmnEvaluationTest.scala
+++ b/examples/src/test/scala/org/camunda/feel/example/DmnEvaluationTest.scala
@@ -1,0 +1,43 @@
+package org.camunda.feel.example
+
+import scala.collection.JavaConverters._
+import org.camunda.bpm.dmn.engine.DmnEngineConfiguration
+import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration
+import org.camunda.bpm.dmn.feel.impl.scala.CamundaFeelEngineFactory
+import org.camunda.bpm.model.dmn.Dmn
+
+trait DmnEvaluationTest {
+
+  val dmnEngine = {
+    val dmnEngineConfig = DmnEngineConfiguration
+      .createDefaultDmnEngineConfiguration()
+      .asInstanceOf[DefaultDmnEngineConfiguration]
+
+    dmnEngineConfig.setDefaultInputEntryExpressionLanguage(
+      "feel-scala-unary-tests");
+    dmnEngineConfig.setDefaultOutputEntryExpressionLanguage("feel-scala");
+    dmnEngineConfig.setDefaultLiteralExpressionLanguage("feel-scala");
+    dmnEngineConfig.setDefaultInputExpressionExpressionLanguage("feel-scala");
+
+    dmnEngineConfig
+      .feelEngineFactory(new CamundaFeelEngineFactory)
+      .buildEngine()
+  }
+
+  def decisionInstance(dmnFile: String) = {
+    val inputStream = getClass.getResourceAsStream(dmnFile)
+
+    Dmn.readModelFromStream(inputStream)
+  }
+
+  def evaluateDecision(dmnFile: String,
+                       decisionId: String,
+                       vars: Map[String, Any]) =
+    dmnEngine.evaluateDecision(decisionId,
+                               decisionInstance(dmnFile),
+                               toVariables(vars))
+
+  private def toVariables(vars: Map[String, Any]) =
+    vars.asJava.asInstanceOf[java.util.Map[String, Object]]
+
+}

--- a/examples/src/test/scala/org/camunda/feel/example/FunctionProviderTest.scala
+++ b/examples/src/test/scala/org/camunda/feel/example/FunctionProviderTest.scala
@@ -1,0 +1,40 @@
+package org.camunda.feel.example
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+class FunctionProviderTest
+    extends FlatSpec
+    with Matchers
+    with DmnEvaluationTest {
+
+  val DMN_FILE = "/function/outputEntryWithFunction.dmn"
+
+  "The decision table" should "invoke a custom scala function" in {
+
+    val result =
+      evaluateDecision(DMN_FILE, "decision", Map("status" -> "green"))
+
+    result.size should be(1)
+    result.getSingleEntry.asInstanceOf[Int] should be(3)
+  }
+
+  it should "invoke a custom java function" in {
+
+    val result =
+      evaluateDecision(DMN_FILE, "decision", Map("status" -> "yellow"))
+
+    result.size should be(1)
+    result.getSingleEntry.asInstanceOf[Int] should be(2)
+  }
+
+  it should "invoke a custom scala function with input variable" in {
+
+    val result =
+      evaluateDecision(DMN_FILE, "decision", Map("status" -> "black"))
+
+    result.size should be(1)
+    result.getSingleEntry.asInstanceOf[Int] should be(14)
+  }
+
+}

--- a/examples/src/test/scala/org/camunda/feel/example/spec/Context.scala
+++ b/examples/src/test/scala/org/camunda/feel/example/spec/Context.scala
@@ -1,0 +1,13 @@
+package org.camunda.feel.example.spec
+
+import java.time.LocalDate
+
+object Context {
+  
+  case class Applicant(maritalStatus: String, monthly: BalanceSummery)
+  
+  case class BalanceSummery(income: Int, repayments: Int, expenses: Int)
+  
+  case class CreditHistoryRecord(record_date: LocalDate, event: String, weight: Int)
+  
+}

--- a/examples/src/test/scala/org/camunda/feel/example/spec/SpecExampleTest.scala
+++ b/examples/src/test/scala/org/camunda/feel/example/spec/SpecExampleTest.scala
@@ -1,0 +1,75 @@
+package org.camunda.feel.example.spec
+
+import java.time.LocalDate
+
+import org.camunda.feel.example.DmnEvaluationTest
+import org.camunda.feel.example.spec.Context.{
+  Applicant,
+  BalanceSummery,
+  CreditHistoryRecord
+}
+import org.scalatest.{FlatSpec, Matchers}
+
+class SpecExampleTest extends FlatSpec with Matchers with DmnEvaluationTest {
+
+  val DMN_FILE = "/spec/SpecExample.dmn"
+
+  val context = Map(
+    "applicant" -> Applicant(
+      maritalStatus = "M",
+      monthly = BalanceSummery(
+        income = 10000,
+        repayments = 2500,
+        expenses = 3000
+      )
+    ),
+    "credit_history" -> List(
+      CreditHistoryRecord(
+        record_date = LocalDate.parse("2008-03-12"),
+        event = "home mortgage",
+        weight = 100
+      ),
+      CreditHistoryRecord(
+        record_date = LocalDate.parse("2011-04-01"),
+        event = "foreclosure warning",
+        weight = 150
+      )
+    )
+  )
+
+  "The applicant" should "have a yearly income of 120000" in {
+
+    val result = evaluateDecision(DMN_FILE, "yearly_income", context)
+
+    result.getSingleEntry.asInstanceOf[Long] should be(120000)
+  }
+
+  it should "have a valid marital status" in {
+
+    val result = evaluateDecision(DMN_FILE, "marital_status_check", context)
+
+    result.getSingleEntry.asInstanceOf[String] should be("valid")
+  }
+
+  it should "have a total expense of 5500" in {
+
+    val result = evaluateDecision(DMN_FILE, "total_expenses", context)
+
+    result.getSingleEntry.asInstanceOf[Long] should be(5500)
+  }
+
+  "The credit history" should "have a total weight of 150" in {
+
+    val result = evaluateDecision(DMN_FILE, "sum_credit", context)
+
+    result.getSingleEntry.asInstanceOf[Long] should be(150)
+  }
+
+  it should "contains no bankruptcy" in {
+
+    val result = evaluateDecision(DMN_FILE, "bankruptcy_check", context)
+
+    result.getSingleEntry.asInstanceOf[Boolean] should be(false)
+  }
+
+}


### PR DESCRIPTION
Restore the examples sub-project in `feel-scala`. 

Separate the `examples` module as a separate project inside the repository to avoid cyclic dependencies with the DMN Engine.