### PR TITLE
New context built-in functions put()/put all()

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
@@ -29,3 +29,35 @@ Returns the entries of the context as list of key-value-pairs.
 get entries({foo: 123})
 // [{key: "foo", value: 123}]
 ```
+
+## put()
+
+Add the given key and value to a context. Returns a new context that includes the entry. It might override an existing entry of the context.  
+
+Returns `null` if the value is not defined.
+
+* parameters:
+  * `context`: context
+  * `key`: string
+  * `value`: any
+* result: context  
+
+```js
+put({x:1}, "y", 2)
+// {x:1, y:2}
+```
+
+## put all()
+
+Union the given contexts (two or more). Returns a new context that includes all entries of the given contexts. It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts are passed in the method.    
+
+Returns `null` if one of the values is not a context.
+
+* parameters:
+  * `contexts`: contexts as varargs
+* result: context  
+
+```js
+put all({x:1}, {y:2})
+// {x:1, y:2}
+```

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -1,14 +1,24 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.context.Context
+import org.camunda.feel.context.Context.StaticContext
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
-import org.camunda.feel.syntaxtree.{ValContext, ValNull, ValString}
+import org.camunda.feel.syntaxtree.{
+  Val,
+  ValContext,
+  ValError,
+  ValList,
+  ValNull,
+  ValString
+}
 
 object ContextBuiltinFunctions {
 
   def functions = Map(
     "get entries" -> List(getEntriesFunction),
-    "get value" -> List(getValueFunction)
+    "get value" -> List(getValueFunction),
+    "put" -> List(putFunction),
+    "put all" -> List(putAllFunction)
   )
 
   private def getEntriesFunction = builtinFunction(
@@ -31,4 +41,37 @@ object ContextBuiltinFunctions {
           .getOrElse(ValNull)
     }
   )
+
+  private def putFunction = builtinFunction(
+    params = List("context", "key", "value"),
+    invoke = {
+      case List(ValContext(_), ValString(_), ValError(_)) => ValNull
+      case List(ValContext(c), ValString(key), value) =>
+        ValContext(
+          StaticContext(
+            variables = c.variableProvider.getVariables + (key -> value)))
+    }
+  )
+
+  private def putAllFunction = builtinFunction(
+    params = List("contexts"),
+    invoke = {
+      case List(ValList(contexts)) if isListOfContexts(contexts) =>
+        ValContext(
+          StaticContext(
+            variables = contexts
+              .flatMap(_ match {
+                case ValContext(c) => c.variableProvider.getVariables
+                case _             => Map.empty
+              })
+              .toMap
+          )
+        )
+      case _ => ValNull
+    },
+    hasVarArgs = true
+  )
+
+  private def isListOfContexts(list: List[Val]) =
+    list.forall(_.isInstanceOf[ValContext])
 }

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -68,7 +68,8 @@ object FeelParser extends JavaTokenParsers {
       "day of year",
       "day of week",
       "month of year",
-      "week of year"
+      "week of year",
+      "put all"
     ).!
   )
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -16,6 +16,7 @@
  */
 package org.camunda.feel.impl.builtin
 
+import org.camunda.feel.context.Context.StaticContext
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
@@ -47,7 +48,7 @@ class BuiltinContextFunctionsTest
       Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
   }
 
-  it should "return empty list if emtpy" in {
+  it should "return empty list if empty" in {
 
     eval(""" get entries({}) """) should be(ValList(List()))
   }
@@ -60,6 +61,127 @@ class BuiltinContextFunctionsTest
   it should "return null if not contains" in {
 
     eval(""" get value({}, "foo") """) should be(ValNull)
+  }
+
+  "A put function" should "add an entry to an empty context" in {
+
+    eval(""" put({}, "x", 1) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(1)))
+      ))
+  }
+
+  it should "add an entry to an existing context" in {
+
+    eval(""" put({x:1}, "y", 2) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(1), "y" -> ValNumber(2)))
+      ))
+  }
+
+  it should "override an entry of an existing context" in {
+
+    eval(""" put({x:1}, "x", 2) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(2)))
+      ))
+  }
+
+  it should "add a context entry to an existing context" in {
+
+    eval(""" put({x:1}, "y", {"z":2}) = {x:1, y:{z:2} } """) should be(
+      ValBoolean(true))
+  }
+
+  it should "return null if the value is not present" in {
+
+    eval(""" put({}, "x", notExisting) """) should be(ValNull)
+  }
+
+  "A put all function" should "return a single empty context" in {
+
+    eval(""" put all({}) """) should be(
+      ValContext(
+        StaticContext(variables = Map.empty)
+      ))
+  }
+
+  it should "return a single context" in {
+
+    eval(""" put all({x:1}) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(1)))
+      ))
+  }
+
+  it should "combine empty contexts" in {
+
+    eval(""" put all({}, {}) """) should be(
+      ValContext(
+        StaticContext(variables = Map.empty)
+      ))
+  }
+
+  it should "add all entries to an empty context" in {
+
+    eval(""" put all({}, {x:1}) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(1)))
+      ))
+  }
+
+  it should "add an entry to an context" in {
+
+    eval(""" put all({x:1}, {y:2}) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(1), "y" -> ValNumber(2)))
+      ))
+  }
+
+  it should "add all entries to an context" in {
+
+    eval(""" put all({x:1}, {y:2, z:3}) """) should be(
+      ValContext(
+        StaticContext(variables =
+          Map("x" -> ValNumber(1), "y" -> ValNumber(2), "z" -> ValNumber(3)))
+      ))
+  }
+
+  it should "override an entry of the existing context" in {
+
+    eval(""" put all({x:1}, {x:2}) """) should be(
+      ValContext(
+        StaticContext(variables = Map("x" -> ValNumber(2)))
+      ))
+  }
+
+  it should "override entries in order" in {
+
+    eval(""" put all({x:1,y:3,z:1}, {x:2,y:2,z:3}, {x:3,y:1,z:2}) """) should be(
+      ValContext(
+        StaticContext(variables =
+          Map("x" -> ValNumber(3), "y" -> ValNumber(1), "z" -> ValNumber(2)))
+      ))
+  }
+
+  it should "combine three contexts" in {
+
+    eval(""" put all({x:1}, {y:2}, {z:3}) """) should be(
+      ValContext(
+        StaticContext(variables =
+          Map("x" -> ValNumber(1), "y" -> ValNumber(2), "z" -> ValNumber(3)))
+      ))
+  }
+
+  it should "add a nested context" in {
+
+    eval(""" put all({x:1}, {y:{z:2}}) = {x:1, y:{z:2} } """) should be(
+      ValBoolean(true))
+  }
+
+  it should "return null if one entry is not a context" in {
+
+    eval(""" put all({}, 1) """) should be(ValNull)
   }
 
 }


### PR DESCRIPTION
## Description

* add new context built-in functions `put()` and `put all()`

In Zeebe, we can replace the custom `appendTo(x, y)` function by `if (x = null) then y else put all(x, y)`.

## Related issues

closes #169
