### PR TITLE
docs: Update version banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -26,6 +26,9 @@ Release date:
 * [ ] if major/minor release, append the [changelog in the documentation](https://camunda.github.io/feel-scala/docs/changelog/) for the released version and mention the new features
 * [ ] if major/minor release, archive the documentation of the previous version
   * use `npm run docusaurus docs:version 1.x` in `/docs` to copy the existing docs under the released version (`1.x` = the released version)
-  * update the latest version in `/docs/docusaurus.config.js` under `docs > versions > current > label`
+  * update the versions in the configuration `/docs/docusaurus.config.js`
+    * set the latest version in `docs > lastVersion`
+    * set the current version in `docs > versions > current > label`
+    * set the supported versions in `docs > versions` (enable/disable the "unmaintained version" banner)
 * [ ] update the version that is used by the FEEL REPL script `/feel-repl.sc` under `import $ivy.org.camunda.feel:feel-engine:1.x.y`
 * [ ] inform the maintainers of other teams about the successful release :tada:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -95,14 +95,23 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
           editUrl:
             'https://github.com/camunda/feel-scala/edit/main/docs/',
-          lastVersion: 'current',
-          // onlyIncludeVersions: ['current', '1.12', '1.11'],
+          // includes the unreleased version
+          includeCurrentVersion: true,
+          // the last released (stable) version
+          lastVersion: '1.15',
+          // override the config for specific versions
           versions: {
+            // for the unreleased version
             current: {
-              label: `1.16 (unreleased)`,
+              // add the postfix "unreleased"
+              label: '1.16 (unreleased)'
+            },
+            // for all supported versions
+            '1.14': {
+              // disable the "unmaintained version" banner
+              banner: 'none',
             },
           },
         },

