### PR TITLE
Automatically add new issues to Zeebe project board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'type: bug'
+labels: ['type: bug', 'team/process-automation']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation
 about: 'Missing or incorrect documentation '
 title: ''
-labels: 'type: documentation'
+labels: ['type: documentation', 'team/process-automation']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'type: enhancement'
+labels: ['type: enhancement', 'team/process-automation']
 assignees: saig0
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -2,7 +2,7 @@
 name: New Release
 about: Building a new release
 title: "[Release] 1.x.y"
-labels: 'type: release'
+labels: ['type: release', 'team/process-automation']
 assignees: koevskinikola, saig0
 
 ---

--- a/.github/workflows/project-new-issues.yml
+++ b/.github/workflows/project-new-issues.yml
@@ -1,0 +1,13 @@
+name: Assign new issues to the default project
+on:
+  issues:
+    types: [ opened, reopened, transferred ]
+jobs:
+  assign:
+    name: Assign to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.0.3
+        with:
+          project-url: https://github.com/orgs/camunda/projects/18
+          github-token: ${{ secrets.PROJECT_ADMIN_TOKEN }}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* Automatically sets the Project of issues to Zeebe. Also adds the `team/process-automation` label to the issue templates.

A secret with the name of `PROJECT_ADMIN_TOKEN` still needs to be added to this repo. I don't have the permissions to do this myself. The secret should be a PAT with the permissions: `repo`, `org:write` and `org:read`.

@saig0 Could you add a PAT to the secrets of this repo, or give me permissions to add one?
