### PR TITLE
feat(engine): read short as FEEL number

### DIFF
--- a/feel-engine/src/main/scala/org/camunda/feel/impl/DefaultValueMapper.scala
+++ b/feel-engine/src/main/scala/org/camunda/feel/impl/DefaultValueMapper.scala
@@ -42,6 +42,7 @@ class DefaultValueMapper extends CustomValueMapper {
     case null   => Some(ValNull)
 
     // scala types
+    case x: Short                               => Some(ValNumber(x))
     case x: Int                                 => Some(ValNumber(x))
     case x: Long                                => Some(ValNumber(x))
     case x: Float if (x.isNaN || x.isInfinity)  => Some(ValNull)

--- a/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BuiltinValueMapperInputTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BuiltinValueMapperInputTest.scala
@@ -30,7 +30,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
   val engine =
     new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))
 
-  it should " read java.lang.String" in {
+  "The value mapper" should "read java.lang.String" in {
     val variables = Map("foo" -> java.lang.String.valueOf("3.4"))
 
     engine
@@ -39,7 +39,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.String]
   }
 
-  it should " read java.lang.Float" in {
+  it should "read java.lang.Float" in {
     val variables = Map("foo" -> java.lang.Float.valueOf("3.4"))
 
     engine
@@ -48,7 +48,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Double]
   }
 
-  it should " read java.lang.Double" in {
+  it should "read java.lang.Double" in {
     val variables = Map("foo" -> java.lang.Double.valueOf("3.4"))
 
     engine
@@ -57,7 +57,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Double]
   }
 
-  it should " read java.lang.Integer" in {
+  it should "read java.lang.Integer" in {
     val variables = Map("foo" -> java.lang.Integer.valueOf("3"))
 
     engine
@@ -66,7 +66,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Long]
   }
 
-  it should " read java.lang.Long" in {
+  it should "read java.lang.Long" in {
     val variables = Map("foo" -> java.lang.Long.valueOf("3"))
 
     engine
@@ -75,7 +75,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Long]
   }
 
-  it should " read java.lang.Short" ignore {
+  it should "read java.lang.Short" in {
     val variables = Map("foo" -> java.lang.Short.valueOf("3"))
 
     engine
@@ -84,7 +84,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Long]
   }
 
-  it should " read java.lang.Boolean" in {
+  it should "read java.lang.Boolean" in {
     val variables = Map("foo" -> java.lang.Boolean.valueOf("true"))
 
     engine
@@ -93,7 +93,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.lang.Boolean]
   }
 
-  it should " read java.util.Date" in {
+  it should "read java.util.Date" in {
     val variables = Map("foo" -> new java.util.Date())
 
     engine
@@ -101,7 +101,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.time.LocalDateTime]
   }
 
-  it should " read null value" in {
+  it should "read null value" in {
     val nullValue: java.lang.Integer = null
 
     val variables = Map("foo" -> nullValue)
@@ -112,7 +112,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe true
   }
 
-  it should " read value from object getter" in {
+  it should "read value from object getter" in {
 
     val variables = Map("foo" -> new SimpleTestPojo("foo"))
 
@@ -122,7 +122,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe true
   }
 
-  it should " read java.util.Map" in {
+  it should "read java.util.Map" in {
     val map: java.util.Map[java.lang.String, java.lang.Object] =
       new util.HashMap[java.lang.String, java.lang.Object]()
     map.put("foo", "myString")
@@ -138,7 +138,7 @@ class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe true
   }
 
-  it should " read java.util.List" in {
+  it should "read java.util.List" in {
     val list: java.util.List[java.lang.Object] =
       new util.ArrayList[java.lang.Object]()
     list.add("myString")

--- a/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BultinValueMapperOutputTest.scala
+++ b/feel-engine/src/test/scala/org/camunda/feel/valuemapper/BultinValueMapperOutputTest.scala
@@ -27,35 +27,35 @@ class BultinValueMapperOutputTest extends FlatSpec with Matchers {
   val engine =
     new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))
 
-  it should " return java.lang.String" in {
+  "The value mapper" should "return java.lang.String" in {
 
     engine
       .evalExpression("\"foo\"", context = Context.EmptyContext)
       .getOrElse() shouldBe a[java.lang.String]
   }
 
-  it should " return java.lang.Double" in {
+  it should "return java.lang.Double" in {
 
     engine
       .evalExpression("10/3", context = Context.EmptyContext)
       .getOrElse() shouldBe a[java.lang.Double]
   }
 
-  it should " return java.lang.Long" in {
+  it should "return java.lang.Long" in {
 
     engine
       .evalExpression("10", context = Context.EmptyContext)
       .getOrElse() shouldBe a[java.lang.Long]
   }
 
-  it should " return java.lang.Boolean" in {
+  it should "return java.lang.Boolean" in {
 
     engine
       .evalExpression("true", context = Context.EmptyContext)
       .getOrElse() shouldBe a[java.lang.Boolean]
   }
 
-  it should " return java.time.LocalDateTime" in {
+  it should "return java.time.LocalDateTime" in {
 
     engine
       .evalExpression("date and time(\"2019-08-12T22:22:22\")",
@@ -63,7 +63,7 @@ class BultinValueMapperOutputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.time.LocalDateTime]
   }
 
-  it should " return java.time.ZonedDateTime" in {
+  it should "return java.time.ZonedDateTime" in {
 
     engine
       .evalExpression("date and time(\"2019-08-12T22:22:22@Europe/Berlin\")",
@@ -71,7 +71,7 @@ class BultinValueMapperOutputTest extends FlatSpec with Matchers {
       .getOrElse() shouldBe a[java.time.ZonedDateTime]
   }
 
-  it should " return null" in {
+  it should "return null" in {
 
     val nullValue: java.lang.Integer = null;
 
@@ -80,7 +80,7 @@ class BultinValueMapperOutputTest extends FlatSpec with Matchers {
       .getOrElse() == nullValue shouldBe true
   }
 
-  it should " return java.util.Map" in {
+  it should "return java.util.Map" in {
 
     val map = engine
       .evalExpression("{\"foo\": 42, \"bar\": 5.5, \"baz\": [1, 2]}",
@@ -101,7 +101,7 @@ class BultinValueMapperOutputTest extends FlatSpec with Matchers {
     list.get(0) shouldBe a[java.lang.Long]
   }
 
-  it should " return java.util.List" in {
+  it should "return java.util.List" in {
 
     val list = engine
       .evalExpression("[6, 5.5, {\"foo\": \"bar\"}]",


### PR DESCRIPTION
* the default value mapper reads values of type `short` as FEEL number

Closes #110 
