### PR TITLE
Filter list with custom function

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -253,21 +253,23 @@ class FeelInterpreter {
       case Filter(list, filter) =>
         withList(
           eval(list),
-          l =>
+          l => {
+            val evalFilterWithItem =
+              (item: Val) => eval(filter)(filterContext(item))
+
             filter match {
               case ConstNumber(index) => filterList(l.items, index)
               case ArithmeticNegation(ConstNumber(index)) =>
                 filterList(l.items, -index)
-              case comparison: Comparison =>
-                filterList(l.items,
-                           item => eval(comparison)(filterContext(item)))
+              case _: Comparison | _: FunctionInvocation |
+                  _: QualifiedFunctionInvocation =>
+                filterList(l.items, evalFilterWithItem)
               case _ =>
                 eval(filter) match {
                   case ValNumber(index) => filterList(l.items, index)
-                  case _ =>
-                    filterList(l.items,
-                               item => eval(filter)(filterContext(item)))
+                  case _                => filterList(l.items, evalFilterWithItem)
                 }
+            }
           }
         )
       case IterationContext(start, end) =>


### PR DESCRIPTION
## Description

* a list can be filtered using a boolean function
* currently, the function is invoked once to determine if it is a number (for index access) or a boolean value (or something else)
* since the function is invoked without the list item, the invocation can fail if the "item" variable is passed in as a parameter
* fix the issue by avoiding the function invocation without "item" variable in the context

## Related issues

closes #359 
