### PR TITLE
Allow unary-tests expressions with some/every

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -17,7 +17,6 @@
 package org.camunda.feel.impl.parser
 
 import fastparse.JavaWhitespace._
-import fastparse.Parsed.Success
 import fastparse._
 import org.camunda.feel._
 import org.camunda.feel.syntaxtree._
@@ -47,16 +46,18 @@ object FeelParser {
   private def reservedWord[_: P] =
     P(
       StringIn("null",
-               "true",
-               "false",
-               "function",
-               "if",
-               "then",
-               "else",
-               "for",
-               "between",
-               "instance",
-               "of"))
+        "true",
+        "false",
+        "function",
+        "if",
+        "then",
+        "else",
+        "for",
+        "between",
+        "instance",
+        "of",
+        "some",
+        "every"))
 
   // list of built-in function names with whitespaces
   // -- other names match the 'function name' pattern

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -428,6 +428,16 @@ class InterpreterUnaryTest
     evalUnaryTests(List(1, 2), "[1,2,3]") should be(ValBoolean(false))
   }
 
+  it should "be checked in an every expression" in {
+    evalUnaryTests(List(1, 2, 3), "every x in ? satisfies x > 3") should be(ValBoolean(false))
+    evalUnaryTests(List(4, 5, 6), "every x in ? satisfies x > 3") should be(ValBoolean(true))
+  }
+
+  it should "be checked in a some expression" in {
+    evalUnaryTests(List(1, 2, 3), "some x in ? satisfies x > 4") should be(ValBoolean(false))
+    evalUnaryTests(List(4, 5, 6), "some x in ? satisfies x > 4") should be(ValBoolean(true))
+  }
+
   "A context" should "be equal to another context" in {
 
     evalUnaryTests(Map.empty, "{}") should be(ValBoolean(true))


### PR DESCRIPTION
## Description

* fix parser failure that prevented the usage of some/every in a unary-tests expression
* extend the reserved words by `some` and `every` to prevent that a variable can be named as it

## Related issues

closes #280 
