### PR TITLE
chore(repo): rename Camunda BPM Platform to Camunda Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A parser and interpreter for FEEL that is written in Scala (see [What is FEEL?](
 The FEEL engine started as a slack time project, grown to a community-driven project and is now officially maintained by [Camunda](https://camunda.org/) :rocket: 
 
 It is integrated in the following projects:
-* [Camunda BPM Platform](https://docs.camunda.org/manual/user-guide/dmn-engine/feel/) as part of the DMN engine
+* [Camunda Platform](https://docs.camunda.org/manual/user-guide/dmn-engine/feel/) as part of the DMN engine
 * [Zeebe](https://docs.zeebe.io/reference/expressions.html#the-expression-language) as expression language
 
 **Features:** :sparkles:

--- a/pom.xml
+++ b/pom.xml
@@ -362,12 +362,12 @@
   <distributionManagement>
     <repository>
       <id>camunda-nexus</id>
-      <name>camunda bpm community extensions</name>
+      <name>camunda platform community extensions</name>
       <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
-      <name>camunda bpm community extensions snapshots</name>
+      <name>camunda platform community extensions snapshots</name>
       <url>
         https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots
       </url>


### PR DESCRIPTION
## Description

We are currently renaming Camunda BPM Platform to Camunda Platform. We only want to do this in places where the name is used descriptively (i.e. not change any code or artifacts).


## Related issues

Related to CAM-12950
