### PR TITLE
[Backport 1.14] chore(deps): bump scala-library from 2.13.8 to 2.13.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <version.java>1.8</version.java>
-    <scala.version>2.13.6</scala.version>
+    <scala.version>2.13.9</scala.version>
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.17.0</version.log4j>
     <plugin.version.shade>3.2.4</plugin.version.shade>

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -212,7 +212,7 @@ object FeelParser {
   private def expLvl2[_: P]: P[Exp] = conjunction
 
   private def expLvl3[_: P]: P[Exp] =
-    expLvl4.flatMap(optional(comparison)) | simplePositiveUnaryTest
+    expLvl4.flatMap(optional(comparison(_))) | simplePositiveUnaryTest
 
   private def expLvl4[_: P]: P[Exp] = mathOperator
 
@@ -369,7 +369,7 @@ object FeelParser {
   // --------------- value/terminal parsers ---------------
 
   private def value[_: P]: P[Exp] =
-    terminalValue.flatMap(optional(chainedValueOp))
+    terminalValue.flatMap(optional(chainedValueOp(_)))
 
   private def terminalValue[_: P]: P[Exp] =
     temporal | functionInvocation | variableRef | literal | inputValue | functionDefinition | "(" ~ expression ~ ")"
@@ -528,7 +528,7 @@ object FeelParser {
 
   // operators of values that can be chained multiple times (e.g. `a.b.c`, `a[1][2]`, `a.b[1].c`)
   private def chainedValueOp[_: P](value: Exp): P[Exp] =
-    (path(value) | filter(value)).flatMap(optional(chainedValueOp))
+    (path(value) | filter(value)).flatMap(optional(chainedValueOp(_)))
 
   private def path[_: P](value: Exp): P[Exp] =
     P(


### PR DESCRIPTION
# Description
Backport of #523 to `1.14`.

relates to camunda/camunda-bpm-platform#2818