### PR TITLE
Support built-in functions `context put()` and `context merge()`

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
@@ -33,38 +33,82 @@ get entries({foo: 123})
 // [{key: "foo", value: 123}]
 ```
 
-## put()
+## context put(context, key, value)
 
-<MarkerCamundaExtension></MarkerCamundaExtension>
+Adds a new entry with the given key and value to the context. Returns a new context that includes the entry.
 
-Add the given key and value to a context. Returns a new context that includes the entry. It might override an existing entry of the context.
+If an entry for the same key already exists in the context, it overrides the value.
 
-Returns `null` if the value is not defined.
-
-- parameters:
-  - `context`: context
-  - `key`: string
-  - `value`: any
-- result: context
+**Function signature**
 
 ```js
-put({x:1}, "y", 2)
+context put(context: context, key: string, value: Any): context
+```
+
+**Examples**
+
+```js
+context put({x:1}, "y", 2)
 // {x:1, y:2}
 ```
 
-## put all()
+:::info
+The function `context put()` replaced the previous function `put()` (Camunda Extension). The
+previous function is deprecated and should not be used anymore.
+:::
 
-<MarkerCamundaExtension></MarkerCamundaExtension>
+## context put(context, keys, value)
 
-Union the given contexts (two or more). Returns a new context that includes all entries of the given contexts. It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts are passed in the method.
+Adds a new entry with the given value to the context. The path of the entry is defined by the keys. Returns a new context that includes the entry. 
 
-Returns `null` if one of the values is not a context.
+If `keys` contains the keys `[k1, k2]` then it adds the nested entry `k1.k2 = value` to the context.
 
-- parameters:
-  - `contexts`: contexts as varargs
-- result: context
+If an entry for the same keys already exists in the context, it overrides the value.
+
+If `keys` are empty, it returns `null`.
+
+**Function signature**
 
 ```js
