### PR TITLE
docs: change to use `feel-service.camunda.com` domain name

### DIFF
--- a/docs/src/components/LiveFeel.js
+++ b/docs/src/components/LiveFeel.js
@@ -51,7 +51,7 @@ const LiveFeel = ({
   function evaluate(parsedContext) {
     axios
       .post(
-        "https://feel.upgradingdave.com/process/start",
+        "https://feel-service.camunda.com/process/start",
         {
           expression: expression,
           context: parsedContext,


### PR DESCRIPTION
## Description

The new domain name `feel-service.camunda.com` for the feel tutorial backend is ready to use!