### PR TITLE
Allow parentheses in context literal

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -483,7 +483,7 @@ object FeelParser {
   // 52
   private def filteredExpression9[_: P]: P[Exp] =
     P(expression9.flatMap(x =>
-      ("[" ~/ expression ~ "]").?.map(_.fold(x)(filterExp =>
+      ("[" ~ expression ~ "]").?.map(_.fold(x)(filterExp =>
         Filter(x, filterExp)))))
 
   // 40

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -88,6 +88,14 @@ class InterpreterExpressionTest
     eval("[1,2,3,4][(1)]") should be(ValNumber(1))
   }
 
+  it should "contain parentheses in a context literal" in {
+    val context = Map("xs" -> List(1, 2, 3))
+
+    eval("{x:(xs[1])}.x", context) should be(ValNumber(1))
+    eval("{x:(xs)[1]}.x", context) should be(ValNumber(1))
+    eval("{x:(xs)}.x", context) should be(ValList(List(ValNumber(1), ValNumber(2), ValNumber(3))))
+  }
+
   it should "contains nested filter expressions" in {
     eval("[1,2,3,4][item > 2][1]") should be(ValNumber(3))
     eval("([1,2,3,4])[item > 2][1]") should be(ValNumber(3))


### PR DESCRIPTION
## Description

* fix parsing failure if a context literal contains parentheses
* the [cut](https://com-lihaoyi.github.io/fastparse/#Cuts) in the filter expression prevented the parser from backtracking

## Related issues

closes #278
