### PR TITLE
build: avoid creating a reduced pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,8 @@
             <configuration>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>scala-shaded</shadedClassifierName>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- avoid creating a reduced pom - see https://github.com/camunda/feel-scala/issues/450 -->
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
               <createSourcesJar>true</createSourcesJar>
               <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>


### PR DESCRIPTION
## Description

* the reduced pom overrides the original pom when installing the artifacts
* avoid creating a reduced pom to fix the issue
* in a previous version of the plugin (3.2.4), no reduced pom was created

## Related issues

closes #450
