### PR TITLE
refactor(interpeter): removal of deprecated Either right calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_2.13</artifactId>
-        <version>3.0.8</version>
+        <version>3.2.10</version>
       </dependency>
 
       <dependency>

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -226,7 +226,7 @@ class FeelInterpreter {
                               resultMapping: List[R] => Val): Val = {
 
     foldEither[T, List[R]](List(), it, {
-      case (xs, x) => f(x).right.map(xs :+ _)
+      case (xs, x) => f(x).map(xs :+ _)
     }, resultMapping)
   }
 
@@ -236,7 +236,7 @@ class FeelInterpreter {
                                resultMapping: R => Val): Val = {
 
     val result = it.foldLeft[Either[ValError, R]](Right(start)) { (result, x) =>
-      result.right.flatMap(xs => op(xs, x))
+      result.flatMap(xs => op(xs, x))
     }
 
     result match {

--- a/src/test/scala/org/camunda/feel/api/ExternalFunctionsConfigurationTest.scala
+++ b/src/test/scala/org/camunda/feel/api/ExternalFunctionsConfigurationTest.scala
@@ -19,9 +19,10 @@ package org.camunda.feel.api
 import org.camunda.feel.FeelEngine
 import org.camunda.feel.FeelEngine.{Configuration, Failure}
 import org.camunda.feel.syntaxtree.ParsedExpression
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExternalFunctionsConfigurationTest extends FlatSpec with Matchers {
+class ExternalFunctionsConfigurationTest extends AnyFlatSpec with Matchers {
 
   val defaultEngine = new FeelEngine()
 

--- a/src/test/scala/org/camunda/feel/api/FeelEngineTest.scala
+++ b/src/test/scala/org/camunda/feel/api/FeelEngineTest.scala
@@ -18,14 +18,15 @@ package org.camunda.feel.api
 
 import org.camunda.feel.FeelEngine
 import org.camunda.feel.FeelEngine.{Failure, UnaryTests}
-import org.camunda.feel.impl.parser.FeelParser
 import org.camunda.feel.syntaxtree.ParsedExpression
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{EitherValues}
 
 /**
   * @author Philipp Ossler
   */
-class FeelEngineTest extends FlatSpec with Matchers with EitherValues {
+class FeelEngineTest extends AnyFlatSpec with Matchers with EitherValues {
 
   val engine = new FeelEngine
 
@@ -94,7 +95,7 @@ class FeelEngineTest extends FlatSpec with Matchers with EitherValues {
     val expr = engine.parseExpression("x + 1")
 
     expr shouldBe a[Right[_, ParsedExpression]]
-    engine.eval(expr.right.get, Map("x" -> 3)) should be(Right(4))
+    engine.eval(expr.value, Map("x" -> 3)) should be(Right(4))
   }
 
   it should "fail to parse an expression 'x+'" in {
@@ -106,7 +107,7 @@ class FeelEngineTest extends FlatSpec with Matchers with EitherValues {
     val expr = engine.parseUnaryTests("< 3")
 
     expr shouldBe a[Right[_, ParsedExpression]]
-    engine.eval(expr.right.get, Map(UnaryTests.defaultInputVariable -> 2)) should be(
+    engine.eval(expr.value, Map(UnaryTests.defaultInputVariable -> 2)) should be(
       Right(true))
   }
 

--- a/src/test/scala/org/camunda/feel/api/context/CustomContextTest.scala
+++ b/src/test/scala/org/camunda/feel/api/context/CustomContextTest.scala
@@ -25,9 +25,10 @@ import org.camunda.feel.context.{
 }
 import org.camunda.feel.context.VariableProvider.StaticVariableProvider
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CustomContextTest extends FlatSpec with Matchers {
+class CustomContextTest extends AnyFlatSpec with Matchers {
 
   val engine = new FeelEngine
 

--- a/src/test/scala/org/camunda/feel/api/context/CustomFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/api/context/CustomFunctionTest.scala
@@ -19,9 +19,10 @@ package org.camunda.feel.api.context
 import org.camunda.feel.FeelEngine
 import org.camunda.feel.context.{CustomFunctionProvider, FunctionProvider}
 import org.camunda.feel.syntaxtree.{ValFunction, ValNumber}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CustomFunctionTest extends FlatSpec with Matchers {
+class CustomFunctionTest extends AnyFlatSpec with Matchers {
 
   val functionProviderFoo = new TestFunctionProvider(
     functions = Map(

--- a/src/test/scala/org/camunda/feel/api/context/JavaCustomFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/api/context/JavaCustomFunctionTest.scala
@@ -18,9 +18,10 @@ package org.camunda.feel.api.context
 
 import org.camunda.feel.context.Context.EmptyContext
 import org.camunda.feel.context.SimpleTestJavaFunctionProvider
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class JavaCustomFunctionTest extends FlatSpec with Matchers {
+class JavaCustomFunctionTest extends AnyFlatSpec with Matchers {
 
   val engine =
     new org.camunda.feel.FeelEngine(new SimpleTestJavaFunctionProvider())

--- a/src/test/scala/org/camunda/feel/api/valuemapper/BuiltinValueMapperInputTest.scala
+++ b/src/test/scala/org/camunda/feel/api/valuemapper/BuiltinValueMapperInputTest.scala
@@ -24,9 +24,10 @@ import org.camunda.feel.context.Context
 import org.camunda.feel.impl.JavaValueMapper
 import org.camunda.feel.valuemapper.{SimpleBooleanTestPojo, SimpleTestPojo}
 import org.camunda.feel.valuemapper.ValueMapper.CompositeValueMapper
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class BuiltinValueMapperInputTest extends FlatSpec with Matchers {
+class BuiltinValueMapperInputTest extends AnyFlatSpec with Matchers {
 
   val engine =
     new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))

--- a/src/test/scala/org/camunda/feel/api/valuemapper/BultinValueMapperOutputTest.scala
+++ b/src/test/scala/org/camunda/feel/api/valuemapper/BultinValueMapperOutputTest.scala
@@ -20,9 +20,10 @@ import org.camunda.feel.FeelEngine
 import org.camunda.feel.context.Context
 import org.camunda.feel.impl.JavaValueMapper
 import org.camunda.feel.valuemapper.ValueMapper.CompositeValueMapper
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class BultinValueMapperOutputTest extends FlatSpec with Matchers {
+class BultinValueMapperOutputTest extends AnyFlatSpec with Matchers {
 
   val engine =
     new FeelEngine(null, CompositeValueMapper(List(new JavaValueMapper())))

--- a/src/test/scala/org/camunda/feel/api/valuemapper/CustomValueMapperTest.scala
+++ b/src/test/scala/org/camunda/feel/api/valuemapper/CustomValueMapperTest.scala
@@ -21,9 +21,10 @@ import org.camunda.feel.context.{Context, CustomContext, VariableProvider}
 import org.camunda.feel.impl._
 import org.camunda.feel.syntaxtree._
 import org.camunda.feel.valuemapper.{CustomValueMapper, ValueMapper}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CustomValueMapperTest extends FlatSpec with Matchers {
+class CustomValueMapperTest extends AnyFlatSpec with Matchers {
 
   trait Enum {
     def items: Seq[Enumerated]

--- a/src/test/scala/org/camunda/feel/examples/SpecExampleTest.scala
+++ b/src/test/scala/org/camunda/feel/examples/SpecExampleTest.scala
@@ -18,9 +18,13 @@ package org.camunda.feel.examples
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SpecExampleTest extends FlatSpec with Matchers with FeelIntegrationTest {
+class SpecExampleTest
+    extends AnyFlatSpec
+    with Matchers
+    with FeelIntegrationTest {
 
   val context: Val = eval(
     """

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -18,8 +18,8 @@ package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.context.Context.StaticContext
 import org.camunda.feel.impl.FeelIntegrationTest
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import org.camunda.feel.syntaxtree._
 
 import scala.math.BigDecimal.int2bigDecimal
@@ -28,7 +28,7 @@ import scala.math.BigDecimal.int2bigDecimal
   * @author Philipp
   */
 class BuiltinContextFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.impl.builtin
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import org.camunda.feel.syntaxtree._
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
@@ -29,7 +29,7 @@ import scala.math.BigDecimal.int2bigDecimal
   * @author Philipp
   */
 class BuiltinConversionFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp
   */
 class BuiltinFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.impl.builtin
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
@@ -28,7 +28,7 @@ import scala.math.BigDecimal.int2bigDecimal
   * @author Philipp
   */
 class BuiltinListFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinNumberFunctionTest.scala
@@ -18,7 +18,8 @@ package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.math.BigDecimal.{double2bigDecimal, int2bigDecimal}
 
@@ -26,7 +27,7 @@ import scala.math.BigDecimal.{double2bigDecimal, int2bigDecimal}
   * @author Philipp
   */
 class BuiltinNumberFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -17,8 +17,8 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.FeelIntegrationTest
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import org.camunda.feel.syntaxtree._
 
 import scala.math.BigDecimal.int2bigDecimal
@@ -27,7 +27,7 @@ import scala.math.BigDecimal.int2bigDecimal
   * @author Philipp
   */
 class BuiltinStringFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinTemporalFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinTemporalFunctionsTest.scala
@@ -20,10 +20,12 @@ import java.time.{LocalDate, LocalTime, ZoneId, ZonedDateTime}
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree.{ValDate, ValDateTime, ValNumber, ValString}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 class BuiltinTemporalFunctionsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest
     with BeforeAndAfter {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -19,13 +19,14 @@ package org.camunda.feel.impl.interpreter
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class DateTimeDurationPropertiesTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterBeanExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBooleanExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBooleanExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterBooleanExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterContextExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterDateTimeExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterDateTimeExpressionTest.scala
@@ -19,13 +19,14 @@ package org.camunda.feel.impl.interpreter
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterDateTimeExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -19,13 +19,14 @@ package org.camunda.feel.impl.interpreter
 import org.camunda.feel.FeelEngine.UnaryTests
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterFunctionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterListExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterLiteralExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 
@@ -83,9 +84,11 @@ class InterpreterLiteralExpressionTest
   it should "be a context (string as key)" in {
     val result = eval(""" {"a":1} """)
 
-    result shouldBe a [ValContext]
+    result shouldBe a[ValContext]
     result match {
-      case ValContext(context) => context.variableProvider.getVariables should be(Map("a" -> ValNumber(1)))
+      case ValContext(context) =>
+        context.variableProvider.getVariables should be(
+          Map("a" -> ValNumber(1)))
     }
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterNumberExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterNumberExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterNumberExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterStringExpressionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -18,13 +18,14 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.impl.FeelIntegrationTest
 import org.camunda.feel.syntaxtree._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
 class InterpreterUnaryTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 
@@ -441,13 +442,17 @@ class InterpreterUnaryTest
   }
 
   it should "be checked in an every expression" in {
-    evalUnaryTests(List(1, 2, 3), "every x in ? satisfies x > 3") should be(ValBoolean(false))
-    evalUnaryTests(List(4, 5, 6), "every x in ? satisfies x > 3") should be(ValBoolean(true))
+    evalUnaryTests(List(1, 2, 3), "every x in ? satisfies x > 3") should be(
+      ValBoolean(false))
+    evalUnaryTests(List(4, 5, 6), "every x in ? satisfies x > 3") should be(
+      ValBoolean(true))
   }
 
   it should "be checked in a some expression" in {
-    evalUnaryTests(List(1, 2, 3), "some x in ? satisfies x > 4") should be(ValBoolean(false))
-    evalUnaryTests(List(4, 5, 6), "some x in ? satisfies x > 4") should be(ValBoolean(true))
+    evalUnaryTests(List(1, 2, 3), "some x in ? satisfies x > 4") should be(
+      ValBoolean(false))
+    evalUnaryTests(List(4, 5, 6), "some x in ? satisfies x > 4") should be(
+      ValBoolean(true))
   }
 
   "A context" should "be equal to another context" in {

--- a/src/test/scala/org/camunda/feel/impl/script/ScriptEngineFactoryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/script/ScriptEngineFactoryTest.scala
@@ -16,13 +16,13 @@
  */
 package org.camunda.feel.impl.script
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   */
-class ScriptEngineFactoryTest extends FlatSpec with Matchers {
+class ScriptEngineFactoryTest extends AnyFlatSpec with Matchers {
 
   val scriptEngineFactory = new FeelScriptEngineFactory
 

--- a/src/test/scala/org/camunda/feel/impl/script/ScriptEngineManagerTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/script/ScriptEngineManagerTest.scala
@@ -16,15 +16,15 @@
  */
 package org.camunda.feel.impl.script
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import javax.script.ScriptEngineManager
 import scala.collection.JavaConverters._
 
 /**
   * @author Philipp Ossler
   */
-class ScriptEngineManagerTest extends FlatSpec with Matchers {
+class ScriptEngineManagerTest extends AnyFlatSpec with Matchers {
 
   val scriptEngineManager = new ScriptEngineManager
 

--- a/src/test/scala/org/camunda/feel/impl/script/ScriptEngineTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/script/ScriptEngineTest.scala
@@ -18,18 +18,16 @@ package org.camunda.feel.impl.script
 
 import java.time.{LocalDate, LocalTime, ZoneId, ZonedDateTime}
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import javax.script.ScriptContext
 import javax.script.SimpleScriptContext
-import javax.script.Bindings
 import javax.script.ScriptException
-import org.camunda.feel.syntaxtree.ValDateTime
 
 /**
   * @author Philipp Ossler
   */
-class ScriptEngineTest extends FlatSpec with Matchers {
+class ScriptEngineTest extends AnyFlatSpec with Matchers {
 
   val scriptEngine = new FeelExpressionScriptEngine(new FeelScriptEngineFactory)
 

--- a/src/test/scala/org/camunda/feel/impl/script/UnaryTestsScriptEngineTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/script/UnaryTestsScriptEngineTest.scala
@@ -16,17 +16,16 @@
  */
 package org.camunda.feel.impl.script
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import javax.script.ScriptContext
 import javax.script.SimpleScriptContext
-import javax.script.Bindings
 import javax.script.ScriptException
 
 /**
   * @author Philipp Ossler
   */
-class UnaryTestsScriptEngineTest extends FlatSpec with Matchers {
+class UnaryTestsScriptEngineTest extends AnyFlatSpec with Matchers {
 
   val scriptEngine = new FeelUnaryTestsScriptEngine(
     new FeelUnaryTestsScriptEngineFactory)

--- a/src/test/scala/org/camunda/feel/impl/valuemapper/DefaultValueMapperTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/valuemapper/DefaultValueMapperTest.scala
@@ -23,13 +23,14 @@ import org.camunda.feel.context.Context
 import org.camunda.feel.impl._
 import org.camunda.feel.syntaxtree._
 import org.camunda.feel.valuemapper.ValueMapper
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author Philipp Ossler
   * @author Falko Menge
   */
-class DefaultValueMapperTest extends FlatSpec with Matchers {
+class DefaultValueMapperTest extends AnyFlatSpec with Matchers {
 
   implicit val valueMapper: ValueMapper =
     ValueMapper.CompositeValueMapper(List(DefaultValueMapper.instance))

--- a/src/test/scala/org/camunda/feel/impl/valuemapper/JavaValueMapperTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/valuemapper/JavaValueMapperTest.scala
@@ -20,9 +20,10 @@ import org.camunda.feel.context.Context
 import org.camunda.feel.impl.{DefaultValueMapper, JavaValueMapper}
 import org.camunda.feel.syntaxtree._
 import org.camunda.feel.valuemapper.ValueMapper
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class JavaValueMapperTest extends FlatSpec with Matchers {
+class JavaValueMapperTest extends AnyFlatSpec with Matchers {
 
   val valueMapper =
     ValueMapper.CompositeValueMapper(


### PR DESCRIPTION
## Description

- removal of unnecessary `Either.right` invocations (since this project uses Scala 2.13 it's right biased)
- update of Scalatest to latest version:
    - alignment of test classes imports to latest Scalatest package names;
    - usage of right biased Scalatest `EitherValues`

