### PR TITLE
chore: switch to non deprecated URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,13 +422,13 @@
     <repository>
       <id>camunda-nexus</id>
       <name>camunda platform community extensions</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>camunda platform community extensions snapshots</name>
       <url>
-        https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots
+        https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions-snapshots/
       </url>
       <!-- for maven 2 compatibility -->
       <uniqueVersion>true</uniqueVersion>


### PR DESCRIPTION

## Description

related to a change that was announced a while ago https://camunda.com/blog/2022/03/a-new-domain-name-for-camunda-artifactory/

We're still seeing a lot of traffic from the machine-account user that is linked to the repository (ci-cambpm --> due to running on the ci.cambpm Jenkins)

## Related issues

closes #
