### PR TITLE
Avoid StackOverflowError with huge lists

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -945,16 +945,16 @@ class FeelInterpreter {
         values + (name -> v) // zip
   }
 
-  private def filterList(list: List[Val], filter: Val => Val): Val =
-    list match {
-      case Nil => ValList(List())
-      case x :: xs =>
-        withBoolean(filter(x), _ match {
-          case false => filterList(xs, filter)
-          case true =>
-            withList(filterList(xs, filter), l => ValList(x :: l.items))
-        })
-    }
+  private def filterList(list: List[Val], filter: Val => Val): Val = {
+    val conditionNotFulfilled = ValString("_")
+
+    mapEither[Val, Val](list,
+      item => withBoolean(filter(item), {
+        case true => item
+        case false => conditionNotFulfilled
+      }).toEither,
+      items => ValList(items.filterNot(_ == conditionNotFulfilled)))
+  }
 
   private def filterList(list: List[Val], index: Number): Val = {
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -180,6 +180,18 @@ class BuiltinListFunctionsTest
     eval("all(0)") should be(ValNull)
   }
 
+  it should "return true if all items are true (huge list)" in {
+    val hugeList = (1 to 10_000).map(_ => true).toList
+
+    eval("all(xs)", Map("xs" -> hugeList)) should be (ValBoolean(true))
+  }
+
+  it should "return null if items are not boolean values (huge list)" in {
+    val hugeList = (1 to 10_000).toList
+
+    eval("all(xs)", Map("xs" -> hugeList)) should be (ValNull)
+  }
+
   "A or() / any() function" should "return false if empty list" in {
 
     eval(" or([]) ") should be(ValBoolean(false))
@@ -205,6 +217,18 @@ class BuiltinListFunctionsTest
 
     eval("or(0)") should be(ValNull)
     eval("any(0)") should be(ValNull)
+  }
+
+  it should "return false if all items are false (huge list)" in {
+    val hugeList = (1 to 10_000).map(_ => false).toList
+
+    eval("any(xs)", Map("xs" -> hugeList)) should be (ValBoolean(false))
+  }
+
+  it should "return null if items are not boolean values (huge list)" in {
+    val hugeList = (1 to 10_000).toList
+
+    eval("any(xs)", Map("xs" -> hugeList)) should be (ValNull)
   }
 
   "A sublist() function" should "return list starting with _" in {
@@ -284,6 +308,16 @@ class BuiltinListFunctionsTest
 
     eval(" flatten([[1,2],[[3]], 4]) ") should be(
       ValList(List(ValNumber(1), ValNumber(2), ValNumber(3), ValNumber(4))))
+  }
+
+  it should "flatten a huge list of lists" in {
+    val hugeList = (1 to 10_000).map(List(_)).toList
+
+    eval("flatten(xs)", Map("xs" -> hugeList)) should be (
+      ValList(
+        hugeList.flatten.map(ValNumber(_))
+      )
+    )
   }
 
   "A sort() function" should "sort list of numbers" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -180,6 +180,12 @@ class BuiltinListFunctionsTest
     eval("all(0)") should be(ValNull)
   }
 
+  it should "return null if one item is not a boolean value" in {
+
+    eval("and(true, null, true)") should be(ValNull)
+    eval("all(true, null, true)") should be(ValNull)
+  }
+
   it should "return true if all items are true (huge list)" in {
     val hugeList = (1 to 10_000).map(_ => true).toList
 
@@ -217,6 +223,12 @@ class BuiltinListFunctionsTest
 
     eval("or(0)") should be(ValNull)
     eval("any(0)") should be(ValNull)
+  }
+
+  it should "return null if one item is not a boolean value" in {
+
+    eval("or(false, null, false)") should be(ValNull)
+    eval("any(false, null, false)") should be(ValNull)
   }
 
   it should "return false if all items are false (huge list)" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -243,4 +243,53 @@ class InterpreterListExpressionTest
              ValNumber(21))))
   }
 
+  private val hugeList: List[Int] = (1 to 10_000).toList
+
+  "A huge list" should "be defined as range" in {
+    eval("for x in 1..10000 return x") should be(
+      ValList(
+        hugeList.map(ValNumber(_))
+      ))
+  }
+
+  it should "be be checked with 'some'" in {
+    eval("some x in xs satisfies x >= 10000", Map("xs" -> hugeList)) should be(
+      ValBoolean(true))
+  }
+
+  it should "be be checked with 'some' (invalid condition)" in {
+    eval("some x in xs satisfies null", Map("xs" -> hugeList)) should be(
+      ValNull)
+  }
+
+  it should "be be checked with 'every'" in {
+    eval("every x in xs satisfies x > 0", Map("xs" -> hugeList)) should be(
+      ValBoolean(true))
+  }
+
+  it should "be be checked with 'every' (invalid condition)" in {
+    eval("every x in xs satisfies null", Map("xs" -> hugeList)) should be(
+      ValNull)
+  }
+
+  it should "be iterated with `for`" in {
+    eval("for x in xs return x", Map("xs" -> hugeList)) should be(
+      ValList(
+        hugeList.map(ValNumber(_))
+      ))
+  }
+
+  it should "be filtered" in {
+    eval("xs[item <= 5000]", Map("xs" -> hugeList)) should be(
+      ValList(
+        hugeList.take(5_000).map(ValNumber(_))
+      ))
+  }
+
+  it should "be accessed by index" in {
+    eval("xs[-1]", Map("xs"->hugeList)) should be (
+      ValNumber(hugeList.last)
+    )
+  }
+
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -252,22 +252,25 @@ class InterpreterListExpressionTest
       ))
   }
 
-  it should "be be checked with 'some'" in {
+  it should "be checked with 'some'" in {
     eval("some x in xs satisfies x >= 10000", Map("xs" -> hugeList)) should be(
       ValBoolean(true))
+
+    eval("some x in xs satisfies x > 10000", Map("xs" -> hugeList)) should be(
+      ValBoolean(false))
   }
 
-  it should "be be checked with 'some' (invalid condition)" in {
+  it should "be checked with 'some' (invalid condition)" in {
     eval("some x in xs satisfies null", Map("xs" -> hugeList)) should be(
       ValNull)
   }
 
-  it should "be be checked with 'every'" in {
+  it should "be checked with 'every'" in {
     eval("every x in xs satisfies x > 0", Map("xs" -> hugeList)) should be(
       ValBoolean(true))
   }
 
-  it should "be be checked with 'every' (invalid condition)" in {
+  it should "be checked with 'every' (invalid condition)" in {
     eval("every x in xs satisfies null", Map("xs" -> hugeList)) should be(
       ValNull)
   }


### PR DESCRIPTION
## Description

* avoid StackOverflowError if one of the following operations is applied to a huge list (e.g. 10.000 items)
  * `filter` 
  * `some`
  * `every`
  * `all()`
  * `any()`
  * `flatten()`

## Related issues

closes #350 
