### PR TITLE
Allow chaining of multiple filter expressions

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -114,10 +114,16 @@ object FeelParser {
     P(textualExpression.rep(1, sep = ",").map(s => ConstList(s.toList)))
 
   private def textualExpression[_: P]: P[Exp] =
-    P(expressionInParentheses | functionDefinition | forExpression | ifExpression | quantifiedExpression | expression2)
+    P(expressionWithContinuation | functionDefinition | forExpression | ifExpression | quantifiedExpression | expression2)
 
-  private def expressionInParentheses[_: P]: P[Exp] =
-    P("(" ~ expression ~ ")").flatMap(continuation)
+  private def expressionWithContinuation[_: P]: P[Exp] =
+    P(
+      "(" ~ expression ~ ")" |
+        variableExpression |
+        list |
+        context |
+        functionInvocation
+    ).flatMap(continuation)
 
   // optimize parsing the expression from left to right by using `flapMap()`
   // `flatMap()` takes the parsed (left) part of the expression and continues with the (right) part
@@ -138,6 +144,11 @@ object FeelParser {
     P(("." ~ name).rep(1))
       .map(ops => ops.foldLeft(base)(PathExpression))
 
+  // an (escaped) identifier but not the name of a function invocation or path expression
+  private def variableExpression[_: P]: P[Exp] =
+    P((identifier.! | escapedIdentifier) ~ !"(").map(n => Ref(List(n)))
+
+  // 2b)
   private def expression2[_: P]: P[Exp] = P(disjunction)
 
   private def expression3[_: P]: P[Exp] = P(conjunction)

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -96,6 +96,40 @@ class InterpreterListExpressionTest
     eval("[1,2,3,4][i]", Map("i" -> -2)) should be(ValNumber(3))
   }
 
+  it should "be filtered multiple times (from literal)" in {
+    eval("[[1]][1][1]") should be(ValNumber(1))
+    eval("[[[1]]][1][1][1]") should be(ValNumber(1))
+    eval("[[[[1]]]][1][1][1][1]") should be(ValNumber(1))
+  }
+
+  it should "be filtered multiple times (from variable)" in {
+    val listOfLists = List(List(1))
+
+    eval("xs[1][1]", Map("xs"->listOfLists)) should be(ValNumber(1))
+    eval("xs[1][1][1]", Map("xs"->List(listOfLists))) should be(ValNumber(1))
+    eval("xs[1][1][1][1]", Map("xs"->List(List(listOfLists)))) should be(ValNumber(1))
+  }
+
+  it should "be filtered multiple times (from function invocation)" in {
+    eval("append([], [1])[1][1]") should be(ValNumber(1))
+    eval("append([], [[1]])[1][1][1]") should be(ValNumber(1))
+    eval("append([], [[[1]]])[1][1][1][1]") should be(ValNumber(1))
+  }
+
+  it should "be filtered multiple times (from path)" in {
+    val listOfLists = List(List(1))
+
+    eval("x.y[1][1]", Map("x"->Map("y" -> listOfLists))) should be(ValNumber(1))
+    eval("x.y[1][1][1]", Map("x"->Map("y" -> List(listOfLists)))) should be(ValNumber(1))
+    eval("x.y[1][1][1][1]", Map("x"->Map("y" -> List(List(listOfLists))))) should be(ValNumber(1))
+  }
+
+  it should "be filtered multiple times (from context projection)" in {
+    eval("{x:[[1]]}.x[1][1]") should be(ValNumber(1))
+    eval("{x:[[[1]]]}.x[1][1][1]") should be(ValNumber(1))
+    eval("{x:[[[[1]]]]}.x[1][1][1][1]") should be(ValNumber(1))
+  }
+
   it should "fail if one element fails" in {
 
     eval("[1, {}.x]") should be(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -105,9 +105,10 @@ class InterpreterListExpressionTest
   it should "be filtered multiple times (from variable)" in {
     val listOfLists = List(List(1))
 
-    eval("xs[1][1]", Map("xs"->listOfLists)) should be(ValNumber(1))
-    eval("xs[1][1][1]", Map("xs"->List(listOfLists))) should be(ValNumber(1))
-    eval("xs[1][1][1][1]", Map("xs"->List(List(listOfLists)))) should be(ValNumber(1))
+    eval("xs[1][1]", Map("xs" -> listOfLists)) should be(ValNumber(1))
+    eval("xs[1][1][1]", Map("xs" -> List(listOfLists))) should be(ValNumber(1))
+    eval("xs[1][1][1][1]", Map("xs" -> List(List(listOfLists)))) should be(
+      ValNumber(1))
   }
 
   it should "be filtered multiple times (from function invocation)" in {
@@ -119,9 +120,12 @@ class InterpreterListExpressionTest
   it should "be filtered multiple times (from path)" in {
     val listOfLists = List(List(1))
 
-    eval("x.y[1][1]", Map("x"->Map("y" -> listOfLists))) should be(ValNumber(1))
-    eval("x.y[1][1][1]", Map("x"->Map("y" -> List(listOfLists)))) should be(ValNumber(1))
-    eval("x.y[1][1][1][1]", Map("x"->Map("y" -> List(List(listOfLists))))) should be(ValNumber(1))
+    eval("x.y[1][1]", Map("x" -> Map("y" -> listOfLists))) should be(
+      ValNumber(1))
+    eval("x.y[1][1][1]", Map("x" -> Map("y" -> List(listOfLists)))) should be(
+      ValNumber(1))
+    eval("x.y[1][1][1][1]", Map("x" -> Map("y" -> List(List(listOfLists))))) should be(
+      ValNumber(1))
   }
 
   it should "be filtered multiple times (from context projection)" in {


### PR DESCRIPTION
## Description

* fix parsing failure if a filter expression is chained more than two times (e.g. `x[1][2][3]`)
* extend the previous parser approach of continuations by all expressions that can have a continuation 

## Related issues

closes #279 
