### PR TITLE
bug(builtin-function): add 'm' parameter support to get entries

### DIFF
--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
@@ -22,11 +22,11 @@ get value({foo: 123}, "foo")
 Returns the entries of the context as list of key-value-pairs.
 
 * parameters:
-  * `context`: context
+  * `m`: context
 * result: list of context which contains two entries for "key" and "value"
 
 ```js
-get entries({foo: 123})
+get entries(m:{foo: 123})
 // [{key: "foo", value: 123}]
 ```
 

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -8,15 +8,16 @@ import org.camunda.feel.syntaxtree._
 object ContextBuiltinFunctions {
 
   def functions = Map(
-    "get entries" -> List(getEntriesFunction),
+    "get entries" -> List(getEntriesFunction("context"),
+                          getEntriesFunction("m")),
     "get value" -> List(getValueFunction),
     "put" -> List(putFunction),
     "put all" -> List(putAllFunction),
     "context" -> List(contextFunction)
   )
 
-  private def getEntriesFunction = builtinFunction(
-    params = List("context"),
+  private def getEntriesFunction(paramName: String) = builtinFunction(
+    params = List(paramName),
     invoke = {
       case List(ValContext(c: Context)) =>
         c.variableProvider.getVariables.map {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -254,8 +254,6 @@ class BuiltinContextFunctionsTest
       ValBoolean(true))
     eval(""" context(get entries({a:1,b:2})) = {a:1, b:2} """) should be(
       ValBoolean(true))
-    eval(""" context(get entries(m:{a:1,b:2})) = {a:1, b:2} """) should be(
-      ValBoolean(true))
     eval(""" context(get entries({a:1,b:2})[key="a"]) = {a:1} """) should be(
       ValBoolean(true))
   }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -51,17 +51,12 @@ class BuiltinContextFunctionsTest
   "A get entries function" should "return all entries when invoked with 'm' argument" in {
 
     val list = eval(""" get entries(m:{foo: 123}) """)
-    list shouldBe a[ValList]
-
-    val items = list.asInstanceOf[ValList].items
-    items should have size 1
-    val context = items(0)
-    context
-      .asInstanceOf[ValContext]
-      .context
-      .variableProvider
-      .getVariables should be(
-      Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
+    list match {
+      case ValList(List(ValContext(context))) =>
+        context.variableProvider.getVariables should be(
+          Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
+      case other => fail(s"Expected list with one context but found '$other'")
+    }
   }
 
   it should "return empty list if empty" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -48,7 +48,7 @@ class BuiltinContextFunctionsTest
       Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
   }
 
-  "A get entries function" should "return all entries when invoked with 'm' argument" in {
+  it should "return all entries when invoked with 'm' argument" in {
 
     val list = eval(""" get entries(m:{foo: 123}) """)
     list match {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -48,6 +48,22 @@ class BuiltinContextFunctionsTest
       Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
   }
 
+  "A get entries function" should "return all entries when invoked with 'm' argument" in {
+
+    val list = eval(""" get entries(m:{foo: 123}) """)
+    list shouldBe a[ValList]
+
+    val items = list.asInstanceOf[ValList].items
+    items should have size 1
+    val context = items(0)
+    context
+      .asInstanceOf[ValContext]
+      .context
+      .variableProvider
+      .getVariables should be(
+      Map("key" -> ValString("foo"), "value" -> ValNumber(123)))
+  }
+
   it should "return empty list if empty" in {
 
     eval(""" get entries({}) """) should be(ValList(List()))
@@ -242,6 +258,8 @@ class BuiltinContextFunctionsTest
     eval(""" context(get entries({a:1})) = {a:1} """) should be(
       ValBoolean(true))
     eval(""" context(get entries({a:1,b:2})) = {a:1, b:2} """) should be(
+      ValBoolean(true))
+    eval(""" context(get entries(m:{a:1,b:2})) = {a:1, b:2} """) should be(
       ValBoolean(true))
     eval(""" context(get entries({a:1,b:2})[key="a"]) = {a:1} """) should be(
       ValBoolean(true))


### PR DESCRIPTION
## Description


* Adds the support to `m` argument  name to `get entries` builtin function. 

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #320
