### PR TITLE
instance-of doesn't work for the type "date and time"

### DIFF
--- a/docs/docs/reference/language-guide/feel-boolean-expressions.md
+++ b/docs/docs/reference/language-guide/feel-boolean-expressions.md
@@ -208,7 +208,7 @@ Checks if the value is of the given type. Available type names:
 - `string`
 - `date`
 - `time`
-- `date time`
+- `date and time`
 - `days and time duration`
 - `years and months duration`
 - `list`

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -219,6 +219,7 @@ class FeelInterpreter {
             case "Any" if x != ValNull => ValBoolean(true)
             case "years and months duration" => withType(x, t => ValBoolean(t == "year-month-duration"))
             case "days and time duration" => withType(x, t => ValBoolean(t == "day-time-duration"))
+            case "date and time" => withType(x, t => ValBoolean(t == "date time"))
             case _                     => withType(x, t => ValBoolean(t == typeName))
           }
         })

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -314,14 +314,16 @@ object FeelParser {
 
   private def typeName[_: P]: P[String] =
     P(
-      durationTypeName |
+      specialTypeName |
         qualifiedName.map(_.mkString("."))
     )
 
-  private def durationTypeName[_: P]: P[String] =
+  private def specialTypeName[_: P]: P[String] =
     P(
       "years and months duration" |
-        "days and time duration"
+        "days and time duration" |
+        "date and time" |
+        "function"
     ).!
 
   private def in[_: P](value: Exp): P[Exp] =

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -113,12 +113,43 @@ class InterpreterExpressionTest
     eval("""null instance of days and time duration""") should be(ValBoolean(false))
   }
 
+  it should "be an instance of (date)" in {
+    eval("""date("2023-03-07") instance of date""") should be(ValBoolean(true))
+    eval(""" @"2023-03-07" instance of date""") should be(ValBoolean(true))
+    eval("1 instance of date") should be(ValBoolean(false))
+  }
+
+  it should "be an instance of (time)" in {
+    eval("""time("11:27:00") instance of time""") should be(ValBoolean(true))
+    eval(""" @"11:27:00" instance of time""") should be(ValBoolean(true))
+    eval("1 instance of time") should be(ValBoolean(false))
+  }
+
+  it should "be an instance of (date and time)" in {
+    eval("""date and time("2023-03-07T11:27:00") instance of date and time""") should be(ValBoolean(true))
+    eval(""" @"2023-03-07T11:27:00" instance of date and time""") should be(ValBoolean(true))
+    eval("1 instance of date and time") should be(ValBoolean(false))
+  }
+
+  it should "be an instance of (list)" in {
+    eval("[1,2,3] instance of list") should be(ValBoolean(true))
+    eval("[] instance of list") should be(ValBoolean(true))
+    eval("1 instance of list") should be(ValBoolean(false))
+  }
+
+  it should "be an instance of (context)" in {
+    eval("{x:1} instance of context") should be(ValBoolean(true))
+    eval("{} instance of context") should be(ValBoolean(true))
+    eval("1 instance of context") should be(ValBoolean(false))
+  }
+
   it should "be an instance of (multiplication)" in {
     eval("2 * 3 instance of number") should be(ValBoolean(true))
   }
 
   it should "be an instance of (function definition)" in {
-    eval(""" (function() "foo") instance of Any """) should be(ValBoolean(true))
+    eval(""" (function() "foo") instance of function """) should be(ValBoolean(true))
+    eval("""1 instance of function""") should be(ValBoolean(false))
   }
 
   it should "be a instance of Any should always pass" in {


### PR DESCRIPTION
## Description

Use the correct type name `date and time` for the `instance of` expression. Previously, it uses the wrong type name [date time](https://camunda.github.io/feel-scala/docs/reference/language-guide/feel-boolean-expressions#instance-of).

```
// DMN compliant 
@"2018-12-08T10:30:11" instance of date and time

// vs.

// not DMN compliant
@"2018-12-08T10:30:11" instance of date time
```

Support the previous type name for backward compatibility.

## Related issues

closes #543
