### PR TITLE
(feat): Fix negative durations in string variables that fail to parse

### DIFF
--- a/src/main/scala/org/camunda/package.scala
+++ b/src/main/scala/org/camunda/package.scala
@@ -120,7 +120,7 @@ package object feel {
     localDateTimePatter.matcher(dateTime).matches
 
   private lazy val yearMonthDurationPattern =
-    Pattern.compile("""-?P(\d+Y)?(\d+M)?""")
+    Pattern.compile("""-?P(\d+Y)?-?(\d+M)?""")
 
   def isYearMonthDuration(duration: String): Boolean =
     yearMonthDurationPattern.matcher(duration).matches

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -207,6 +207,12 @@ class BuiltinConversionFunctionsTest
       ValDayTimeDuration("P2DT20H14M"))
   }
 
+  "A duration() function" should "parse string variables with -" in {
+
+    eval(""" duration(x) """, Map("x" -> "PT-5M")) should be(
+      ValDayTimeDuration("PT-5M"))
+  }
+
   it should "convert year-month-String" in {
 
     eval(""" duration(x) """, Map("x" -> "P2Y4M")) should be(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* 

Negative durations when they are string variables don't parse

feel("""duration(durationBefore)""", Map("durationBefore" -> "PT-5M")) shows error


This pr fixes the issue. 
## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #513
