### PR TITLE
docs: mark Camunda extensions in versions 1.15 and 1.14

### DIFF
--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-boolean.md
@@ -3,6 +3,8 @@ id: feel-built-in-functions-boolean
 title: Boolean Functions
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## not()
 
 * parameters:
@@ -15,6 +17,8 @@ not(true)
 ```
 
 ## is defined()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Checks if a given value is defined or not. A value is defined if it exists, and it is an instance of one of the FEEL data types including `null`.
 

--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-context.md
@@ -3,6 +3,8 @@ id: feel-built-in-functions-context
 title: Context Functions
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## get value()
 
 Returns the value of the context entry with the given key.
@@ -32,6 +34,8 @@ get entries({foo: 123})
 
 ## put()
 
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
 Add the given key and value to a context. Returns a new context that includes the entry. It might override an existing entry of the context.  
 
 Returns `null` if the value is not defined.
@@ -48,6 +52,8 @@ put({x:1}, "y", 2)
 ```
 
 ## put all()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Union the given contexts (two or more). Returns a new context that includes all entries of the given contexts. It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts are passed in the method.    
 

--- a/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/versioned_docs/version-1.14/reference/builtin-functions/feel-built-in-functions-string.md
@@ -3,6 +3,8 @@ id: feel-built-in-functions-string
 title: String Functions
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## substring()
 
 * parameters:
@@ -157,6 +159,8 @@ split("a;b;c;;", ";")
 ```
 
 ## extract()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Returns all matches of the pattern in the given string. Returns an empty list if the pattern doesn't
 match.

--- a/docs/versioned_docs/version-1.14/reference/language-guide/feel-variables.md
+++ b/docs/versioned_docs/version-1.14/reference/language-guide/feel-variables.md
@@ -3,6 +3,8 @@ id: feel-variables
 title: Variables
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ### Access Variables
 
 Access the value of a variable by its variable name.
@@ -47,6 +49,8 @@ Restrictions of a variable name:
   `every`, `satisfies`).
 
 ### Escape variable names
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 If a variable name or a context key contains any special character (e.g. whitespace, dash, etc.)
 then the name can be wrapped into single backquotes/backticks (e.g. ``` `foo bar` ```).

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-boolean.md
@@ -4,6 +4,8 @@ title: Boolean functions
 description: "This document outlines current boolean functions and a few examples."
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## not()
 
 - parameters:
@@ -16,6 +18,8 @@ not(true)
 ```
 
 ## is defined()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Checks if a given value is defined. A value is defined if it exists, and it is an instance of one of the FEEL data types including `null`.
 

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-context.md
@@ -4,6 +4,8 @@ title: Context functions
 description: "This document outlines context functions and a few examples."
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## get value()
 
 Returns the value of the context entry with the given key.
@@ -33,6 +35,8 @@ get entries({foo: 123})
 
 ## put()
 
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
 Add the given key and value to a context. Returns a new context that includes the entry. It might override an existing entry of the context.
 
 Returns `null` if the value is not defined.
@@ -49,6 +53,8 @@ put({x:1}, "y", 2)
 ```
 
 ## put all()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Union the given contexts (two or more). Returns a new context that includes all entries of the given contexts. It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts are passed in the method.
 

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-string.md
@@ -4,6 +4,8 @@ title: String functions
 description: "This document outlines built-in string functions and examples."
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ## substring()
 
 - parameters:
@@ -158,6 +160,8 @@ split("a;b;c;;", ";")
 ```
 
 ## extract()
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 Returns all matches of the pattern in the given string. Returns an empty list if the pattern doesn't
 match.

--- a/docs/versioned_docs/version-1.15/reference/language-guide/feel-variables.md
+++ b/docs/versioned_docs/version-1.15/reference/language-guide/feel-variables.md
@@ -4,6 +4,8 @@ title: Variables
 description: "This document outlines variables and examples."
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 ### Access variables
 
 Access the value of a variable by its variable name.
@@ -48,6 +50,8 @@ Restrictions of a variable name:
   `every`, `satisfies`).
 
 ### Escape variable names
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
 
 If a variable name or a context key contains any special character (e.g. whitespace, dash, etc.)
 then the name can be wrapped into single backquotes/backticks (e.g. ``` `foo bar` ```).


### PR DESCRIPTION
## Description

Add markers for all Camunda extensions in the docs for versions 1.15 and 1.14.

## Related issues

Backport of #550
