### PR TITLE
fix: filter expression with numeric function

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -234,6 +234,18 @@ class InterpreterListExpressionTest
       ValNumber(1))
   }
 
+  it should "fail if the filter doesn't return a boolean or a number" in {
+    eval(""" [1,2,3,4]["not a valid filter"] """) should be (
+      ValError("Expected boolean filter or number but found 'ValString(not a valid filter)'")
+    )
+  }
+
+  it should "fail if the filter doesn't return always a boolean" in {
+    eval("[1,2,3,4][if item < 3 then true else null]") should be (
+      ValError("expected Boolean but found 'ValNull'")
+    )
+  }
+
   it should "fail if one element fails" in {
 
     eval("[1, {}.x]") should be(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -137,7 +137,7 @@ class InterpreterListExpressionTest
     eval("[1,2,3,4][modulo(2,4)]") should be(ValNumber(2))
   }
 
-  it should "be filtered via custom function" in {
+  it should "be filtered via custom boolean function" in {
     val functionInvocations: ListBuffer[Val] = ListBuffer.empty
 
     val result = eval(
@@ -159,6 +159,28 @@ class InterpreterListExpressionTest
       ValNumber(2),
       ValNumber(3),
       ValNumber(4))
+    )
+  }
+
+  it should "be filtered via custom numeric function" in {
+    val functionInvocations: ListBuffer[Val] = ListBuffer.empty
+
+    val result = eval(
+      expression = "[1,2,3,4][f(item)]",
+      variables = Map(),
+      functions = Map("f" -> ValFunction(
+        params = List("x"),
+        invoke = {
+          case List(x) =>
+            functionInvocations += x
+            ValNumber(3)
+        }
+      )))
+
+    result should be(ValNumber(3))
+
+    functionInvocations should be(List(
+      ValNumber(1))
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -131,6 +131,12 @@ class InterpreterListExpressionTest
       ValList(List(ValNumber(2), ValNumber(4))))
   }
 
+  it should "be filtered via numeric function" in {
+    eval("[1,2,3,4][abs(1)]") should be(ValNumber(1))
+
+    eval("[1,2,3,4][modulo(2,4)]") should be(ValNumber(2))
+  }
+
   it should "be filtered via custom function" in {
     val functionInvocations: ListBuffer[Val] = ListBuffer.empty
 


### PR DESCRIPTION
## Description

- if the filter of a list returns a number then the expression should return the item at the given index
- note that the code could look more elegant but we want to avoid unintended function invocation because the invocations are visible by the function provider (https://github.com/camunda/feel-scala/issues/359)
- we could improve the code later if the function defines the types of the arguments and the return value (https://github.com/camunda/feel-scala/issues/295)

## Related issues

closes #507
