### PR TITLE
fix(parser) managing arbitrary names for a context key

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -420,10 +420,7 @@ object FeelParser {
   private def context[_: P]: P[Exp] =
     P(
       "{" ~ contextEntry.rep(0, sep = ",") ~ "}"
-    ).map{
-      entries =>
-        ConstContext(entries.toList)
-    }
+    ).map(entries => ConstContext(entries.toList))
 
   private def contextEntry[_: P]: P[(String, Exp)] = P(
     (contextAnySymbol | identifierWithWhitespaces | name | stringWithQuotes) ~ ":" ~ expression

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -169,7 +169,7 @@ object FeelParser {
   // use only if the identifier is followed by a predefined character (e.g. `(` or `:`)
   private def identifierWithWhitespaces[_: P]: P[String] =
     P(
-      identifier ~~ (" " ~~ identifier).repX(1)
+      identifier ~~ (" ".repX(1) ~~ identifier).repX(1)
     ).!
 
   private def name[_: P]: P[String] = P(
@@ -420,11 +420,18 @@ object FeelParser {
   private def context[_: P]: P[Exp] =
     P(
       "{" ~ contextEntry.rep(0, sep = ",") ~ "}"
-    ).map(entries => ConstContext(entries.toList))
+    ).map{
+      entries =>
+        ConstContext(entries.toList)
+    }
 
   private def contextEntry[_: P]: P[(String, Exp)] = P(
-    (name | stringWithQuotes) ~ ":" ~ expression
+    (contextAnySymbol | identifierWithWhitespaces | name | stringWithQuotes) ~ ":" ~ expression
   )
+
+  private def contextAnySymbol[_: P]: P[String] = {
+    P((!"\"" ~ !"{" ~ !"}" ~ !":" ~ !"," ~ AnyChar ~ !"{").rep(1).!)
+  }
 
   private def variableRef[_: P]: P[Exp] =
     P(

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -423,12 +423,18 @@ object FeelParser {
     ).map(entries => ConstContext(entries.toList))
 
   private def contextEntry[_: P]: P[(String, Exp)] = P(
-    (contextAnySymbol | identifierWithWhitespaces | name | stringWithQuotes) ~ ":" ~ expression
+    (contextKeyAnySymbol | identifierWithWhitespaces | name | stringWithQuotes) ~ ":" ~ expression
   )
 
-  private def contextAnySymbol[_: P]: P[String] = {
-    P((!"\"" ~ !"{" ~ !"}" ~ !":" ~ !"," ~ AnyChar ~ !"{").rep(1).!)
-  }
+  private def contextKeyAnySymbol[_: P]: P[String] =
+    P(
+      (!reservedSymbol ~ AnyChar).rep(1)
+    ).!
+
+  private def reservedSymbol[_: P]: P[String] =
+    P(
+      CharIn("\"", "{", "}", ":", ",", "[", "]", "`")
+    ).!
 
   private def variableRef[_: P]: P[Exp] =
     P(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -172,6 +172,8 @@ class InterpreterContextExpressionTest
     eval("{foo+bar:1}.`foo+bar` = 1") should be(ValBoolean(true))
     eval("{foo+bar:1, simple_special++char:4}.`simple_special++char` = 4") should be(ValBoolean(true))
     eval("""{\uD83D\uDC0E:"\uD83D\uDE00"}.`\uD83D\uDC0E`""") should be(ValString("\uD83D\uDE00"))
+
+    eval("{ friend+of+mine:2, hello_there:{ how_are_you?:2, are_you_happy?:`friend+of+mine`+3 } }.hello_there.`are_you_happy?`") should be(ValNumber(5))
   }
 
   it should "fail when special symbols violate context syntax" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -170,16 +170,20 @@ class InterpreterContextExpressionTest
 
   it should "be accessed when defined with a name having special symbols" in {
     eval("{foo+bar:1}.`foo+bar` = 1") should be(ValBoolean(true))
-    eval("{foo+bar:1, simple_special++char:4}.`simple_special++char` = 4") should be(ValBoolean(true))
-    eval("""{\uD83D\uDC0E:"\uD83D\uDE00"}.`\uD83D\uDC0E`""") should be(ValString("\uD83D\uDE00"))
+    eval("{foo+bar:1, simple_special++char:4}.`simple_special++char` = 4") should be(
+      ValBoolean(true))
+    eval("""{\uD83D\uDC0E:"\uD83D\uDE00"}.`\uD83D\uDC0E`""") should be(
+      ValString("\uD83D\uDE00"))
 
-    eval("{ friend+of+mine:2, hello_there:{ how_are_you?:2, are_you_happy?:`friend+of+mine`+3 } }.hello_there.`are_you_happy?`") should be(ValNumber(5))
+    eval(
+      "{ friend+of+mine:2, hello_there:{ how_are_you?:2, are_you_happy?:`friend+of+mine`+3 } }.hello_there.`are_you_happy?`") should be(
+      ValNumber(5))
   }
 
   it should "fail when special symbols violate context syntax" in {
-    eval("{foo{bar:1}.`foo{bar` = 1") shouldBe a [ValError]
-    eval("{foo,bar:1}.`foo,bar` = 1") shouldBe a [ValError]
-    eval("{foo:bar:1}.`foo:bar` = 1") shouldBe a [ValError]
+    eval("{foo{bar:1}.`foo{bar` = 1") shouldBe a[ValError]
+    eval("{foo,bar:1}.`foo,bar` = 1") shouldBe a[ValError]
+    eval("{foo:bar:1}.`foo:bar` = 1") shouldBe a[ValError]
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -161,4 +161,23 @@ class InterpreterContextExpressionTest
     )
   }
 
+  it should "be accessed when defined with a name having white spaces" in {
+    eval("{foo bar:1}.`foo bar` = 1") should be(ValBoolean(true))
+    eval("{foo   bar:1}.`foo   bar` = 1") should be(ValBoolean(true))
+    eval("{foo bar:1, fizz buzz: 30}.`fizz buzz` = 1") should be(
+      ValBoolean(false))
+  }
+
+  it should "be accessed when defined with a name having special symbols" in {
+    eval("{foo+bar:1}.`foo+bar` = 1") should be(ValBoolean(true))
+    eval("{foo+bar:1, simple_special++char:4}.`simple_special++char` = 4") should be(ValBoolean(true))
+    eval("""{\uD83D\uDC0E:"\uD83D\uDE00"}.`\uD83D\uDC0E`""") should be(ValString("\uD83D\uDE00"))
+  }
+
+  it should "fail when special symbols violate context syntax" in {
+    eval("{foo{bar:1}.`foo{bar` = 1") shouldBe a [ValError]
+    eval("{foo,bar:1}.`foo,bar` = 1") shouldBe a [ValError]
+    eval("{foo:bar:1}.`foo:bar` = 1") shouldBe a [ValError]
+  }
+
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -150,6 +150,14 @@ class InterpreterFunctionTest
     eval("f(test name:2)", functions = functions) should be(ValNumber(3))
   }
 
+  it should "be invoked with one named parameter containing more than one whitespace" in {
+    val functions =
+      Map("f" -> eval("""function(test   name yada) `test   name yada` + 1""").asInstanceOf[ValFunction])
+
+    eval("f(test   name yada:1)", functions = functions) should be(ValNumber(2))
+    eval("f(test   name yada:2)", functions = functions) should be(ValNumber(3))
+  }
+
   "An external java function definition" should "be invoked with one double parameter" in {
 
     val functions = Map(


### PR DESCRIPTION
## Description

* introduces new parsing options for context key names

As you may notice, I slightly changed also the behavior of `private def identifierWithWhitespaces[_: P]: P[String]` since in previous version it supported only names with a single whitespace.

## Related issues

closes #310
