### PR TITLE
fix(engine): access list by variable

### DIFF
--- a/feel-engine/src/main/scala/org/camunda/feel/impl/parser/Exp.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/impl/parser/Exp.scala
@@ -7,6 +7,11 @@ import org.camunda.feel.impl._
   */
 sealed trait Exp
 
+sealed trait Comparison extends Exp {
+  val x: Exp
+  val y: Exp
+}
+
 case object ConstNull extends Exp
 
 case object ConstInputValue extends Exp
@@ -71,15 +76,15 @@ case class Exponentiation(x: Exp, y: Exp) extends Exp
 
 case class ArithmeticNegation(x: Exp) extends Exp
 
-case class Equal(x: Exp, y: Exp) extends Exp
+case class Equal(x: Exp, y: Exp) extends Comparison
 
-case class LessThan(x: Exp, y: Exp) extends Exp
+case class LessThan(x: Exp, y: Exp) extends Comparison
 
-case class LessOrEqual(x: Exp, y: Exp) extends Exp
+case class LessOrEqual(x: Exp, y: Exp) extends Comparison
 
-case class GreaterThan(x: Exp, y: Exp) extends Exp
+case class GreaterThan(x: Exp, y: Exp) extends Comparison
 
-case class GreaterOrEqual(x: Exp, y: Exp) extends Exp
+case class GreaterOrEqual(x: Exp, y: Exp) extends Comparison
 
 case class FunctionInvocation(function: String, params: FunctionParameters)
     extends Exp

--- a/feel-engine/src/main/scala/org/camunda/feel/interpreter/impl/FeelInterpreter.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/interpreter/impl/FeelInterpreter.scala
@@ -139,8 +139,16 @@ class FeelInterpreter {
               case ConstNumber(index) => filterList(l.items, index)
               case ArithmeticNegation(ConstNumber(index)) =>
                 filterList(l.items, -index)
+              case comparison: Comparison =>
+                filterList(l.items,
+                           item => eval(comparison)(filterContext(item)))
               case _ =>
-                filterList(l.items, item => eval(filter)(filterContext(item)))
+                eval(filter) match {
+                  case ValNumber(index) => filterList(l.items, index)
+                  case _ =>
+                    filterList(l.items,
+                               item => eval(filter)(filterContext(item)))
+                }
           }
         )
       case Range(start, end) =>

--- a/feel-engine/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterListExpressionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterListExpressionTest.scala
@@ -66,16 +66,16 @@ class InterpreterListExpressionTest
   it should "be filtered via index" in {
 
     eval("[1,2,3,4][1]") should be(ValNumber(1))
-
     eval("[1,2,3,4][2]") should be(ValNumber(2))
 
     eval("[1,2,3,4][-1]") should be(ValNumber(4))
-
     eval("[1,2,3,4][-2]") should be(ValNumber(3))
 
     eval("[1,2,3,4][5]") should be(ValNull)
-
     eval("[1,2,3,4][-5]") should be(ValNull)
+
+    eval("[1,2,3,4][i]", Map("i" -> 2)) should be(ValNumber(2))
+    eval("[1,2,3,4][i]", Map("i" -> -2)) should be(ValNumber(3))
   }
 
   it should "fail if one element fails" in {


### PR DESCRIPTION
Access an item of a list by providing a variable as the index.

```js
["a","b","c"][index]
// if index = 2 then result is "b"
```

Closes #80 