### PR TITLE
Expression with conjunction/disjunction (and/or) fails if it contains parentheses

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -147,7 +147,9 @@ object FeelParser {
         "return",
         "then",
         "else",
-        "satisfies"
+        "satisfies",
+        "and",
+        "or"
       )
     ).!
 
@@ -490,7 +492,7 @@ object FeelParser {
 
   private def functionInvocation[_: P]: P[Exp] =
     P(
-      (identifierWithWhitespaces
+      ((identifierWithWhitespaces | functionNameWithReservedWord)
         .map(List(_)) | qualifiedName) ~ "(" ~ functionParameters.? ~ ")"
     ).map {
       case (name :: Nil, None) =>
@@ -506,6 +508,13 @@ object FeelParser {
                                     names.last,
                                     parameters)
     }
+
+  // List all built-in function names that contains a reserved word. These names are not allowed as
+  // regular function names.
+  private def functionNameWithReservedWord[_: P]: P[String] =
+    P(
+      "and" | "or" | "date and time" | "years and months duration"
+    ).!
 
   private def functionParameters[_: P]: P[FunctionParameters] =
     namedParameters | positionalParameters

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBooleanExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBooleanExpressionTest.scala
@@ -75,6 +75,14 @@ class InterpreterBooleanExpressionTest
       ValBoolean(true))
   }
 
+  it should "be in conjunction (with parentheses)" in {
+    eval("x and (y)", Map("x" -> true, "y" -> false)) should be(
+      ValBoolean(false))
+
+    eval("(x) and y", Map("x" -> true, "y" -> false)) should be(
+      ValBoolean(false))
+  }
+
   it should "be in disjunction" in {
 
     eval("false or true") should be(ValBoolean(true))
@@ -89,6 +97,12 @@ class InterpreterBooleanExpressionTest
     eval("2 or false") should be(ValNull)
 
     eval("2 or 4") should be(ValNull)
+  }
+
+  it should "be in disjunction (with parentheses)" in {
+    eval("x or (y)", Map("x" -> false, "y" -> true)) should be(ValBoolean(true))
+
+    eval("(x) or y", Map("x" -> false, "y" -> true)) should be(ValBoolean(true))
   }
 
   it should "be in disjunction with comparison" in {


### PR DESCRIPTION
## Description

* add the reserved keywords: "and", "or" to avoid that a conjunction/disjunction is parsed as a function name
* change the parsing behavior to avoid that a function name contains a reserved keyword like "and" / "or"
* list all built-in function names with keywords explicitly because they don't match the regular function name anymore

## Related issues

closes #397 
