### PR TITLE
fix: fixed abs() function to be invoked with named parameter "n"

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
@@ -12,7 +12,7 @@ object NumericBuiltinFunctions {
     "decimal" -> List(decimalFunction, decimalFunction3),
     "floor" -> List(floorFunction),
     "ceiling" -> List(ceilingFunction),
-    "abs" -> List(absFunction),
+    "abs" -> List(absFunctionNumber, absFunctionN),
     "modulo" -> List(moduloFunction),
     "sqrt" -> List(sqrtFunction),
     "log" -> List(logFunction),
@@ -71,10 +71,14 @@ object NumericBuiltinFunctions {
     }
   }
 
-  private def absFunction =
-    builtinFunction(params = List("number"), invoke = {
+  private def absFunction(paramName: String) =
+    builtinFunction(params = List(paramName), invoke = {
       case List(ValNumber(n)) => ValNumber(n.abs)
     })
+
+  private def absFunctionNumber = absFunction("number")
+
+  private def absFunctionN = absFunction("n")
 
   private def moduloFunction =
     builtinFunction(params = List("dividend", "divisor"), invoke = {

--- a/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/NumericBuiltinFunctions.scala
@@ -12,7 +12,7 @@ object NumericBuiltinFunctions {
     "decimal" -> List(decimalFunction, decimalFunction3),
     "floor" -> List(floorFunction),
     "ceiling" -> List(ceilingFunction),
-    "abs" -> List(absFunctionNumber, absFunctionN),
+    "abs" -> List(absFunction(paramName = "number"), absFunction(paramName = "n")),
     "modulo" -> List(moduloFunction),
     "sqrt" -> List(sqrtFunction),
     "log" -> List(logFunction),
@@ -75,10 +75,6 @@ object NumericBuiltinFunctions {
     builtinFunction(params = List(paramName), invoke = {
       case List(ValNumber(n)) => ValNumber(n.abs)
     })
-
-  private def absFunctionNumber = absFunction("number")
-
-  private def absFunctionN = absFunction("n")
 
   private def moduloFunction =
     builtinFunction(params = List("dividend", "divisor"), invoke = {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
@@ -180,6 +180,18 @@ class BuiltinNumberFunctionsTest
     eval(" abs(-10) ") should be(ValNumber(10))
   }
 
+  "abs() function" should "be invoked with named parameter number" in {
+
+    eval(" abs(number: 1) ") should be(ValNumber(1))
+    eval(" abs(number: -1) ") should be(ValNumber(1))
+  }
+
+  "abs() function" should "be invoked with named parameter n" in {
+
+    eval(" abs(n: 1) ") should be(ValNumber(1))
+    eval(" abs(n: -1) ") should be(ValNumber(1))
+  }
+
   "A modulo() function" should "return the remainder of the division of dividend by divisor" in {
 
     eval(" modulo(12, 5) ") should be(ValNumber(2))

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
@@ -180,13 +180,13 @@ class BuiltinNumberFunctionsTest
     eval(" abs(-10) ") should be(ValNumber(10))
   }
 
-  "abs() function" should "be invoked with named parameter number" in {
+  it should "be invoked with named parameter number" in {
 
     eval(" abs(number: 1) ") should be(ValNumber(1))
     eval(" abs(number: -1) ") should be(ValNumber(1))
   }
 
-  "abs() function" should "be invoked with named parameter n" in {
+  it should "be invoked with named parameter n" in {
 
     eval(" abs(n: 1) ") should be(ValNumber(1))
     eval(" abs(n: -1) ") should be(ValNumber(1))


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* The `abs()` can now be invoked either with a named parameter `n` or `number`

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #164 
