### PR TITLE
Increase test coverage

### DIFF
--- a/feel-engine/src/test/scala/org/camunda/feel/context/JavaCustomFunctionTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/context/JavaCustomFunctionTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.context
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class JavaCustomFunctionTest extends FlatSpec with Matchers {
+
+  val engine =
+    new org.camunda.feel.FeelEngine(new SimpleTestJavaFunctionProvider())
+
+  it should "call java custom function" in {
+
+    engine.evalExpression("myCustomFunction()", context = Context.EmptyContext) should be(
+      Right("foo"))
+  }
+
+}

--- a/feel-engine/src/test/scala/org/camunda/feel/context/SimpleTestJavaFunctionProvider.java
+++ b/feel-engine/src/test/scala/org/camunda/feel/context/SimpleTestJavaFunctionProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.context;
+
+import org.camunda.feel.syntaxtree.ValString;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class SimpleTestJavaFunctionProvider extends JavaFunctionProvider {
+
+  protected Map<String, JavaFunction> functions = new HashMap<>();
+
+  public SimpleTestJavaFunctionProvider() {
+    functions.put("myCustomFunction", new JavaFunction(Collections.emptyList(),
+        args -> new ValString("foo")));
+  }
+
+  @Override
+  public Optional<JavaFunction> resolveFunction(String functionName) {
+    return Optional.ofNullable(functions.get(functionName));
+  }
+
+  @Override
+  public Collection<String> getFunctionNames() {
+    return functions.keySet();
+  }
+
+}

--- a/feel-engine/src/test/scala/org/camunda/feel/impl/spi/SimpleTestContext.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/impl/spi/SimpleTestContext.scala
@@ -1,0 +1,29 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.impl.spi
+
+import org.camunda.feel.context.VariableProvider
+
+case class SimpleTestContext(context: Map[String, _]) extends VariableProvider {
+
+  override def getVariable(name: String): Option[Any] = {
+    if (context.contains(name)) {
+      Some(context.get(name))
+
+    } else {
+      None
+    }
+  }
+
+  override def keys: Iterable[String] = context.keys
+}

