### PR TITLE
test: verify unary-tests with list variable

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -551,10 +551,15 @@ class InterpreterUnaryTest
                    Map("now" -> "2019-08-13")) should be(ValBoolean(false))
   }
 
-  it should "be compared with a list" in {
+  it should "be compared with a list value" in {
 
     evalUnaryTests(2, """[1,2,3]""") should be(ValBoolean(true))
     evalUnaryTests(4, """[1,2,3]""") should be(ValBoolean(false))
+  }
+
+  it should "be compared with a list variable" in {
+    evalUnaryTests(2, "x", Map("x" -> List(1,2,3))) should be (ValBoolean(true))
+    evalUnaryTests(4, "x", Map("x" -> List(1,2,3))) should be (ValBoolean(false))
   }
 
 }


### PR DESCRIPTION
## Description

Add a test case to verify that a value in a unary-tests expression can be compared to a variable with a list value.

## Related issues

Verifies that #308 is fixed (since version `1.14.0`).
