### PR TITLE
REPL: provide variables as JSON

### DIFF
--- a/feel-repl.sc
+++ b/feel-repl.sc
@@ -38,7 +38,6 @@ def unpackJson(json: ujson.Value): Any = {
 // print on loading the script
 println(fansi.Color.LightBlue("===== FEEL Engine REPL ======"))
 println(fansi.Color.LightBlue("""> Evaluate FEEL expressions using 'feel("1 + 3")'"""))
-println(fansi.Color.LightBlue("""> Provide variables using 'feel("x + 3", Map("x" -> 2))'"""))
 println(fansi.Color.LightBlue("""> Provide variables as Map using 'feel("x + 3", Map("x" -> 2))'"""))
 println(fansi.Color.LightBlue("""> Provide variables as JSON string using 'feel("x + 3", "{ \"x\" : 2 }")'"""))
 

--- a/feel-repl.sc
+++ b/feel-repl.sc
@@ -39,8 +39,8 @@ def unpackJson(json: ujson.Value): Any = {
 println(fansi.Color.LightBlue("===== FEEL Engine REPL ======"))
 println(fansi.Color.LightBlue("""> Evaluate FEEL expressions using 'feel("1 + 3")'"""))
 println(fansi.Color.LightBlue("""> Provide variables using 'feel("x + 3", Map("x" -> 2))'"""))
-println(fansi.Color.LightBlue("""> Provide variables as Map or JSON string using 'feel("x + 3", Map("x" -> 2))'"""))
+println(fansi.Color.LightBlue("""> Provide variables as Map using 'feel("x + 3", Map("x" -> 2))'"""))
+println(fansi.Color.LightBlue("""> Provide variables as JSON string using 'feel("x + 3", "{ \"x\" : 2 }")'"""))
 
 // usage: amm --predef feel-repl.sc
-
 

--- a/feel-repl.sc
+++ b/feel-repl.sc
@@ -7,18 +7,40 @@ import $ivy.`org.apache.logging.log4j:log4j-slf4j-impl:2.14.0`, org.apache.loggi
 Configurator.setRootLevel(Level.WARN)
 
 // initialize the FEEL engine
-val feelEngine = new FeelEngine() 
+val feelEngine = new FeelEngine()
 
 // define a shortcut function for evaluation
 def feel(expression: String, context: Map[String, Any] = Map.empty) {
   feelEngine.evalExpression(expression, context) match {
     case Right(result) => println(fansi.Color.LightGreen(s"> $result"))
-    case Left(failure) => println(fansi.Color.LightRed(s"> $failure"))  
+    case Left(failure) => println(fansi.Color.LightRed(s"> $failure"))
   }
 }
 
+def feel(expression: String, jsonContext: String) {
+  val json = ujson.read(jsonContext) match {
+    case ujson.Obj(objValue) => {
+      val context = objValue.map { case (key, value) => key -> unpackJson(value)}.toMap
+      feel(expression, context)
+    }
+    case otherValue => println(fansi.Color.LightRed(s"> Expected a JSON object as variables but found '$otherValue'"))
+  }
+}
+
+def unpackJson(json: ujson.Value): Any = {
+  json match {
+    case ujson.Obj(objValue) => objValue.map { case (key, value) => key -> unpackJson(value)}.toMap
+    case ujson.Arr(arrValue) => arrValue.map(unpackJson).toList
+    case primitiveValue => primitiveValue.value
+  }
+}
+
+// print on loading the script
 println(fansi.Color.LightBlue("===== FEEL Engine REPL ======"))
 println(fansi.Color.LightBlue("""> Evaluate FEEL expressions using 'feel("1 + 3")'"""))
 println(fansi.Color.LightBlue("""> Provide variables using 'feel("x + 3", Map("x" -> 2))'"""))
+println(fansi.Color.LightBlue("""> Provide variables as Map or JSON string using 'feel("x + 3", Map("x" -> 2))'"""))
 
 // usage: amm --predef feel-repl.sc
+
+


### PR DESCRIPTION
## Description

* add a new function for the REPL to provide variables as a JSON string instead of a map
* use [uPickle](http://www.lihaoyi.com/upickle/#uJson) to deserialize the JSON string because it is already bundled in the Ammonite REPL (i.e. no additional dependency to download) 

## Related issues

closes #223
