### PR TITLE
feat(builtin-function): add string 'joining' function

### DIFF
--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-list.md
@@ -318,3 +318,23 @@ flatten([[1,2],[[3]], 4])
 sort(list: [3,1,4,5,2], precedes: function(x,y) x < y) 
 // [1,2,3,4,5]
 ```
+
+## joining()
+
+* parameters:
+  * `list`: the list of strings to join
+  * `delimiter`: (optional) the string that is used between each element (default: "" empty string)
+  * `prefix`: (optional) the string that is used at the beginning of the joined result (default: "" empty string)
+  * `suffix`: (optional) the string that is used at the end of the joined result (default: "" empty string)
+* result: the joined list as a string
+
+```js
+joining(["a","b","c"])
+// "abc"
+
+joining(["a","b","c"], ", ")
+// "a, b, c"
+
+joining(["a","b","c"], ", ", "[", "]")
+// "[a, b, c]"
+```

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -16,11 +16,10 @@
  */
 package org.camunda.feel.impl.builtin
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.math.BigDecimal.int2bigDecimal
 
@@ -306,6 +305,20 @@ class BuiltinListFunctionsTest
 
     eval(" product([2,3,4]) ") should be(ValNumber(24))
     eval(" product(2,3,4) ") should be(ValNumber(24))
+  }
+
+  "A joining function" should "return an empty string if the input list is empty" in {
+    eval(" joining([]) ") should be(ValString(""))
+  }
+
+  it should "return joined strings " in {
+    eval(""" joining(["foo","bar","baz"]) """) should be(ValString("foobarbaz"))
+    eval(""" joining(["foo","bar","baz"], "::") """) should be(
+      ValString("foo::bar::baz"))
+    eval(""" joining(["foo","bar","baz"], "::", "hello-")  """) should be(
+      ValString("hello-foo::bar::baz"))
+    eval(""" joining(["foo","bar","baz"], "::", "hello-", "-goodbye")  """) should be(
+      ValString("hello-foo::bar::baz-goodbye"))
   }
 
 }


### PR DESCRIPTION
## Description


* implements a built in list function for joining list of strings.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #327

## Side notes

Please note the introduction of the following [function](https://github.com/camunda/feel-scala/compare/master...P3trur0:issue-327?expand=1#diff-167a34e327bc3b021ce1a8bdac9ffba233d67a685279f389700145c4d41135a2R433). It is based on the behavior of `withListOfNumbers`, but it tries to be more generic.
