### PR TITLE
A context key can be a name or a string

### DIFF
--- a/docs/docs/reference/language-guide/feel-context-expressions.md
+++ b/docs/docs/reference/language-guide/feel-context-expressions.md
@@ -5,13 +5,19 @@ title: Context Expressions
 
 ### Literal
 
-Creates a new context with the given entries. Each entry has a key and a value. The value can be any
-type.
+Creates a new context with the given entries. Each entry has a key and a value. The key is either a
+name or a string. The value can be any type.
 
 ```js
 {
   a: 1,
   b: 2
+}
+// {a:1, b:2}
+
+{
+  "a": 1,
+  "b": 2
 }
 // {a:1, b:2}
 ```

--- a/docs/docs/reference/language-guide/feel-data-types.md
+++ b/docs/docs/reference/language-guide/feel-data-types.md
@@ -139,15 +139,18 @@ A list of elements. The elements can be of any type. The list can be empty.
 
 ### Context
 
-A list of entries. Each entry has a key and a value. The value can be any type. The context can be
-empty.
+A list of entries. Each entry has a key and a value. The key is either a name or a string. The value
+can be any type. The context can be empty.
 
 * Java Type: `java.util.Map`
 
 ```js
 {}
+
+{a:1}
+{b: 2, c: "valid"}
+{nested: {d: 3}}
+
 {"a": 1}
 {"b": 2, "c": "valid"}
-
-{"nested": {"d": 3}}
 ```

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
@@ -50,7 +50,7 @@ class InterpreterLiteralExpressionTest
     eval("null") should be(ValNull)
   }
 
-  it should "be a context" in {
+  it should "be a context (identifier as key)" in {
 
     eval("{ a : 1 }")
       .asInstanceOf[ValContext]
@@ -78,6 +78,15 @@ class InterpreterLiteralExpressionTest
       .context
       .variableProvider
       .getVariables should be(Map("b" -> ValNumber(1)))
+  }
+
+  it should "be a context (string as key)" in {
+    val result = eval(""" {"a":1} """)
+
+    result shouldBe a [ValContext]
+    result match {
+      case ValContext(context) => context.variableProvider.getVariables should be(Map("a" -> ValNumber(1)))
+    }
   }
 
   it should "be a list" in {


### PR DESCRIPTION
## Description

* update the docs and mention that a context key is either a name or a string
* add a test case for context with string key

## Related issues

closes #296 
