### PR TITLE
fix(engine): add `satisfies`, `return`, `then`, `else` as reserved keywords

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,5 +20,5 @@ A clear and concise description of what you expected to happen.
 **Environment**
 * FEEL engine version: [1.x.y]
 * Affects: 
-  * Camunda BPM: [7.x] <!-- link the issue: https://jira.camunda.com/browse/CAM- -->
+  * Camunda Automation Platform 7: [7.x] <!-- link the issue: https://jira.camunda.com/browse/CAM- -->
   * Zeebe broker: [0.x] <!-- link the issue: https://github.com/zeebe-io/zeebe/issues# -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,5 +15,5 @@ A clear and concise description of what you want to happen.
 
 **Related issues**
 
-* Camunda BPM: <!-- link the issue: https://jira.camunda.com/browse/CAM- -->
+* Camunda Autormation Platform 7: <!-- link the issue: https://jira.camunda.com/browse/CAM- -->
 * Zeebe broker: <!-- link the issue: https://github.com/zeebe-io/zeebe/issues# -->

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -143,7 +143,11 @@ object FeelParser {
         "true",
         "false",
         "function",
-        "in"
+        "in",
+        "return",
+        "then",
+        "else",
+        "satisfies"
       )
     ).!
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -71,6 +71,20 @@ class InterpreterExpressionTest
     eval("if 1 instance of number then 1 else 2") should be(ValNumber(1))
   }
 
+  it should "be an if-then-else (with variable and function call -> then)" in {
+    eval("if 7 > var then flatten(xs) else []",
+         Map("xs" -> List(1, 2), "var" -> 3)) should be(
+      ValList(List(ValNumber(1), ValNumber(2)))
+    )
+  }
+
+  it should "be an if-then-else (with variable and function call -> else)" in {
+    eval("if false then var else flatten(xs)",
+         Map("xs" -> List(1, 2), "var" -> 3)) should be(
+      ValList(List(ValNumber(1), ValNumber(2)))
+    )
+  }
+
   it should "be a simple positive unary test" in {
 
     eval("< 3", Map(UnaryTests.defaultInputVariable -> 2)) should be(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -38,6 +38,8 @@ class InterpreterListExpressionTest
       ValBoolean(true))
     eval("some x in xs satisfies x > 2", Map("xs" -> List(1, 2))) should be(
       ValBoolean(false))
+    eval("some x in xs satisfies count(xs) > 2", Map("xs" -> List(1, 2))) should be(
+      ValBoolean(false))
 
     eval("some x in [1,2], y in [2,3] satisfies x < y") should be(
       ValBoolean(true))
@@ -79,6 +81,10 @@ class InterpreterListExpressionTest
 
     eval("for x in xs return x * 2", Map("xs" -> List(1, 2))) should be(
       ValList(List(ValNumber(2), ValNumber(4))))
+
+    eval("for y in xs return index of([2, 3], y)",  Map("xs" -> List(1, 2))) should be(
+      ValList(List(ValList(List()), ValList(List(ValNumber(1)))))
+    )
   }
 
   it should "be processed in a for-expression (range)" in {


### PR DESCRIPTION
## Description

Add `satisfies`, `return`, `then`, `else` as reserved keywords.

## Related issues

closes #394
