### PR TITLE
[Backport 1.12] Use the clock when creating the engine with the builder

### DIFF
--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -91,7 +91,8 @@ object FeelEngine {
     def build: FeelEngine = new FeelEngine(
       functionProvider = functionProvider_,
       valueMapper = valueMapper_,
-      configuration = configuration_
+      configuration = configuration_,
+      clock = clock_
     )
 
   }


### PR DESCRIPTION
## Description

Backport of #189 

## Related issues

closes #188 
