### PR TITLE
fix: Instance of with correct duration names

### DIFF
--- a/docs/docs/reference/language-guide/feel-boolean-expressions.md
+++ b/docs/docs/reference/language-guide/feel-boolean-expressions.md
@@ -230,6 +230,12 @@ Use the type `Any` to check if the value is not `null`.
 
 null instance of Any
 // false
+
+"duration("P3M") instance of years and months duration"
+// true
+
+"duration("PT4H") instance of days and time duration"
+// true
 ```
 
 ### Unary-tests/in

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -217,6 +217,8 @@ class FeelInterpreter {
         withVal(eval(x), x => {
           typeName match {
             case "Any" if x != ValNull => ValBoolean(true)
+            case "years and months duration" => withType(x, t => ValBoolean(t == "year-month-duration"))
+            case "days and time duration" => withType(x, t => ValBoolean(t == "day-time-duration"))
             case _                     => withType(x, t => ValBoolean(t == typeName))
           }
         })

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -314,8 +314,15 @@ object FeelParser {
 
   private def typeName[_: P]: P[String] =
     P(
-      qualifiedName
-    ).map(_.mkString("."))
+      durationTypeName |
+        qualifiedName.map(_.mkString("."))
+    )
+
+  private def durationTypeName[_: P]: P[String] =
+    P(
+      "years and months duration" |
+        "days and time duration"
+    ).!
 
   private def in[_: P](value: Exp): P[Exp] =
     P(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -106,6 +106,13 @@ class InterpreterExpressionTest
     eval("x instance of string", Map("x" -> 0)) should be(ValBoolean(false))
   }
 
+  it should "be an instance of (duration)" in {
+    eval("duration(P3M) instance of years and months duration") should be(ValBoolean(true))
+    eval("duration(PT4H) instance of days and time duration") should be(ValBoolean(true))
+    eval("null instance of ears and months duration") should be(ValBoolean(false))
+    eval("null instance of days and time duration") should be(ValBoolean(false))
+  }
+
   it should "be an instance of (multiplication)" in {
     eval("2 * 3 instance of number") should be(ValBoolean(true))
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -107,10 +107,10 @@ class InterpreterExpressionTest
   }
 
   it should "be an instance of (duration)" in {
-    eval("duration(P3M) instance of years and months duration") should be(ValBoolean(true))
-    eval("duration(PT4H) instance of days and time duration") should be(ValBoolean(true))
-    eval("null instance of ears and months duration") should be(ValBoolean(false))
-    eval("null instance of days and time duration") should be(ValBoolean(false))
+    eval("""duration("P3M") instance of years and months duration""") should be(ValBoolean(true))
+    eval("""duration("PT4H") instance of days and time duration""") should be(ValBoolean(true))
+    eval("""null instance of years and months duration""") should be(ValBoolean(false))
+    eval("""null instance of days and time duration""") should be(ValBoolean(false))
   }
 
   it should "be an instance of (multiplication)" in {


### PR DESCRIPTION
## Description
*  instance of doesn't work for durations 

Expected behavior

null instance of years and months duration -> false
null instance of days and time duration -> false

duration("P3M") instance of years and months duration -> true
duration("PT4H") instance of days and time duration -> true



## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #155
