### PR TITLE
Allow variable names with date-time keywords

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -44,11 +44,6 @@ object FeelParser extends JavaTokenParsers {
     | "between\\b".r
     | "instance\\b".r | "of\\b".r)
 
-  private lazy val dateTimeWords: Parser[String] = ("date and time".r
-    | "date".r
-    | "time".r
-    | "duration".r)
-
   // list of built-in function names with whitespaces
   // -- other names match the 'function name' pattern
   private lazy val builtinFunctionName: Parser[String] = ("date and time"
@@ -118,7 +113,7 @@ object FeelParser extends JavaTokenParsers {
   private lazy val expression8 = functionInvocation | builtinFunctionInvocation | filteredExpression9
   // 2 i)
   private lazy val expression9 =
-    not(dateTimeWords) ~> name ^^ (n => Ref(List(n))) |
+    not(dateTimeLiteral) ~> name ^^ (n => Ref(List(n))) |
       literal |
       "?" ^^^ ConstInputValue |
       simplePositiveUnaryTest |

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -144,7 +144,10 @@ class InterpreterExpressionTest
     "elseY",
     "betweenXandY",
     "notThis",
-    "inside"
+    "inside",
+    "durationX",
+    "dateX",
+    "timeX"
   ).foreach { variableName =>
     it should s"contain a key-word ($variableName)" in {
 


### PR DESCRIPTION
## Description

* adjust the parser to allow variable names with a date-time keyword 

## Related issues

closes #184 