--- a/docs/versioned_docs/version-1.15/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.15/playground/playground.mdx
@@ -1,0 +1,23 @@
+---
+id: playground
+title: Playground for FEEL expressions
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+:::danger Work in progress
+The playground is created as part of our Camunda Summer Hack Days project 2022.
+
+It may be broken. But stay tuned for updates!
+:::
+
+Use the interactive editor below to evaluate
+[FEEL expressions](/docs/reference/language-guide/feel-expressions-introduction.md).
+
+<LiveFeel
+  defaultExpression={dedent`
+      3 + x`}
+  feelContext='{"x": 5}'
+  metadata={{ page: "tutorial-playground" }}
+/>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-1-1.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-1-1.mdx
@@ -1,0 +1,40 @@
+---
+id: tutorial-1-1
+title: "1.1 Numeric expressions"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+Let's start our quest. :triangular_flag_on_post: FEEL allows you to use basic
+[numeric calculations](/docs/reference/language-guide/feel-numeric-expressions.md) like addition,
+subtraction and multiplication to name a few. Our friend arrived in Spain by boat, specifically
+Cadiz. The goal is to reach Pamplona (which is 1,030.8 kms away).
+
+As part of the quest, Zee received magical items :sparkles: and decided to use The Boots of Hermes
+:shoe:, which give its wearer a speed of 48.2 kms/hour.
+
+Using numeric operators, how many hours would it take to get there? Consider resting for 30 minutes
+every 5 hours. Let's also round up the number for total resting time by using a
+[numeric function](/docs/reference/builtin-functions/feel-built-in-functions-numeric.md).
+
+<LiveFeel
+  defaultExpression={dedent`
+      // change formula considering resting time plus total time
+      round up(distance / speed, 0)`}
+  feelContext='{"distance": 1030.8, "speed": 48.2, "restInHrs": 0.5, "restInterval": 5}'
+  metadata={{ page: "tutorial-1-1" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>
+      It would take Zee 24 hours to complete the trip.
+    </div>
+    <br />
+    <pre title={'Expression'}>
+      round up(restInHrs * (distance / speed) / restInterval + distance / speed, 0)
+    </pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-1-2.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-1-2.mdx
@@ -1,0 +1,40 @@
+---
+id: tutorial-1-2
+title: "1.2 More numeric expressions"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+Once Zee arrived to Pamplona, a mystical creature appeared: Lerna's Hydra. :snake: The Hydra was a
+one-headed monster that when it's head was cut off, 2 more heads would grew in its place.
+
+Zee reached for a sword :dagger_knife: and cut off the head of the beast. As a result 2 more
+appeared. :scream: Zee cut both heads off again, which doubled to 4. How many heads would the beast
+have after cutting them for 5 times?
+
+We could try to represent this in a multiplication like this: `2*2*2*2*2`, but we can leverage
+[exponentiation](/docs/reference/language-guide/feel-numeric-expressions.md#exponentiation) and
+represent it like the following expression:
+
+<LiveFeel
+  defaultExpression={dedent`
+    // use exponentiation to represent the multiplications
+    2*2*2*2*2`}
+  feelContext='{"base": 2, "exponent": 5}'
+  metadata={{ page: "tutorial-1-2" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>
+      By the 5th time, there were 32 heads and no apparent way out, thankfully the heads started
+      fighting with each other and Zee was able to escape.
+    </div>
+    <br />
+    <pre title={'Expression'}>
+      base ** exponent
+    </pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-1-3.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-1-3.mdx
@@ -1,0 +1,39 @@
+---
+id: tutorial-1-3
+title: "1.3 Numeric functions"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+Zee is now entering France :fr: and during the battle with Hydra lost the Boots of Hermes. It is
+7:00 AM and our friend has to continue by foot. :walking: The goal is to walk to Lyon which is
+729.1 kms distance.
+
+Considering average walking speed is 5 km/h how many days would Zee need to walk without taking many
+rest?, and at what time would Zee reach Lyon?
+
+First determine the number of days using expressions were already used `distance / speed`.
+In this case: `729.1 / 5 = 145 hrs`. To determine arrival time, we can leverage modular clock
+(24 hours) arithmetics using the function [modulo()](/docs/reference/builtin-functions/feel-built-in-functions-numeric.md#modulo).
+
+<LiveFeel
+  defaultExpression={dedent`
+    // use a 24 hour clock
+    hours + startingHour`}
+  feelContext='{"startingHour": 7, "hours": 145, "modulus": 24}'
+  metadata={{ page: "tutorial-1-2" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>
+      Zee would take 6 days to arrive and would be there at 8:00 AM.
+    </div>
+    <br />
+    <pre title={'Expression'}>
+      modulo((hours + startingHour), modulus)
+    </pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-2-1.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-2-1.mdx
@@ -1,0 +1,32 @@
+---
+id: tutorial-2-1
+title: "2.1 String expressions"
+---
+
+import dedent from "dedent";
+import LiveFeel from "@site/src/components/LiveFeel";
+import EnvelopeAddress from "@site/src/components/EnvelopeAddress";
+
+Before he continues on his quest, Zee promised to keep in touch with friends back home and send them
+each a letter. :incoming_envelope:
+
+Luckily, FEEL [string expressions](/docs/reference/language-guide/feel-string-expressions.md) are
+here to Help and save time. Use an expression to fill the name on the envelope that contains the
+first and the last name.
+
+<EnvelopeAddress
+  defaultExpression={dedent`
+      // concatenate the first and the last name
+      firstName`}
+  feelContext='{"firstName":"?", "lastName":"?"}'
+  metadata={{ page: "tutorial-2-1" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>Zee labels the envelopes and send them out.</div>
+    <br />
+    <pre title={"Expression"}>firstName + " " + lastName</pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-3-1.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-3-1.mdx
@@ -1,0 +1,37 @@
+---
+id: tutorial-3-1
+title: "3.1 Temporal expressions"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+The next stop would put Zee in Cologne :de:, as the journey continued there was an important
+question to answer: would Zee get in time for the conference? :watch:
+
+The trip started on September 15th, 2022, and since the journey began, around 200 hours had passed.
+CamundaCon will start on October 5th, 2022.
+
+Let's use [temporal operators](/docs/reference/language-guide/feel-temporal-expressions.md) to check
+how many days Zee has left:
+
+<LiveFeel
+  defaultExpression={dedent`
+    // use temporal math to calculate the remaining days
+    date(startingDate) + duration("PT200H")`}
+    feelContext='{"startingDate": "2022-09-15", "targetDate": "2022-10-05"}'
+  metadata={{ page: "tutorial-3-1" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>
+      Zee has 11 days to arrive in Berlin.
+    </div>
+    <br />
+    <pre title={'Expression'}>
+      (date(targetDate) - date(startingDate) - duration("PT200H")) / duration("P1D")
+    </pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-3-2.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-3-2.mdx
@@ -1,0 +1,38 @@
+---
+id: tutorial-3-2
+title: "3.2 Temporal functions"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+Since Zee has 11 days to reach the CamundaCon, Zee decides to stay a bit longer in Cologne. :de: For
+the last trip, Zee wants to take a train :bullettrain_front: to Berlin.
+
+On the train schedule, there is a special train that leaves Cologne on each Monday morning. Zee
+looks at the calendar but is unsure about the current weekday.
+
+Can you help him? Use
+[temporal functions](/docs/reference/builtin-functions/feel-built-in-functions-temporal.md) to resolve the
+current weekday.
+
+<LiveFeel
+  defaultExpression={dedent`
+    // use a function to get the weekday of the current date
+    date(targetDate)`}
+    feelContext='{"targetDate": "2022-10-05", "remainingTime": "P11D"}'
+  metadata={{ page: "tutorial-3-2" }}
+/>
+
+<details>
+  <summary>Solution</summary>
+  <div>
+    <div>
+      It is Saturday. Zee can stay the weekend in Cologne.
+    </div>
+    <br />
+    <pre title={'Expression'}>
+      day of week(date(targetDate) - duration(remainingTime))
+    </pre>
+  </div>
+</details>

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial-4-1.md
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial-4-1.md
@@ -1,0 +1,12 @@
+---
+id: tutorial-4-1
+title: "4.1 Final Stop: Lists expressions"
+---
+:::danger
+# Under Construction :construction:
+
+Here we will have some witty way of explaining usage of list expressions in FEEL
+
+:::
+
+ Final Stop BERLIN!!!! in time for CamundaCon

--- a/docs/versioned_docs/version-1.15/tutorial/tutorial.mdx
+++ b/docs/versioned_docs/version-1.15/tutorial/tutorial.mdx
@@ -1,0 +1,45 @@
+---
+id: tutorial
+title: "The quest begins"
+---
+
+import LiveFeel from "@site/src/components/LiveFeel";
+import dedent from "dedent";
+
+:::danger Work in progress
+The tutorial is created as part of our Camunda Summer Hack Days project 2022.
+
+It may be incomplete, wrong, or broken. But stay tuned for updates!
+:::
+
+Welcome to our tutorial. :wave:
+
+We'll do our best to guide you through the different capabilities
+of [FEEL](/docs/reference/what-is-feel.md) and hopefully make the
+process fun. :tada:
+
+We are enlisting you to help us guide our friend "Zee" to complete a quest from Spain :es: to Berlin
+:de: in time for CamundaCon (2022). With the use of FEEL we'll be able to help in the journey.
+
+Before we start, let's say "Hi" to Zee:
+
+![Zee](/img/zee.png)
+
+Use the interactive editor below to evaluate the
+[FEEL expression](/docs/reference/language-guide/feel-expressions-introduction.md) and greet Zee.
+
+<LiveFeel
+    defaultExpression={dedent`
+    "Hello Zee"
+    `}
+    metadata={{ page: "tutorial-the-quest-begins" }}
+/>
+
+:::note
+FEEL is an expression language. Compared to script languages or other complex programming
+languages, an expression language evaluates only a single expression.
+:::
+
+Zee is happy to have you on board. So, let the journey begin. :rocket:
+
+

--- a/docs/versioned_sidebars/version-1.15-sidebars.json
+++ b/docs/versioned_sidebars/version-1.15-sidebars.json
@@ -163,6 +163,74 @@
       "id": "version-1.15/samples/context-samples"
     }
   ],
+  "version-1.15/Tutorial": [
+    {
+      "type": "doc",
+      "id": "tutorial/tutorial"
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Tutorial 1: Numbers",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-1-1"
+        },
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-1-2"
+        },
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-1-3"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Tutorial 2: Strings",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-2-1"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Tutorial 3: Temporal",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-3-1"
+        },
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-3-2"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "type": "category",
+      "label": "Tutorial 4: Lists",
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-1.15/tutorial/tutorial-4-1"
+        }
+      ]
+    }
+  ],
+  "version-1.15/Playground": [
+    {
+      "type": "doc",
+      "id": "playground/playground"
+    }
+  ],
   "version-1.15/Changelog": [
     {
       "type": "doc",


### PR DESCRIPTION
## Description

Set the last version to the last released version, instead of the current dev version. This changes the behavior to redirect by default to the last released version. In most cases, this should be the version that users are looking for.

Disable the "unmaintained version" for the last released version (1.15) and all supported versions (1.14).

For reference: https://docusaurus.io/docs/versioning#configuring-versioning-behavior.

---

## Before

![image](https://user-images.githubusercontent.com/4305769/202976885-9e2da0b3-01ed-4292-be63-f7845e99677e.png)

--- 

## After

![image](https://user-images.githubusercontent.com/4305769/202976959-a013ea16-4b31-4997-b700-0d745f911e4c.png)

![image](https://user-images.githubusercontent.com/4305769/202977034-0b2e0495-8c10-4650-9020-9e32d783495b.png)

![image](https://user-images.githubusercontent.com/4305769/202977090-961cb505-7659-48cc-8c59-40051855a250.png)

![image](https://user-images.githubusercontent.com/4305769/202977124-09c05511-92a8-42f2-9071-2eea32a317db.png)

---

## Related issues


