### PR TITLE
Parse nested path and filter expressions

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -76,6 +76,49 @@ class InterpreterExpressionTest
     eval(" `a-b` ", Map("a-b" -> 3)) should be(ValNumber(3))
   }
 
+  it should "contains parentheses" in {
+    eval("(1 + 2)") should be(ValNumber(3))
+    eval("(1 + 2) + 3") should be(ValNumber(6))
+    eval("1 + (2 + 3)") should be(ValNumber(6))
+
+    eval("([1,2,3])[1]") should be(ValNumber(1))
+    eval("({x:1}).x") should be(ValNumber(1))
+    eval("{x:(1)}.x") should be(ValNumber(1))
+
+    eval("[1,2,3,4][(1)]") should be(ValNumber(1))
+  }
+
+  it should "contains nested filter expressions" in {
+    eval("[1,2,3,4][item > 2][1]") should be(ValNumber(3))
+    eval("([1,2,3,4])[item > 2][1]") should be(ValNumber(3))
+    eval("([1,2,3,4][item > 2])[1]") should be(ValNumber(3))
+  }
+
+  it should "contains nested path expressions" in {
+    eval("{x:{y:1}}.x.y") should be(ValNumber(1))
+    eval("{x:{y:{z:1}}}.x.y.z") should be(ValNumber(1))
+
+    eval("({x:{y:{z:1}}}).x.y.z") should be(ValNumber(1))
+    eval("({x:{y:{z:1}}}.x).y.z") should be(ValNumber(1))
+    eval("({x:{y:{z:1}}}.x.y).z") should be(ValNumber(1))
+  }
+
+  it should "contains nested filter and path expressions" in {
+    eval("[{x:{y:1}},{x:{y:2}},{x:{y:3}}].x.y[2]") should be(ValNumber(2))
+    eval("([{x:{y:1}},{x:{y:2}},{x:{y:3}}]).x.y[2]") should be(ValNumber(2))
+    eval("([{x:{y:1}},{x:{y:2}},{x:{y:3}}].x).y[2]") should be(ValNumber(2))
+    eval("([{x:{y:1}},{x:{y:2}},{x:{y:3}}].x.y)[2]") should be(ValNumber(2))
+
+    eval("([{x:{y:1}},{x:{y:2}},{x:{y:3}}]).x[2].y") should be(ValNumber(2))
+    eval("([{x:{y:1}},{x:{y:2}},{x:{y:3}}])[2].x.y") should be(ValNumber(2))
+
+    eval("[{x:[1,2]},{x:[3,4]},{x:[5,6]}][2].x[1]") should be(ValNumber(3))
+
+    eval("([{x:[1,2]},{x:[3,4]},{x:[5,6]}]).x[2][1]") should be(ValNumber(3))
+    eval("([{x:[1,2]},{x:[3,4]},{x:[5,6]}].x)[2][1]") should be(ValNumber(3))
+    eval("([{x:[1,2]},{x:[3,4]},{x:[5,6]}].x[2])[1]") should be(ValNumber(3))
+  }
+
   "Null" should "compare to null" in {
 
     eval("null = null") should be(ValBoolean(true))
@@ -161,7 +204,6 @@ class InterpreterExpressionTest
       eval(s"$variableName = true", Map(variableName -> true)) should be(
         ValBoolean(true))
     }
-
   }
 
 }


### PR DESCRIPTION
## Description

* after replacing the parser library in `1.13.0`, some expressions with nested filter and path access can not be parsed anymore (e.g. `([1,2,3,4][item > 2])[1]`, `([{x:{y:1}},{x:{y:2}},{x:{y:3}}]).x[2].y`)
* introduce new parser combinators to parser nested filter and path expressions that follow an expression in brackets
  * instead of using a recursive parsing style as it is currently the case, use a continuation parsing style
  * this style fits better for parsing an expression from left to right and doesn't require limitations to avoid endless recursions
  * since this style seems promising to reduce some limitations of the parser, I plan to roll it out more step-by-step 

## Related issues

closes #258 
