### PR TITLE
Allow unary-tests without braces

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -234,10 +234,13 @@ object FeelParser {
   }
 
   private def unaryTests[_: P]: P[Exp] = P(
-    ("not" ~ "(" ~ positiveUnaryTests ~ ")").map(Not) |
-      positiveUnaryTests |
-      P("-").map(_ => ConstBool(true))
+    acceptAnyInputValue |
+      ("not" ~ "(" ~ positiveUnaryTests ~ ")").map(Not) |
+      positiveUnaryTests
   )
+
+  private def acceptAnyInputValue[_: P]() =
+    P("-" ~ End).map(_ => ConstBool(true))
 
   private def positiveUnaryTests[_: P]: P[Exp] =
     P(positiveUnaryTest.rep(1, ",").map {
@@ -250,12 +253,12 @@ object FeelParser {
   private def positiveUnaryTest[_: P]: P[Exp] =
     P(
       P("null").map(_ => InputEqualTo(ConstNull)) |
-        simplePositiveUnaryTest |
+        simplePositiveUnaryTest ~ End |
         expression.map(UnaryTestExpression)
     )
 
   private def simpleUnaryTests[_: P]: P[Exp] = P[Exp](
-    P("-").map(_ => ConstBool(true)) |
+    acceptAnyInputValue |
       ("not" ~ "(" ~ simplePositiveUnaryTests ~ ")").map(Not) |
       simplePositiveUnaryTests
   )

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -162,6 +162,18 @@ class InterpreterUnaryTest
     evalUnaryTests(null, "false") should be(ValBoolean(false))
   }
 
+  it should "compare to a boolean comparison (numeric)" in {
+
+    evalUnaryTests(true, "1 < 2") should be(ValBoolean(true))
+    evalUnaryTests(true, "2 < 1") should be(ValBoolean(false))
+  }
+
+  it should "compare to a boolean comparison (string)" in {
+
+    evalUnaryTests(true, """ "a" = "a" """) should be(ValBoolean(true))
+    evalUnaryTests(true, """ "a" = "b" """) should be(ValBoolean(false))
+  }
+
   "A date" should "compare with '<'" in {
 
     evalUnaryTests(date("2015-09-17"), """< date("2015-09-18")""") should be(


### PR DESCRIPTION
## Description

* fix a limitation of the parser to write unary-tests expressions with a boolean comparison but without braces
* the problem was caused by the backtracking since the first literal was parsed by `simpleValue`
* help the backtracking by defining that `simplePositiveUnaryTest` is not followed by something else except another `simplePositiveUnaryTest`

## Related issues

closes #109 