-put all({x:1}, {y:2})
+context put(context: context, keys: list<string>, value: Any): context
+```
+
+**Examples**
+
+```js
+context put({x:1}, ["y"], 2)
+// {x:1, y:2}
+
+context put({x:1, y: {z:0}}, ["y", "z"], 2)
+// {x:1, y: {z:2}}
+
+context put({x:1}, ["y", "z"], 2)
+// {x:1, y: {z:2}}
+```
+
+## context merge(contexts)
+
+Union the given contexts. Returns a new context that includes all entries of the given contexts. 
+
+If an entry for the same key already exists in a context, it overrides the value. The entries are overridden in the same order as in the list of contexts.
+
+**Function signature**
+
+```js
+context merge(contexts: list<context>): context
+```
+
+**Examples**
+
+```js
+context merge([{x:1}, {y:2}])
+// {x:1, y:2}
+
+context merge([{x:1, y: 0}, {y:2}])
 // {x:1, y:2}
 ```
+
+:::info
+The function `context merge()` replaced the previous function `put all()` (Camunda Extension). The
+previous function is deprecated and should not be used anymore.
+:::

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -19,7 +19,8 @@ object ContextBuiltinFunctions {
                           getEntriesFunction("m")),
     "get value" -> List(getValueFunction(List("m", "key")),
                         getValueFunction(List("context", "key"))),
-    "put" -> List(putFunction),
+    "context put" -> List(contextPutFunction),
+    "put" -> List(contextPutFunction), // deprecated function name
     "context merge" -> List(contextMergeFunction),
     "put all" -> List(contextMergeFunction), // deprecated function name
     "context" -> List(contextFunction)
@@ -46,7 +47,7 @@ object ContextBuiltinFunctions {
     }
   )
 
-  private def putFunction = builtinFunction(
+  private def contextPutFunction = builtinFunction(
     params = List("context", "key", "value"),
     invoke = {
       case List(ValContext(_), ValString(_), ValError(_)) => ValNull

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -1,25 +1,20 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.context.Context
-import org.camunda.feel.context.Context.StaticContext
+import org.camunda.feel.context.Context.{EmptyContext, StaticContext}
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
-import org.camunda.feel.syntaxtree.{
-  Val,
-  ValContext,
-  ValError,
-  ValList,
-  ValNull,
-  ValString
-}
+import org.camunda.feel.syntaxtree.{Val, ValContext, ValError, ValList, ValNull, ValString}
+
+import scala.annotation.tailrec
 
 object ContextBuiltinFunctions {
 
   def functions = Map(
     "get entries" -> List(getEntriesFunction("context"),
-                          getEntriesFunction("m")),
+      getEntriesFunction("m")),
     "get value" -> List(getValueFunction(List("m", "key")),
-                        getValueFunction(List("context", "key"))),
-    "context put" -> List(contextPutFunction),
+      getValueFunction(List("context", "key"))),
+    "context put" -> List(contextPutFunction, contextPutFunction2),
     "put" -> List(contextPutFunction), // deprecated function name
     "context merge" -> List(contextMergeFunction),
     "put all" -> List(contextMergeFunction), // deprecated function name
@@ -51,12 +46,59 @@ object ContextBuiltinFunctions {
     params = List("context", "key", "value"),
     invoke = {
       case List(ValContext(_), ValString(_), ValError(_)) => ValNull
-      case List(ValContext(c), ValString(key), value) =>
-        ValContext(
-          StaticContext(
-            variables = c.variableProvider.getVariables + (key -> value)))
+      case List(context: ValContext, ValString(key), value) => contextPut(
+        contextValue = context, key = key, value = value
+      )
+      // delegate to other context put function with keys
+      case List(ValContext(_), ValList(_), ValError(_)) => ValNull
+      case List(ValContext(_), ValList(keys), _) if keys.isEmpty => ValNull
+      case List(context: ValContext, keys: ValList, value) if isListOfStrings(keys.items) =>
+        contextPutFunction2.invoke(List(context, keys, value))
     }
   )
+
+  private def contextPut(contextValue: ValContext, key: String, value: Val): ValContext = {
+    ValContext(
+      StaticContext(
+        variables = contextValue.context.variableProvider.getVariables + (key -> value)))
+  }
+
+  private def contextPutFunction2 = builtinFunction(
+    params = List("context", "keys", "value"),
+    invoke = {
+      case List(ValContext(_), ValList(_), ValError(_)) => ValNull
+      case List(ValContext(_), ValList(keys), _) if keys.isEmpty => ValNull
+      case List(context: ValContext, ValList(keys), value) if isListOfStrings(keys) =>
+        val listOfKeys = keys.asInstanceOf[List[ValString]].map(_.value)
+
+        contextPutWithKeys(context, listOfKeys, value)
+    }
+  )
+
+  // TODO (saig0): Add @tailrec to ensure that it is a tail-recursion
+  private def contextPutWithKeys(contextValue: ValContext, keys: List[String], value: Val): Val = {
+    keys match {
+      case Nil => contextValue
+      case key :: Nil => contextPut(contextValue = contextValue, key = key, value = value)
+      case key :: tail =>
+        val contextOfKey = contextValue.context.variableProvider.getVariable(key).map {
+          case contextOfKey: ValContext => contextOfKey
+          case _ => ValContext(EmptyContext)
+        }.getOrElse(ValContext(EmptyContext))
+
+        contextPut(
+          contextValue = contextValue,
+          key = key,
+          value =
+            contextPutWithKeys(
+              contextValue = contextOfKey,
+              keys = tail,
+              value = value))
+    }
+  }
+
+  private def isListOfStrings(list: List[Val]): Boolean =
+    list.forall(_.isInstanceOf[ValString])
 
   private def contextMergeFunction = builtinFunction(
     params = List("contexts"),
@@ -67,7 +109,7 @@ object ContextBuiltinFunctions {
             variables = contexts
               .flatMap(_ match {
                 case ValContext(c) => c.variableProvider.getVariables
-                case _             => Map.empty
+                case _ => Map.empty
               })
               .toMap
           )

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -20,7 +20,8 @@ object ContextBuiltinFunctions {
     "get value" -> List(getValueFunction(List("m", "key")),
                         getValueFunction(List("context", "key"))),
     "put" -> List(putFunction),
-    "put all" -> List(putAllFunction),
+    "context merge" -> List(contextMergeFunction),
+    "put all" -> List(contextMergeFunction), // deprecated function name
     "context" -> List(contextFunction)
   )
 
@@ -56,7 +57,7 @@ object ContextBuiltinFunctions {
     }
   )
 
-  private def putAllFunction = builtinFunction(
+  private def contextMergeFunction = builtinFunction(
     params = List("contexts"),
     invoke = {
       case List(ValList(contexts)) if isListOfContexts(contexts) =>

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -117,10 +117,58 @@ class BuiltinContextFunctionsTest
     eval(""" context put({}, "x", notExisting) """) should be(ValNull)
   }
 
-  it should "be invoked with named parameters" in {
+  it should "be invoked with named parameters (key)" in {
     eval(""" context put(context: {x:1}, key: "y", value: 2) = {x:1, y:2} """) should be (
       ValBoolean(true)
     )
+  }
+
+  it should "add an a context entry with list argument" in {
+    eval(""" context put({x:1}, ["y"], 2) = {x:1, y:2} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  it should "add nested context entry" in {
+    eval(""" context put({x:1, y:{a:1}}, ["y", "b"], 2) = {x:1, y:{a:1, b:2}} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  it should "override nested context entry" in {
+    eval(""" context put({x:1, y:{a:1}}, ["y", "a"], 2) = {x:1, y:{a:2}} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  it should "add nested context entry if key doesn't exist" in {
+    eval(""" context put({x:1}, ["y", "z"], 2) = {x:1, y:{z:2}} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  it should "override nested context entry if existing value is not a context" in {
+    eval(""" context put({x:1, y:2}, ["y", "z"], 2) = {x:1, y:{z:2}} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  it should "be invoked with named parameters (keys)" in {
+    eval(""" context put(context: {x:{y:1}}, keys: ["x","y"], value: 2) = {x:{y:2}} """) should be(
+      ValBoolean(true)
+    )
+  }
+
+  it should "return null if keys are empty" in {
+    eval(""" context put({x:1}, [], 2) """) should be (ValNull)
+  }
+
+  it should "return null if keys are null" in {
+    eval(""" context put({x:1}, null, 2) """) should be (ValNull)
+  }
+
+  it should "return null if keys are not a list of strings" in {
+    eval(""" context put({x:1}, [1,2,3], 2) """) should be(ValNull)
   }
 
   "A put function (deprecated)" should "behave as the context put function" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -76,9 +76,9 @@ class BuiltinContextFunctionsTest
     eval(""" get value({}, "foo") """) should be(ValNull)
   }
 
-  "A put function" should "add an entry to an empty context" in {
+  "A context put function" should "add an entry to an empty context" in {
 
-    eval(""" put({}, "x", 1) """) should be(
+    eval(""" context put({}, "x", 1) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(1)))
       ))
@@ -86,7 +86,7 @@ class BuiltinContextFunctionsTest
 
   it should "add an entry to an existing context" in {
 
-    eval(""" put({x:1}, "y", 2) """) should be(
+    eval(""" context put({x:1}, "y", 2) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(1), "y" -> ValNumber(2)))
       ))
@@ -94,21 +94,47 @@ class BuiltinContextFunctionsTest
 
   it should "override an entry of an existing context" in {
 
-    eval(""" put({x:1}, "x", 2) """) should be(
+    eval(""" context put({x:1}, "x", 2) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(2)))
       ))
   }
 
+  it should "override an entry and keep the original order" in {
+    eval(""" context put({x:1, y:0, z:0}, "y", 2) = {x:1, y:2, z:0} """) should be (
+      ValBoolean(true)
+    )
+  }
+
   it should "add a context entry to an existing context" in {
 
-    eval(""" put({x:1}, "y", {"z":2}) = {x:1, y:{z:2} } """) should be(
+    eval(""" context put({x:1}, "y", {"z":2}) = {x:1, y:{z:2} } """) should be(
       ValBoolean(true))
   }
 
   it should "return null if the value is not present" in {
 
-    eval(""" put({}, "x", notExisting) """) should be(ValNull)
+    eval(""" context put({}, "x", notExisting) """) should be(ValNull)
+  }
+
+  it should "be invoked with named parameters" in {
+    eval(""" context put(context: {x:1}, key: "y", value: 2) = {x:1, y:2} """) should be (
+      ValBoolean(true)
+    )
+  }
+
+  "A put function (deprecated)" should "behave as the context put function" in {
+    eval(""" put({}, "x", 1) = context put({}, "x", 1) """) should be (
+      ValBoolean(true)
+    )
+
+    eval(""" put({x:1}, "y", 2) = context put({x:1}, "y", 2) """) should be (
+      ValBoolean(true)
+    )
+
+    eval(""" put({x:1}, "x", 2) = context put({x:1}, "x", 2) """) should be (
+      ValBoolean(true)
+    )
   }
 
   "A context merge function" should "return a single empty context" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -111,9 +111,9 @@ class BuiltinContextFunctionsTest
     eval(""" put({}, "x", notExisting) """) should be(ValNull)
   }
 
-  "A put all function" should "return a single empty context" in {
+  "A context merge function" should "return a single empty context" in {
 
-    eval(""" put all({}) """) should be(
+    eval(""" context merge({}) """) should be(
       ValContext(
         StaticContext(variables = Map.empty)
       ))
@@ -121,7 +121,7 @@ class BuiltinContextFunctionsTest
 
   it should "return a single context" in {
 
-    eval(""" put all({x:1}) """) should be(
+    eval(""" context merge({x:1}) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(1)))
       ))
@@ -129,7 +129,7 @@ class BuiltinContextFunctionsTest
 
   it should "combine empty contexts" in {
 
-    eval(""" put all({}, {}) """) should be(
+    eval(""" context merge({}, {}) """) should be(
       ValContext(
         StaticContext(variables = Map.empty)
       ))
@@ -137,7 +137,7 @@ class BuiltinContextFunctionsTest
 
   it should "add all entries to an empty context" in {
 
-    eval(""" put all({}, {x:1}) """) should be(
+    eval(""" context merge({}, {x:1}) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(1)))
       ))
@@ -145,7 +145,7 @@ class BuiltinContextFunctionsTest
 
   it should "add an entry to an context" in {
 
-    eval(""" put all({x:1}, {y:2}) """) should be(
+    eval(""" context merge({x:1}, {y:2}) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(1), "y" -> ValNumber(2)))
       ))
@@ -153,7 +153,7 @@ class BuiltinContextFunctionsTest
 
   it should "add all entries to an context" in {
 
-    eval(""" put all({x:1}, {y:2, z:3}) """) should be(
+    eval(""" context merge({x:1}, {y:2, z:3}) """) should be(
       ValContext(
         StaticContext(variables =
           Map("x" -> ValNumber(1), "y" -> ValNumber(2), "z" -> ValNumber(3)))
@@ -162,7 +162,7 @@ class BuiltinContextFunctionsTest
 
   it should "override an entry of the existing context" in {
 
-    eval(""" put all({x:1}, {x:2}) """) should be(
+    eval(""" context merge({x:1}, {x:2}) """) should be(
       ValContext(
         StaticContext(variables = Map("x" -> ValNumber(2)))
       ))
@@ -170,7 +170,7 @@ class BuiltinContextFunctionsTest
 
   it should "override entries in order" in {
 
-    eval(""" put all({x:1,y:3,z:1}, {x:2,y:2,z:3}, {x:3,y:1,z:2}) """) should be(
+    eval(""" context merge({x:1,y:3,z:1}, {x:2,y:2,z:3}, {x:3,y:1,z:2}) """) should be(
       ValContext(
         StaticContext(variables =
           Map("x" -> ValNumber(3), "y" -> ValNumber(1), "z" -> ValNumber(2)))
@@ -179,7 +179,7 @@ class BuiltinContextFunctionsTest
 
   it should "combine three contexts" in {
 
-    eval(""" put all({x:1}, {y:2}, {z:3}) """) should be(
+    eval(""" context merge({x:1}, {y:2}, {z:3}) """) should be(
       ValContext(
         StaticContext(variables =
           Map("x" -> ValNumber(1), "y" -> ValNumber(2), "z" -> ValNumber(3)))
@@ -188,13 +188,42 @@ class BuiltinContextFunctionsTest
 
   it should "add a nested context" in {
 
-    eval(""" put all({x:1}, {y:{z:2}}) = {x:1, y:{z:2} } """) should be(
+    eval(""" context merge({x:1}, {y:{z:2}}) = {x:1, y:{z:2} } """) should be(
       ValBoolean(true))
   }
 
   it should "return null if one entry is not a context" in {
 
-    eval(""" put all({}, 1) """) should be(ValNull)
+    eval(""" context merge({}, 1) """) should be(ValNull)
+  }
+
+  it should "be invoked with a list of contexts" in {
+    eval(""" context merge([{x:1}, {y:2}]) = {x:1, y: 2} """) should be(
+      ValBoolean(true)
+    )
+  }
+
+  it should "be invoked with named parameters" in {
+    eval(""" context merge(contexts: [{x:1}, {y:2}]) = {x:1, y:2} """) should be(
+      ValBoolean(true)
+    )
+  }
+
+  "A put all function (deprecated)" should "behave as the context merge function" in {
+    eval(""" put all({}) = context merge({}) """) should be(ValBoolean(true))
+
+    eval(""" put all({x:1}) = context merge({x:1}) """) should be(ValBoolean(true))
+
+    eval(""" put all({x:1}, {y:2}) = context merge({x:1}, {y:2}) """) should be(ValBoolean(true))
+
+    eval(
+      """ put all({x:1,y:3,z:1}, {x:2,y:2,z:3}, {x:3,y:1,z:2}) = context merge({x:1,y:3,z:1}, {x:2,y:2,z:3}, {x:3,y:1,z:2}) """) should be(
+      ValBoolean(true)
+    )
+
+    eval(""" put all({x:1}, {y:{z:2}}) = context merge({x:1}, {y:{z:2}}) """) should be(
+      ValBoolean(true)
+    )
   }
 
   "A context function" should "return an empty context" in {


### PR DESCRIPTION
## Description

- Add the new function `context put(context: context, key: string, value: Any): context` from DMN 1.4 
  - Replaces the previous function [put()](https://camunda.github.io/feel-scala/docs/reference/builtin-functions/feel-built-in-functions-context/#put)
  - Keep the previous function for backward compatibility 
  - Mark the previous function as deprecated in the docs 
- Add the new function `context put(context: context, keys: list<string>, value: Any): context` from DMN 1.4 
  - It has the same name as the function above but a different signature
  - It allows to add a nested entry to the context 
- Add the new function `context merge(contexts: list<context>): context` from DMN 1.4 
  - Replaces the previous function [put all()](https://camunda.github.io/feel-scala/docs/reference/builtin-functions/feel-built-in-functions-context/#put-all)
  - Keep the previous function for backward compatibility 
  - Mark the previous function as deprecated in the docs 

I used a new style for the docs to highlight the different signatures of a function. Happy to receive any feedback about the new style. If the style is good, I'll apply it for the other functions as well with #555.

![image](https://user-images.githubusercontent.com/4305769/223362059-d375eab2-d0fc-4269-8915-6fda4ba84120.png)

## Related issues

closes #554
