### PR TITLE
handle null values in max and min list functions

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -64,7 +64,7 @@ object ListBuiltinFunctions {
       case List(l @ ValList(list)) =>
         list match {
           case Nil                   => ValNull
-          case _ if (l.isComparable) => list.min
+          case _ if (l.isComparable) => list.filter { _ != ValNull}.min
           case _                     => logger.warn(s"$l is not comparable"); ValNull
         }
     },
@@ -77,7 +77,7 @@ object ListBuiltinFunctions {
       case List(l @ ValList(list)) =>
         list match {
           case Nil                   => ValNull
-          case _ if (l.isComparable) => list.max
+          case _ if (l.isComparable) => list.filter { _ != ValNull}.max
           case _                     => logger.warn(s"$l is not comparable"); ValNull
         }
     },

--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -88,11 +88,13 @@ sealed trait Val extends Ordered[Val] {
     case _: ValDateTime          => true
     case _: ValYearMonthDuration => true
     case _: ValDayTimeDuration   => true
-    case ValList(list) =>
-      list.headOption
+    case ValList(list) => {
+      val filteredList = list filter { _ != ValNull}
+      filteredList.headOption
         .map(head =>
-          head.isComparable && list.forall(_.getClass == head.getClass))
-        .getOrElse(false)
+          head.isComparable && filteredList.forall(_.getClass == head.getClass)
+        ).getOrElse(false)
+    }
     case _ => false
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -57,7 +57,8 @@ class BuiltinListFunctionsTest
   }
 
   it should "return the minimum item of numbers" in {
-
+    eval(" min([null,1,2,3]) ") should be(ValNumber(1))
+    eval(" min(null,1,2,3) ") should be(ValNumber(1))
     eval(" min([1,2,3]) ") should be(ValNumber(1))
     eval(" min(1,2,3) ") should be(ValNumber(1))
   }
@@ -80,6 +81,8 @@ class BuiltinListFunctionsTest
   }
 
   it should "return the maximum item of numbers" in {
+    eval(" max([null,1,2,3]) ") should be(ValNumber(3))
+    eval(" max(null,1,2,3) ") should be(ValNumber(3))
 
     eval(" max([1,2,3]) ") should be(ValNumber(3))
     eval(" max(1,2,3) ") should be(ValNumber(3))


### PR DESCRIPTION
## Description
 isComparable for Lists now handles ValNull as does the list functions min, max. The behaviour is such min and max will just ignore null values.

## Related issues
382

closes #382
