### PR TITLE
fix(engine): list projection with variable

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -978,17 +978,9 @@ class FeelInterpreter {
     names match {
       case Nil => x
       case n :: ns =>
-        withContext(
-          x, {
-            case ctx: ValContext =>
-              EvalContext
-                .wrap(ctx.context)(context.valueMapper)
-                .variable(n) match {
-                case e: ValError => e
-                case x: Val      => ref(x, ns)
-              }
-            case e => error(e, s"context contains no entry with key '$n'")
-          }
+        withVal(
+          path(x, n),
+          value => ref(value, ns)
         )
     }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -50,10 +50,15 @@ class InterpreterContextExpressionTest
     eval("{ a: { b:1 } }.a.b") should be(ValNumber(1))
   }
 
-  it should "be accessed in a list" in {
+  it should "be accessed in a list (literal)" in {
 
     eval("[ {a:1, b:2}, {a:3, b:4} ].a") should be(
       ValList(List(ValNumber(1), ValNumber(3))))
+  }
+
+  it should "be accessed in a list (variable)" in {
+    eval("a.b", Map("a" -> List(Map("b" -> 1), Map("b" -> 2)))) should be(
+      ValList(List(ValNumber(1), ValNumber(2))))
   }
 
   it should "be accessed in same context" in {


### PR DESCRIPTION
## Description

* fix path expression for list of contexts (i.e. list projection) with variable reference
  * reuse the existing logic of `path` expressions to avoid duplication and a difference in the behavior 
* it worked previously because it was parsed as a `path` expression instead of a `ref` expression

## Related issues

closes #384 
