### PR TITLE
docs: fix #504, playground can't display legitimate false return values

### DIFF
--- a/docs/src/components/LiveFeel.js
+++ b/docs/src/components/LiveFeel.js
@@ -67,9 +67,7 @@ const LiveFeel = ({
         }
       )
       .then((response) => {
-        if (response?.data?.result) {
-          onResult(JSON.stringify(response.data.result));
-        } else if (response?.data?.error) {
+        if (response?.data?.error) {
           const errorMessage = response.data.error;
           const match = errorPattern.exec(errorMessage);
           onError({
@@ -77,6 +75,8 @@ const LiveFeel = ({
             line: match?.groups?.line,
             position: match?.groups?.position,
           });
+        } else {
+          onResult(JSON.stringify(response.data.result));
         }
       });
   }


### PR DESCRIPTION
## Description

* Small change to `LiveFeel.js` to look at "error" rather than "result" in order to know whether or not to display error. This way, expressions that legitimately evaluate to `false` will be displayed in playground results. 

## Related issues

closes #504 
