### PR TITLE
Allows escape sequences in string literals

### DIFF
--- a/docs/docs/reference/language-guide/feel-data-types.md
+++ b/docs/docs/reference/language-guide/feel-data-types.md
@@ -32,6 +32,8 @@ A whole or floating point number.
 
 ### String
 
+A sequence of characters enclosed in double quotes `"`. The sequence can also contain escaped characters starting with `\` (e.g. `\'`, `\"`, `\\`, `\n`, `\r`, `\t`, unicode like `\u269D` or `\U101EF`).
+
 * Java Type: `java.lang.String`
 
 ```js
@@ -39,6 +41,8 @@ A whole or floating point number.
 ```
 
 ### Boolean
+
+A boolean value. It is either true or false. 
 
 * Java Type: `java.lang.Boolean`
 
@@ -48,6 +52,8 @@ false
 ```
 
 ### Date 
+
+A date value without a time component.
 
 * Format: `yyyy-MM-dd`.
 * Java Type: `java.time.LocalDate`

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -101,9 +101,10 @@ object FeelParser {
         0)
     )
 
+  // 33 + 64
+  // characters or string escape sequences (\', \", \\, \n, \r, \t, \u269D, \U101EF)
   private def stringLiteralWithQuotes[_: P]: P[String] =
-    P("\"" ~~ (!"\"" ~~ AnyChar.!).repX ~~ "\"")
-      .map(_.mkString)
+    P("\"" ~~ (("\\" | !"\"") ~~ AnyChar).repX.! ~~ "\"")
 
   // 1 a)
   private def expression[_: P]: P[Exp] = P(textualExpression)

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -76,4 +76,20 @@ class InterpreterStringExpressionTest
     eval(""" "a" != null """) should be(ValBoolean(true))
   }
 
+  List(""" \' """,
+       """ \" """,
+       """ \\ """,
+       """ \n """,
+       """ \r """,
+       """ \t """,
+       """ \u269D """,
+       """ \U101EF """)
+    .foreach { escapeChar =>
+      it should s"contains an escape sequence ($escapeChar)" in {
+
+        eval(s""" "a $escapeChar b" """) should be(
+          ValString(s"""a $escapeChar b"""))
+      }
+    }
+
 }


### PR DESCRIPTION
## Description

* allow escape sequences in string literals starting with `\` 

## Related issues

closes #236
