### PR TITLE
[Backport 1.11] Compare not existing variables with null

### DIFF
--- a/docs/develop/feel-built-in-functions.md
+++ b/docs/develop/feel-built-in-functions.md
@@ -135,6 +135,30 @@ not(true)
 // false
 ```
 
+### is defined()
+
+Checks if a given value is defined or not. A value is defined if it exists, and it is an instance of one of the FEEL data types including `null`.
+
+The function can be used to check if a variable, or a context entry (e.g. a property of a variable) exists. It allows differentiating between a variable that is `null` and a value that doesn't exist.   
+
+* parameters:
+  * `value`: any
+* result: boolean
+
+```js
+is defined(1)
+// true
+
+is defined(null)
+// true
+
+is defined(x)
+// false - if no variable "x" exists
+
+is defined(x.y)
+// false - if no variable "x" exists or it doesn't have a property "y"
+```
+
 ## String Functions 
 
 ### substring()

--- a/docs/develop/feel-expression.md
+++ b/docs/develop/feel-expression.md
@@ -138,13 +138,30 @@ duration("P1Y") / duration("P1M")
 | greater than or equal | `>=` | `>= 10` |
 | between | `between _ and _` | `x between 3 and 9` |
 
-* less than/greater than/between are only supported for: 
+The operators less than, greater than, and between are only supported for: 
   * number
   * date
   * time
   * date-time
   * year-month-duration
   * day-time-duration 
+  
+Any value can be compared with `null` to check if it is equal to `null`, or if it exists. Comparing `null` to a value different from `null` results in `false`. It returns `true` if the value, or the context entry (e.g. the property of a variable) is `null` or doesn't exist. The built-in function [is defined()](feel-built-in-functions.md#is-defined) can be used to differentiate between a value that is `null` and a value that doesn't exist. 
+
+```js
+null = null
+// true
+
+"foo" = null
+// false
+
+x = null
+// true - if "x" is null or doesn't exist
+
+x.y = null
+// true - if "x" is null, "x" doesn't exist, 
+//           "y" is null, or "x" has no property "y" 
+```  
 
 ### Disjunction and Conjunction
 

--- a/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
@@ -57,7 +57,10 @@ object BuiltinFunctions extends FunctionProvider {
       "years and months duration" -> List(durationFunction2)
     )
 
-  private def booleanFunctions = Map("not" -> List(notFunction))
+  private def booleanFunctions = Map(
+    "not" -> List(notFunction),
+    "is defined" -> List(isDefinedFunction)
+  )
 
   private def stringFunctions =
     Map(
@@ -1113,6 +1116,15 @@ object BuiltinFunctions extends FunctionProvider {
             .getVariable(key)
             .getOrElse(ValNull)
         case e => error(e)
+      }
+    )
+
+  private def isDefinedFunction =
+    ValFunction(
+      params = List("value"),
+      invoke = _ match {
+        case (value: ValError) :: Nil => ValBoolean(false)
+        case _                        => ValBoolean(true)
       }
     )
 

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -489,8 +489,8 @@ class FeelInterpreter {
       c: (Any, Any) => Boolean,
       f: Boolean => Val)(implicit context: EvalContext): Val =
     x match {
-      case ValNull                 => withVal(y, y => f(c(ValNull, y)))
-      case x if (y == ValNull)     => f(c(x, ValNull))
+      case ValNull                 => f(c(ValNull, y.toOption.getOrElse(ValNull)))
+      case x if (y == ValNull)     => f(c(x.toOption.getOrElse(ValNull), ValNull))
       case ValNumber(x)            => withNumber(y, y => f(c(x, y)))
       case ValBoolean(x)           => withBoolean(y, y => f(c(x, y)))
       case ValString(x)            => withString(y, y => f(c(x, y)))

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -60,7 +60,8 @@ object FeelParser extends JavaTokenParsers {
     | "index of"
     | "distinct values"
     | "get entries"
-    | "get value")
+    | "get value"
+    | "is defined")
 
   // list of built-in function parameter names with whitespaces
   // -- other names match the 'parameter name' pattern

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
@@ -40,4 +40,24 @@ class BuiltinFunctionsTest
     eval(" not(false) ") should be(ValBoolean(true))
   }
 
+  "A is defined() function" should "return true if the value is present" in {
+
+    eval("is defined(null)") should be(ValBoolean(true))
+
+    eval("is defined(1)") should be(ValBoolean(true))
+    eval("is defined(true)") should be(ValBoolean(true))
+    eval("is defined([])") should be(ValBoolean(true))
+    eval("is defined({})") should be(ValBoolean(true))
+    eval(""" is defined( {"a":1}.a ) """) should be(ValBoolean(true))
+  }
+
+  it should "return false if the value is not present" in {
+
+    eval("is defined(a)") should be(ValBoolean(false))
+    eval("is defined(a.b)") should be(ValBoolean(false))
+
+    eval("is defined({}.a)") should be(ValBoolean(false))
+    eval("is defined({}.a.b)") should be(ValBoolean(false))
+  }
+
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -75,4 +75,40 @@ class InterpreterExpressionTest
     eval("null != null") should be(ValBoolean(false))
   }
 
+  it should "compare to nullable variable" in {
+
+    eval("null = x", Map("x" -> ValNull)) should be(ValBoolean(true))
+    eval("null = x", Map("x" -> 1)) should be(ValBoolean(false))
+
+    eval("null != x", Map("x" -> ValNull)) should be(ValBoolean(false))
+    eval("null != x", Map("x" -> 1)) should be(ValBoolean(true))
+  }
+
+  it should "compare to nullable context entry" in {
+
+    eval("null = {x: null}.x") should be(ValBoolean(true))
+    eval("null = {x: 1}.x") should be(ValBoolean(false))
+
+    eval("null != {x: null}.x") should be(ValBoolean(false))
+    eval("null != {x: 1}.x") should be(ValBoolean(true))
+  }
+
+  it should "compare to not existing variable" in {
+
+    eval("null = x") should be(ValBoolean(true))
+    eval("null = x.y") should be(ValBoolean(true))
+
+    eval("x = null") should be(ValBoolean(true))
+    eval("x.y = null") should be(ValBoolean(true))
+  }
+
+  it should "compare to not existing context entry" in {
+
+    eval("null = {}.x") should be(ValBoolean(true))
+    eval("null = {x: null}.x.y") should be(ValBoolean(true))
+
+    eval("{}.x = null") should be(ValBoolean(true))
+    eval("{x: null}.x.y = null") should be(ValBoolean(true))
+  }
+
 }


### PR DESCRIPTION
## Description

* backport #176 to `1.11.x` 

## Related issues

closes #150
