### PR TITLE
Filter a list of contexts by entry with name "item"

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -969,7 +969,7 @@ class FeelInterpreter {
   private def filterContext(x: Val)(
       implicit context: EvalContext): EvalContext =
     x match {
-      case ValContext(ctx: Context) => context + ctx + ("item" -> x)
+      case ValContext(ctx: Context) => context + ("item" -> x) + ctx
       case v                        => context + ("item" -> v)
     }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -79,6 +79,19 @@ class InterpreterContextExpressionTest
       .getVariables should be(Map("a" -> ValNumber(3), "b" -> ValNumber(4)))
   }
 
+  it should "be filtered by name 'item'" in {
+
+    eval("[ {item:1}, {item:2}, {item:3} ][item >= 2]") match {
+      case ValList(List(ValContext(context1), ValContext(context2))) =>
+        context1.variableProvider.getVariables should be(
+          Map("item" -> ValNumber(2)))
+        context2.variableProvider.getVariables should be(
+          Map("item" -> ValNumber(3)))
+
+      case actual => fail(s"expected a list with two items but found '$actual'")
+    }
+  }
+
   it should "be accessed and filtered in a list" in {
 
     eval("[ {a:1, b:2}, {a:3, b:4} ].a[1]") should be(ValNumber(1))


### PR DESCRIPTION
## Description

* a list of contexts can be filtered by using the names of the context entries
* additionally, the current item can be accessed under the name 'item'
* avoid that a context value with name 'item' is shadowed by the current item

## Related issues

closes #154