--- a/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BuiltinValueMapperInputTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BuiltinValueMapperInputTest.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.valuemapper
+
+import java.util
+import java.util.Collections
+
+import org.camunda.feel.FeelEngine
+import org.camunda.feel.context.Context
+import org.camunda.feel.impl.JavaValueMapper
+import org.camunda.feel.valuemapper.ValueMapper.CompositeValueMapper
+import org.scalatest.{FlatSpec, Matchers}
+
+class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
+
+  val engine =
+    new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))
+
+  it should " read java.lang.String" in {
+    val variables = Map("foo" -> java.lang.String.valueOf("3.4"))
+
+    engine
+      .evalExpression("foo + \"hello\"",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.String]
+  }
+
+  it should " read java.lang.Float" in {
+    val variables = Map("foo" -> java.lang.Float.valueOf("3.4"))
+
+    engine
+      .evalExpression("foo + 1",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Double]
+  }
+
+  it should " read java.lang.Double" in {
+    val variables = Map("foo" -> java.lang.Double.valueOf("3.4"))
+
+    engine
+      .evalExpression("foo + 1",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Double]
+  }
+
+  it should " read java.lang.Integer" in {
+    val variables = Map("foo" -> java.lang.Integer.valueOf("3"))
+
+    engine
+      .evalExpression("foo + 1",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Long]
+  }
+
+  it should " read java.lang.Long" in {
+    val variables = Map("foo" -> java.lang.Long.valueOf("3"))
+
+    engine
+      .evalExpression("foo + 1",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Long]
+  }
+
+  it should " read java.lang.Short" ignore {
+    val variables = Map("foo" -> java.lang.Short.valueOf("3"))
+
+    engine
+      .evalExpression("foo + 1",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Long]
+  }
+
+  it should " read java.lang.Boolean" in {
+    val variables = Map("foo" -> java.lang.Boolean.valueOf("true"))
+
+    engine
+      .evalExpression("foo or false",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.lang.Boolean]
+  }
+
+  it should " read java.util.Date" in {
+    val variables = Map("foo" -> new java.util.Date())
+
+    engine
+      .evalExpression("foo", context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe a[java.time.LocalDateTime]
+  }
+
+  it should " read null value" in {
+    val nullValue: java.lang.Integer = null
+
+    val variables = Map("foo" -> nullValue)
+
+    engine
+      .evalExpression("foo = null",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe true
+  }
+
+  it should " read value from object getter" in {
+
+    val variables = Map("foo" -> new SimpleTestPojo("foo"))
+
+    engine
+      .evalExpression("foo.getMyString() = \"foo\"",
+                      context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe true
+  }
+
+  it should " read java.util.Map" in {
+    val map: java.util.Map[java.lang.String, java.lang.Object] =
+      new util.HashMap[java.lang.String, java.lang.Object]()
+    map.put("foo", "myString")
+    map.put("bar", java.lang.Integer.valueOf(2))
+    map.put("baz", Collections.singletonMap("foo", "bar"))
+
+    val variables = Map("map" -> map)
+
+    engine
+      .evalExpression(
+        "map.foo = \"myString\" and map.bar = 2 and map.baz.foo = \"bar\"",
+        context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe true
+  }
+
+  it should " read java.util.List" in {
+    val list: java.util.List[java.lang.Object] =
+      new util.ArrayList[java.lang.Object]()
+    list.add("myString")
+    list.add(java.lang.Integer.valueOf(2))
+    list.add(Collections.singletonMap("foo", "bar"))
+
+    val variables = Map("list" -> list)
+
+    engine
+      .evalExpression(
+        "list[1] = \"myString\" and list[2] = 2 and list[3].foo = \"bar\"",
+        context = Context.StaticContext(variables, null))
+      .getOrElse() shouldBe true
+  }
+
+}

--- a/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BultinValueMapperOutputTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BultinValueMapperOutputTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.valuemapper
+
+import org.camunda.feel.FeelEngine
+import org.camunda.feel.context.Context
+import org.camunda.feel.impl.JavaValueMapper
+import org.camunda.feel.valuemapper.ValueMapper.CompositeValueMapper
+import org.scalatest.{FlatSpec, Matchers}
+
+class BultinValueMapperOutputTest extends FlatSpec with Matchers {
+
+  val engine =
+    new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))
+
+  it should " return java.lang.String" in {
+
+    engine
+      .evalExpression("\"foo\"", context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.lang.String]
+  }
+
+  it should " return java.lang.Double" in {
+
+    engine
+      .evalExpression("10/3", context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.lang.Double]
+  }
+
+  it should " return java.lang.Long" in {
+
+    engine
+      .evalExpression("10", context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.lang.Long]
+  }
+
+  it should " return java.lang.Boolean" in {
+
+    engine
+      .evalExpression("true", context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.lang.Boolean]
+  }
+
+  it should " return java.time.LocalDateTime" in {
+
+    engine
+      .evalExpression("date and time(\"2019-08-12T22:22:22\")",
+                      context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.time.LocalDateTime]
+  }
+
+  it should " return java.time.ZonedDateTime" in {
+
+    engine
+      .evalExpression("date and time(\"2019-08-12T22:22:22@Europe/Berlin\")",
+                      context = Context.EmptyContext)
+      .getOrElse() shouldBe a[java.time.ZonedDateTime]
+  }
+
+  it should " return null" in {
+
+    val nullValue: java.lang.Integer = null;
+
+    engine
+      .evalExpression("null", context = Context.EmptyContext)
+      .getOrElse() == nullValue shouldBe true
+  }
+
+  it should " return java.util.Map" in {
+
+    val map = engine
+      .evalExpression("{\"foo\": 42, \"bar\": 5.5, \"baz\": [1, 2]}",
+                      context = Context.EmptyContext)
+      .getOrElse()
+      .asInstanceOf[java.util.Map[_, _]]
+
+    map shouldBe a[java.util.Map[_, _]]
+
+    map.get("foo") shouldBe a[java.lang.Long]
+    map.get("bar") shouldBe a[java.lang.Double]
+    map.get("baz") shouldBe a[java.util.List[_]]
+
+    val list = map
+      .get("baz")
+      .asInstanceOf[java.util.List[_]]
+
+    list.get(0) shouldBe a[java.lang.Long]
+  }
+
+  it should " return java.util.List" in {
+
+    val list = engine
+      .evalExpression("[6, 5.5, {\"foo\": \"bar\"}]",
+                      context = Context.EmptyContext)
+      .getOrElse()
+      .asInstanceOf[java.util.List[_]]
+
+    list shouldBe a[java.util.List[_]]
+
+    list.get(0) shouldBe a[java.lang.Long]
+    list.get(1) shouldBe a[java.lang.Double]
+    list.get(2) shouldBe a[java.util.Map[_, _]]
+
+    val map = list
+      .get(2)
+      .asInstanceOf[java.util.Map[_, _]]
+
+    map.get("foo") shouldBe a[java.lang.String]
+  }
+
+}

--- a/feel-engine/src/test/scala/org/camunda/feel/valuemapper/SimpleTestPojo.java
+++ b/feel-engine/src/test/scala/org/camunda/feel/valuemapper/SimpleTestPojo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.valuemapper;
+
+public class SimpleTestPojo {
+
+  protected String myString;
+
+  public SimpleTestPojo(String string) {
+    myString = string;
+  }
+
+  public String getMyString() {
+    return myString;
+  }
+
+}


### PR DESCRIPTION
Adds tests for the following scenarios:
* Register custom function providers using the `JavaFunctionProvider`
* Evaluate...
  * expressions with context and result "left" & "right"
  * unary-tests with context and result "left" & "right"
* Built-in value mappers tested in a blackbox manner

Closes #103
