### PR TITLE
fix(engine): compare context and list values

### DIFF
--- a/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterContextExpressionTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.interpreter.impl
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.camunda.feel.syntaxtree._
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Philipp Ossler
@@ -95,6 +95,41 @@ class InterpreterContextExpressionTest
 
     eval(" { a:1, b: {}.x } ") should be(
       ValError("context contains no entry with key 'x'"))
+  }
+
+  it should "be compared with '='" in {
+
+    eval("{} = {}") should be(ValBoolean(true))
+    eval("{x:1} = {x:1}") should be(ValBoolean(true))
+    eval("{x:{ y:1 }} = {x:{ y:1 }}") should be(ValBoolean(true))
+
+    eval("{} = {x:1}") should be(ValBoolean(false))
+    eval("{x:1} = {}") should be(ValBoolean(false))
+    eval("{x:1} = {x:2}") should be(ValBoolean(false))
+    eval("{x:1} = {y:1}") should be(ValBoolean(false))
+
+    eval("{x:1} = {x:true}") should be(ValBoolean(false))
+  }
+
+  it should "be compared with '!='" in {
+
+    eval("{} != {}") should be(ValBoolean(false))
+    eval("{x:1} != {x:1}") should be(ValBoolean(false))
+    eval("{x:{ y:1 }} != {x:{ y:1 }}") should be(ValBoolean(false))
+
+    eval("{} != {x:1}") should be(ValBoolean(true))
+    eval("{x:1} != {}") should be(ValBoolean(true))
+    eval("{x:1} != {x:2}") should be(ValBoolean(true))
+    eval("{x:1} != {y:1}") should be(ValBoolean(true))
+
+    eval("{x:1} != {x:true}") should be(ValBoolean(true))
+  }
+
+  it should "fail to compare if not a context" in {
+
+    eval("{} = 1") should be(
+      ValError("expect Context but found 'ValNumber(1)'")
+    )
   }
 
 }

--- a/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterListExpressionTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.interpreter.impl
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.camunda.feel.syntaxtree._
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Philipp Ossler
@@ -99,6 +99,45 @@ class InterpreterListExpressionTest
 
     eval("[1, {}.x]") should be(
       ValError("context contains no entry with key 'x'"))
+  }
+
+  it should "be compared with '='" in {
+
+    eval("[] = []") should be(ValBoolean(true))
+    eval("[1] = [1]") should be(ValBoolean(true))
+    eval("[[1]] = [[1]]") should be(ValBoolean(true))
+    eval("[{x:1}] = [{x:1}]") should be(ValBoolean(true))
+
+    eval("[] = [1]") should be(ValBoolean(false))
+    eval("[1] = []") should be(ValBoolean(false))
+    eval("[1] = [2]") should be(ValBoolean(false))
+    eval("[[1]] = [[2]]") should be(ValBoolean(false))
+    eval("[{x:1}] = [{x:2}]") should be(ValBoolean(false))
+
+    eval("[1] = [true]") should be(ValBoolean(false))
+  }
+
+  it should "be compared with '!='" in {
+
+    eval("[] != []") should be(ValBoolean(false))
+    eval("[1] != [1]") should be(ValBoolean(false))
+    eval("[[1]] != [[1]]") should be(ValBoolean(false))
+    eval("[{x:1}] != [{x:1}]") should be(ValBoolean(false))
+
+    eval("[] != [1]") should be(ValBoolean(true))
+    eval("[1] != []") should be(ValBoolean(true))
+    eval("[1] != [2]") should be(ValBoolean(true))
+    eval("[[1]] != [[2]]") should be(ValBoolean(true))
+    eval("[{x:1}] != [{x:2}]") should be(ValBoolean(true))
+
+    eval("[1] != [true]") should be(ValBoolean(true))
+  }
+
+  it should "fail to compare if not a list" in {
+
+    eval("[] = 1") should be(
+      ValError("expect List but found 'ValNumber(1)'")
+    )
   }
 
   "A for-expression" should "iterate over a range" in {

--- a/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/interpreter/impl/InterpreterUnaryTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.interpreter.impl
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.camunda.feel.syntaxtree._
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Philipp Ossler
@@ -414,6 +414,28 @@ class InterpreterUnaryTest
     evalUnaryTests(dayTimeDuration("P2DT4H"),
                    """[duration("P1D")..duration("P2D")]""") should be(
       ValBoolean(false))
+  }
+
+  "A list" should "be equal to another list" in {
+
+    evalUnaryTests(List.empty, "[]") should be(ValBoolean(true))
+    evalUnaryTests(List(1, 2), "[1,2]") should be(ValBoolean(true))
+
+    evalUnaryTests(List(1, 2), "[]") should be(ValBoolean(false))
+    evalUnaryTests(List(1, 2), "[1]") should be(ValBoolean(false))
+    evalUnaryTests(List(1, 2), "[2,1]") should be(ValBoolean(false))
+    evalUnaryTests(List(1, 2), "[1,2,3]") should be(ValBoolean(false))
+  }
+
+  "A context" should "be equal to another context" in {
+
+    evalUnaryTests(Map.empty, "{}") should be(ValBoolean(true))
+    evalUnaryTests(Map("x" -> 1), "{x:1}") should be(ValBoolean(true))
+
+    evalUnaryTests(Map("x" -> 1), "{}") should be(ValBoolean(false))
+    evalUnaryTests(Map("x" -> 1), "{x:2}") should be(ValBoolean(false))
+    evalUnaryTests(Map("x" -> 1), "{y:1}") should be(ValBoolean(false))
+    evalUnaryTests(Map("x" -> 1), "{x:1,y:2}") should be(ValBoolean(false))
   }
 
   "An empty expression ('-')" should "be always true" in {


### PR DESCRIPTION
* in an expression, a list/context value can be compared to another list/context value
  * two contexts are equal if they have the same keys and every entry is equal
  * two lists are equal if they have the same size and every item is equal
  * ignore failures when comparing the entries/items (e.g. different types)
* in a unary-test, a list/context input value can be compared to a list/context value

closes #134 
