### PR TITLE
fix: fixed oddFunction to eval negative numbers

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
@@ -5,6 +5,7 @@ import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
 import org.camunda.feel.syntaxtree._
 
 import scala.math.BigDecimal.RoundingMode
+import scala.math.Numeric.BigDecimalAsIfIntegral.abs
 
 object NumericBuiltinFunctions {
 
@@ -100,7 +101,7 @@ object NumericBuiltinFunctions {
 
   private def oddFunction =
     builtinFunction(params = List("number"), invoke = {
-      case List(ValNumber(n)) => ValBoolean(n % 2 == 1)
+      case List(ValNumber(n)) => ValBoolean(abs(n) % 2 == 1)
     })
 
   private def evenFunction =

--- a/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
@@ -5,7 +5,6 @@ import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
 import org.camunda.feel.syntaxtree._
 
 import scala.math.BigDecimal.RoundingMode
-import scala.math.Numeric.BigDecimalAsIfIntegral.abs
 
 object NumericBuiltinFunctions {
 
@@ -101,7 +100,7 @@ object NumericBuiltinFunctions {
 
   private def oddFunction =
     builtinFunction(params = List("number"), invoke = {
-      case List(ValNumber(n)) => ValBoolean(abs(n) % 2 == 1)
+      case List(ValNumber(n)) => ValBoolean(n.abs % 2 == 1)
     })
 
   private def evenFunction =

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
@@ -205,6 +205,8 @@ class BuiltinNumberFunctionsTest
 
     eval(" odd(5) ") should be(ValBoolean(true))
     eval(" odd(2) ") should be(ValBoolean(false))
+    eval(" odd(-5)") should be(ValBoolean(true))
+    eval(" odd(-2)") should be(ValBoolean(false))
   }
 
   "A even() function" should "return true if number is even" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
@@ -205,6 +205,10 @@ class BuiltinNumberFunctionsTest
 
     eval(" odd(5) ") should be(ValBoolean(true))
     eval(" odd(2) ") should be(ValBoolean(false))
+  }
+
+  it should "return true if negative number is odd" in {
+
     eval(" odd(-5)") should be(ValBoolean(true))
     eval(" odd(-2)") should be(ValBoolean(false))
   }


### PR DESCRIPTION
Signed-off-by: Kasper Aaquist Johansen <kasperaaquist@gmail.com>

## Description

* Made oddFunction return `true` when evaluating negative numbers.  

closes #151 
