### PR TITLE
fix(builtin-function): joining() function renamed and aligned with join

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
@@ -319,7 +319,7 @@ sort(list: [3,1,4,5,2], precedes: function(x,y) x < y)
 // [1,2,3,4,5]
 ```
 
-## join()
+## string join()
 Joins a list of strings into a single string. It ignores `null` items in the list.
 Similar to Java's [joining](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Collectors.html#joining(java.lang.CharSequence,java.lang.CharSequence,java.lang.CharSequence)) function.
 * parameters:
@@ -329,16 +329,16 @@ Similar to Java's [joining](https://docs.oracle.com/en/java/javase/11/docs/api/j
   * `suffix`: (optional) the string that is used at the end of the joined result (default: "" empty string)
 * result: the joined list as a string
 ```js
-join(["a","b","c"])
+string join(["a","b","c"])
 // "abc"
-join(["a"], "X")
+string join(["a"], "X")
 // "a"
-join(["a","b","c"], ", ")
+string join(["a","b","c"], ", ")
 // "a, b, c"
-join(["a","b","c"], ", ", "[", "]")
+string join(["a","b","c"], ", ", "[", "]")
 // "[a, b, c]"
-join(["a",null,"c"])
+string join(["a",null,"c"])
 // "ac"
-join([])
+string join([])
 // ""
 ```

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
@@ -318,3 +318,27 @@ flatten([[1,2],[[3]], 4])
 sort(list: [3,1,4,5,2], precedes: function(x,y) x < y) 
 // [1,2,3,4,5]
 ```
+
+## join()
+Joins a list of strings into a single string. It ignores `null` items in the list.
+Similar to Java's [joining](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Collectors.html#joining(java.lang.CharSequence,java.lang.CharSequence,java.lang.CharSequence)) function.
+* parameters:
+  * `list`: the list of strings to join
+  * `delimiter`: (optional) the string that is used between each element (default: "" empty string)
+  * `prefix`: (optional) the string that is used at the beginning of the joined result (default: "" empty string)
+  * `suffix`: (optional) the string that is used at the end of the joined result (default: "" empty string)
+* result: the joined list as a string
+```js
+join(["a","b","c"])
+// "abc"
+join(["a"], "X")
+// "a"
+join(["a","b","c"], ", ")
+// "a, b, c"
+join(["a","b","c"], ", ", "[", "]")
+// "[a, b, c]"
+join(["a",null,"c"])
+// "ac"
+join([])
+// ""
+```

--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -43,9 +43,9 @@ object ListBuiltinFunctions {
     "distinct values" -> List(distinctValuesFunction),
     "flatten" -> List(flattenFunction),
     "sort" -> List(sortFunction),
-    "join" -> List(joinFunction,
-                   joinWithDelimiterFunction,
-                   joinWithDelimiterAndPrefixAndSuffixFunction)
+    "string join" -> List(joinFunction,
+                          joinWithDelimiterFunction,
+                          joinWithDelimiterAndPrefixAndSuffixFunction)
   )
 
   private def listContainsFunction =
