### PR TITLE
Parse unary-tests expression with boolean and conjunction/disjunction 

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -574,7 +574,7 @@ object FeelParser {
 
   // boolean literals are ambiguous for unary-tests. give precedence to comparison with input.
   private def positiveUnaryTest[_: P]: P[Exp] =
-    boolean.map(InputEqualTo) | expression.map(UnaryTestExpression)
+    (boolean.map(InputEqualTo) ~ End) | expression.map(UnaryTestExpression)
 
   private def anyInput[_: P]: P[Exp] =
     P(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -185,12 +185,27 @@ class InterpreterUnaryTest
   it should "compare to a conjunction (and)" in {
     evalUnaryTests(true, "true and true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false and true") shouldBe ValBoolean(false)
+
+    evalUnaryTests(true, "true and null") shouldBe ValBoolean(false)
+    evalUnaryTests(true, "false and null") shouldBe ValBoolean(false)
+
+    evalUnaryTests(true, """true and "otherwise" """) shouldBe ValBoolean(
+      false)
+    evalUnaryTests(true, """false and "otherwise" """) shouldBe ValBoolean(
+      false)
   }
 
   it should "compare to a disjunction (or)" in {
     evalUnaryTests(true, "true or true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false or true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false or false") shouldBe ValBoolean(false)
+
+    evalUnaryTests(true, "true or null") shouldBe ValBoolean(true)
+    evalUnaryTests(true, "false or null") shouldBe ValBoolean(false)
+
+    evalUnaryTests(true, """true or "otherwise" """) shouldBe ValBoolean(true)
+    evalUnaryTests(true, """false or "otherwise" """) shouldBe ValBoolean(
+      false)
   }
 
   "A date" should "compare with '<'" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -182,6 +182,17 @@ class InterpreterUnaryTest
     evalUnaryTests(true, """ "a" = "b" """) should be(ValBoolean(false))
   }
 
+  it should "compare to a conjunction (and)" in {
+    evalUnaryTests(true, "true and true") shouldBe ValBoolean(true)
+    evalUnaryTests(true, "false and true") shouldBe ValBoolean(false)
+  }
+
+  it should "compare to a disjunction (or)" in {
+    evalUnaryTests(true, "true or true") shouldBe ValBoolean(true)
+    evalUnaryTests(true, "false or true") shouldBe ValBoolean(true)
+    evalUnaryTests(true, "false or false") shouldBe ValBoolean(false)
+  }
+
   "A date" should "compare with '<'" in {
 
     evalUnaryTests(date("2015-09-17"), """< date("2015-09-18")""") should be(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -183,6 +183,7 @@ class InterpreterUnaryTest
   }
 
   it should "compare to a conjunction (and)" in {
+    // it is uncommon to use a conjunction in a unary-tests but the engine should be able to parse
     evalUnaryTests(true, "true and true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false and true") shouldBe ValBoolean(false)
 
@@ -196,6 +197,7 @@ class InterpreterUnaryTest
   }
 
   it should "compare to a disjunction (or)" in {
+    // it is uncommon to use a disjunction in a unary-tests but the engine should be able to parse
     evalUnaryTests(true, "true or true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false or true") shouldBe ValBoolean(true)
     evalUnaryTests(true, "false or false") shouldBe ValBoolean(false)


### PR DESCRIPTION
## Description

* a unary-tests expression with a boolean literal and a conjunction/disjunction failed to parse
* the parser expected no other chars (EOF) after the boolean literal was accepted
* adjust the parser to accept the boolean literal only at the end of the expression (EOF)

## Related issues

closes #429 
