### PR TITLE
Updating Docs and Writing Tests for Leading Zeros

### DIFF
--- a/docs/docs/reference/language-guide/feel-numeric-expressions.md
+++ b/docs/docs/reference/language-guide/feel-numeric-expressions.md
@@ -5,7 +5,7 @@ title: Numeric Expressions
 
 ### Literal
 
-Creates a new numeric value.
+Creates a new numeric value. Leading zeros are valid.
 
 ```js
 1
@@ -14,6 +14,10 @@ Creates a new numeric value.
 .5
 
 -2 
+
+01
+
+-0002
 ```
 
 ### Addition
@@ -50,3 +54,4 @@ Creates a new numeric value.
 2 ** 3   
 // 8
 ```
+

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
@@ -33,6 +33,11 @@ class InterpreterLiteralExpressionTest
     eval("2") should be(ValNumber(2))
     eval("2.4") should be(ValNumber(2.4))
     eval("-3") should be(ValNumber(-3))
+    eval("02") should be(ValNumber(2))
+    eval("02.4") should be(ValNumber(2.4))
+    eval("-03") should be(ValNumber(-3))
+    eval("0000002") should be(ValNumber(2))
+
   }
 
   it should "be a string" in {
@@ -83,9 +88,11 @@ class InterpreterLiteralExpressionTest
   it should "be a context (string as key)" in {
     val result = eval(""" {"a":1} """)
 
-    result shouldBe a [ValContext]
+    result shouldBe a[ValContext]
     result match {
-      case ValContext(context) => context.variableProvider.getVariables should be(Map("a" -> ValNumber(1)))
+      case ValContext(context) =>
+        context.variableProvider.getVariables should be(
+          Map("a" -> ValNumber(1)))
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* Numeric literals with leading zeros are supported. Updated
the docs with examples and write tests to verify that is
the case

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #301