@@ -429,12 +429,13 @@ object ListBuiltinFunctions {
   private def withListOfStrings(list: List[Val],
                                 f: List[String] => Val): Val = {
     val strings =
-      list.filterNot(elem => elem == ValNull)
-      .map(elem =>
-        elem match {
-          case n: ValString => n
-          case x            => ValError(s"expected string but found '$x'")
-      })
+      list
+        .filterNot(elem => elem == ValNull)
+        .map(elem =>
+          elem match {
+            case n: ValString => n
+            case x            => ValError(s"expected string but found '$x'")
+        })
 
     strings.find(_.isInstanceOf[ValError]) match {
       case Some(e) => e

--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -1,6 +1,7 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
+import org.camunda.feel.{Number, logger}
 import org.camunda.feel.syntaxtree.{
   Val,
   ValBoolean,
@@ -11,7 +12,6 @@ import org.camunda.feel.syntaxtree.{
   ValNumber,
   ValString
 }
-import org.camunda.feel.{Number, logger}
 
 import scala.annotation.tailrec
 
@@ -428,11 +428,11 @@ object ListBuiltinFunctions {
 
   private def withListOfStrings(list: List[Val],
                                 f: List[String] => Val): Val = {
-    val strings = list
+    val strings =
+      list.filterNot(elem => elem == ValNull)
       .map(elem =>
         elem match {
           case n: ValString => n
-          case ValNull      => ValString("")
           case x            => ValError(s"expected string but found '$x'")
       })
 

--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -1,7 +1,16 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
-import org.camunda.feel.syntaxtree._
+import org.camunda.feel.syntaxtree.{
+  Val,
+  ValBoolean,
+  ValError,
+  ValFunction,
+  ValList,
+  ValNull,
+  ValNumber,
+  ValString
+}
 import org.camunda.feel.{Number, logger}
 
 import scala.annotation.tailrec

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -355,40 +355,40 @@ class BuiltinListFunctionsTest
   }
 
   "A join function" should "return an empty string if the input list is empty" in {
-    eval(" join([]) ") should be(ValString(""))
+    eval(" string join([]) ") should be(ValString(""))
   }
 
   it should "return an empty string if the input list is empty and a delimiter is defined" in {
-    eval(""" join([], "X") """) should be(ValString(""))
+    eval(""" string join([], "X") """) should be(ValString(""))
   }
 
   it should "return joined strings" in {
-    eval(""" join(["foo","bar","baz"]) """) should be(ValString("foobarbaz"))
+    eval(""" string join(["foo","bar","baz"]) """) should be(ValString("foobarbaz"))
   }
 
   it should "return joined strings when delimiter is null" in {
-    eval(""" join(["foo","bar","baz"], null) """) should be(ValString("foobarbaz"))
+    eval(""" string join(["foo","bar","baz"], null) """) should be(ValString("foobarbaz"))
   }
 
   it should "return original string when list contains a single entry" in {
-    eval(""" join(["a"], "X") """) should be(ValString("a"))
+    eval(""" string join(["a"], "X") """) should be(ValString("a"))
   }
 
   it should "ignore null strings" in {
-    eval(""" join(["foo", null, "baz"], null) """) should be(ValString("foobaz"))
+    eval(""" string join(["foo", null, "baz"], null) """) should be(ValString("foobaz"))
   }
 
   it should "ignore null strings with delimiter" in {
-    eval(""" join(["foo", null, "baz"], "X") """) should be(ValString("fooXbaz"))
+    eval(""" string join(["foo", null, "baz"], "X") """) should be(ValString("fooXbaz"))
   }
 
   it should "return joined strings with custom separator" in {
-    eval(""" join(["foo","bar","baz"], "::") """) should be(
+    eval(""" string join(["foo","bar","baz"], "::") """) should be(
       ValString("foo::bar::baz"))
   }
 
   it should "return joined strings with custom separator, a prefix and a suffix" in {
-    eval(""" join(["foo","bar","baz"], "::", "hello-", "-goodbye")  """) should be(
+    eval(""" string join(["foo","bar","baz"], "::", "hello-", "-goodbye")  """) should be(
       ValString("hello-foo::bar::baz-goodbye"))
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -354,21 +354,37 @@ class BuiltinListFunctionsTest
     eval(" product(2,3,4) ") should be(ValNumber(24))
   }
 
-  "A joining function" should "return an empty string if the input list is empty" in {
-    eval(" joining([]) ") should be(ValString(""))
+  "A join function" should "return an empty string if the input list is empty" in {
+    eval(" join([]) ") should be(ValString(""))
+  }
+
+  it should "return an empty string if the input list is empty and a delimiter is defined" in {
+    eval(""" join([], "X") """) should be(ValString(""))
   }
 
   it should "return joined strings" in {
-    eval(""" joining(["foo","bar","baz"]) """) should be(ValString("foobarbaz"))
+    eval(""" join(["foo","bar","baz"]) """) should be(ValString("foobarbaz"))
+  }
+
+  it should "return joined strings when delimiter is null" in {
+    eval(""" join(["foo","bar","baz"], null) """) should be(ValString("foobarbaz"))
+  }
+
+  it should "return original string when list contains a single entry" in {
+    eval(""" join(["a"], "X") """) should be(ValString("a"))
+  }
+
+  it should "ignore null strings" in {
+    eval(""" join(["foo", null, "baz"], null) """) should be(ValString("foobaz"))
   }
 
   it should "return joined strings with custom separator" in {
-    eval(""" joining(["foo","bar","baz"], "::") """) should be(
+    eval(""" join(["foo","bar","baz"], "::") """) should be(
       ValString("foo::bar::baz"))
   }
 
   it should "return joined strings with custom separator, a prefix and a suffix" in {
-    eval(""" joining(["foo","bar","baz"], "::", "hello-", "-goodbye")  """) should be(
+    eval(""" join(["foo","bar","baz"], "::", "hello-", "-goodbye")  """) should be(
       ValString("hello-foo::bar::baz-goodbye"))
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -378,6 +378,10 @@ class BuiltinListFunctionsTest
     eval(""" join(["foo", null, "baz"], null) """) should be(ValString("foobaz"))
   }
 
+  it should "ignore null strings with delimiter" in {
+    eval(""" join(["foo", null, "baz"], "X") """) should be(ValString("fooXbaz"))
+  }
+
   it should "return joined strings with custom separator" in {
     eval(""" join(["foo","bar","baz"], "::") """) should be(
       ValString("foo::bar::baz"))


### PR DESCRIPTION
## Description

* joining function renamed as join
* join function behavior modified to reflect specs (e.g.: empty string and null delimiter management)
* unit tests added
* documentation updated

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #372 
