### PR TITLE
chore(interpreter): add a test for whitespaced named parameters

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -179,4 +179,8 @@ class InterpreterFunctionTest
     eval("round(3.2)", functions = functions) should be(ValNumber(3))
   }
 
+  it should "be properly evaluated when parameters containing whitespaces" in {
+    eval("""number(from: "1.000.000,01", decimal separator:",", grouping separator:".")""") should be(ValNumber(1_000_000.01))
+  }
+
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -138,6 +138,18 @@ class InterpreterFunctionTest
     eval(""" index of([1,2,3,2],2)[1]  """) should be(ValNumber(2))
   }
 
+  it should "be properly evaluated when parameters contain whitespaces" in {
+    eval("""number(from: "1.000.000,01", decimal separator:",", grouping separator:".")""") should be(ValNumber(1_000_000.01))
+  }
+
+  it should "be invoked with one named parameter containing whitespaces" in {
+    val functions =
+      Map("f" -> eval("""function(test name) `test name` + 1""").asInstanceOf[ValFunction])
+
+    eval("f(test name:1)", functions = functions) should be(ValNumber(2))
+    eval("f(test name:2)", functions = functions) should be(ValNumber(3))
+  }
+
   "An external java function definition" should "be invoked with one double parameter" in {
 
     val functions = Map(
@@ -177,10 +189,6 @@ class InterpreterFunctionTest
         .asInstanceOf[ValFunction])
 
     eval("round(3.2)", functions = functions) should be(ValNumber(3))
-  }
-
-  it should "be properly evaluated when parameters contain whitespaces" in {
-    eval("""number(from: "1.000.000,01", decimal separator:",", grouping separator:".")""") should be(ValNumber(1_000_000.01))
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -179,7 +179,7 @@ class InterpreterFunctionTest
     eval("round(3.2)", functions = functions) should be(ValNumber(3))
   }
 
-  it should "be properly evaluated when parameters containing whitespaces" in {
+  it should "be properly evaluated when parameters contain whitespaces" in {
     eval("""number(from: "1.000.000,01", decimal separator:",", grouping separator:".")""") should be(ValNumber(1_000_000.01))
   }
 


### PR DESCRIPTION
## Description

* this adds a unit test for #311.  

Please, mind that I build the test based on [this](https://github.com/camunda/tck/issues/7). There, the function used is:

`number(from: "1.000.000,01", decimal sep:",", grouping sep:".")`

while in the codebase here the expected parameters names are:

- `from`, `decimal separator`, `grouping separator`

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

This tests the behavior expected by #311.

closes #311