### PR TITLE
Fix parsing `time offset` of variable

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -186,7 +186,7 @@ object FeelParser {
 
   private def qualifiedName[_: P]: P[List[String]] =
     P(
-      name.rep(1, sep = ".")
+      (valueProperty | name).rep(1, sep = ".")
     ).map(_.toList)
 
   // a string wrapped in double quotes. it can contain an escape sequences (e.g. \', \", \\, \n, \r, \t, \u269D, \U101EF).

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -22,6 +22,8 @@ import org.camunda.feel.syntaxtree._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.time.ZonedDateTime
+
 /**
   * @author Philipp Ossler
   */
@@ -190,6 +192,15 @@ class DateTimeDurationPropertiesTest
   it should "has a time offset property" in {
 
     eval(""" date and time("2017-03-10T11:45:30+02:00").time offset """) should be(
+      ValDayTimeDuration("PT2H"))
+  }
+
+  it should "has a variable with a time offset property" in {
+
+    eval(""" dateTime.time offset """,
+         Map(
+           "dateTime" -> ValDateTime(
+             ZonedDateTime.parse("2017-03-10T11:45:30+02:00")))) should be(
       ValDayTimeDuration("PT2H"))
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

`x.time offset` would fail parsing. It considered the variable to be `x.time`. The parser would then not be able to parse ` offset`.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #547
