### PR TITLE
Builder-style method is used instead of getter

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/ObjectContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/ObjectContext.scala
@@ -36,11 +36,13 @@ case class ObjectContext(obj: Any) extends Context {
         val methods = objClass.getMethods find (method => {
           val methodName = method.getName
           val returnType = method.getReturnType
-          methodName == name ||
+          val hasParameters = method.getParameterCount > 0
+
+          !hasParameters && (methodName == name ||
           methodName == getGetterName(name) ||
           ((returnType == java.lang.Boolean.TYPE ||
           returnType == classOf[java.lang.Boolean]) &&
-          methodName == getBooleanGetterName(name))
+          methodName == getBooleanGetterName(name)))
         })
 
         methods.map(_.invoke(obj))

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
@@ -45,6 +45,28 @@ class InterpreterBeanExpressionTest
 
   }
 
+  it should "ignore getter method with arguments as field" in {
+
+    class A(x: Int) {
+      def getResult(y: Int): Int = x + y
+    }
+
+    eval("a.result", Map("a" -> new A(2))) should be(
+      ValError("context contains no entry with key 'result'")
+    )
+  }
+
+  it should "ignore method with arguments as field (builder-style)" in {
+
+    class A(x: Int) {
+      def plus(y: Int): A = new A(x + y)
+    }
+
+    eval("a.plus", Map("a" -> new A(2))) should be(
+      ValError("context contains no entry with key 'plus'")
+    )
+  }
+
   it should "invoke a method without arguments" in {
 
     class A { def foo() = "foo" }


### PR DESCRIPTION
## Description

* an expression can access the properties of a bean via field or method lookup 
* ignore methods with parameters when resolving available fields of a bean

## Related issues

closes #413 
