### PR TITLE
bug(builtin-function): add 'm' and 'key' parameters support to get value

### DIFF
--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
@@ -8,12 +8,12 @@ title: Context Functions
 Returns the value of the context entry with the given key.
 
 * parameters:
-  * `context`: context
+  * `m`: context
   * `key`: string
 * result: any
 
 ```js
-get value({foo: 123}, "foo") 
+get value(m:{foo: 123}, key:"foo") 
 // 123
 ```
 

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -9,7 +9,8 @@ object ContextBuiltinFunctions {
 
   def functions = Map(
     "get entries" -> List(getEntriesFunction),
-    "get value" -> List(getValueFunction),
+    "get value" -> List(getValueFunction(List("m", "key")),
+                        getValueFunction(List("context", "key"))),
     "put" -> List(putFunction),
     "put all" -> List(putAllFunction),
     "context" -> List(contextFunction)
@@ -26,8 +27,8 @@ object ContextBuiltinFunctions {
     }
   )
 
-  private def getValueFunction = builtinFunction(
-    params = List("context", "key"),
+  private def getValueFunction(parameters: List[String]) = builtinFunction(
+    params = parameters,
     invoke = {
       case List(ValContext(c), ValString(key)) =>
         c.variableProvider

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -57,7 +57,7 @@ class BuiltinContextFunctionsTest
     eval(""" get value({foo: 123}, "foo") """) should be(ValNumber(123))
   }
 
-  "A get value function" should "return the value when arguments are named 'm' and 'key'" in {
+  it should "return the value when arguments are named 'm' and 'key'" in {
     eval(""" get value(m:{foo: 123}, key:"foo") """) should be(ValNumber(123))
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -54,13 +54,16 @@ class BuiltinContextFunctionsTest
   }
 
   "A get value function" should "return the value" in {
-
     eval(""" get value({foo: 123}, "foo") """) should be(ValNumber(123))
   }
 
-  it should "return null if not contains" in {
+  "A get value function" should "return the value when arguments are named 'm' and 'key'" in {
+    eval(""" get value(m:{foo: 123}, key:"foo") """) should be(ValNumber(123))
+  }
 
+  it should "return null if not contains" in {
     eval(""" get value({}, "foo") """) should be(ValNull)
+    eval(""" get value(m:{}, key:"foo") """) should be(ValNull)
   }
 
   "A put function" should "add an entry to an empty context" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -61,6 +61,11 @@ class BuiltinContextFunctionsTest
     eval(""" get value(m:{foo: 123}, key:"foo") """) should be(ValNumber(123))
   }
 
+  it should "return the value when arguments are named 'context' and 'key'" in {
+    eval(""" get value(context:{foo: 123}, key:"foo") """) should be(
+      ValNumber(123))
+  }
+
   it should "return null if not contains" in {
     eval(""" get value({}, "foo") """) should be(ValNull)
     eval(""" get value(m:{}, key:"foo") """) should be(ValNull)


### PR DESCRIPTION
## Description

* Adds `m` and `key` parameters support to `get value`

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #313
