### PR TITLE
ci(github): new action to build with maven

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -1,0 +1,25 @@
+name: Build project with Maven
+on:
+  pull_request:
+  schedule:
+  - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Java setup
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Run Maven
+      run: mvn -B clean verify com.mycila:license-maven-plugin:check


### PR DESCRIPTION
## Description

* add new GitHub action to trigger the Maven build 
* the main purpose is to provide a check for community contributions because they don't trigger the regular CI

## Related issues

none