### PR TITLE
Add new get value function with dynamic path

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
@@ -26,6 +26,33 @@ get value({a: 1}, "b")
 // null
 ```
 
+## get value(context, keys)
+
+Returns the value of the context entry for a context path defined by the given keys.
+
+If `keys` contains the keys `[k1, k2]` then it returns the value at the nested entry `k1.k2` of the context.
+
+If `keys` are empty or the nested entry defined by the keys doesn't exist in the context, it returns `null`.
+
+**Function signature**
+
+```js
+get value(context: context, keys: list<string>): Any
+```
+
+**Examples**
+
+```js
+get value({x:1, y: {z:0}}, ["y", "z"]) 
+// 0
+
+get value({x: {y: {z:0}}}, ["x", "y"])
+// {z:0}
+
+get value({a: {b: 3}}, ["b"])
+// null
+```
+
 ## get entries(context)
 
 Returns the entries of the context as a list of key-value-pairs.

--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -128,7 +128,7 @@ class FeelEngine(
     valueMapper = valueMapper,
     variableProvider = VariableProvider.EmptyVariableProvider,
     functionProvider = FunctionProvider.CompositeFunctionProvider(
-      List(new BuiltinFunctions(clock), functionProvider))
+      List(new BuiltinFunctions(clock, valueMapper), functionProvider))
   )
 
   def evalExpression(

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -14,7 +14,7 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
     "get entries" -> List(getEntriesFunction("context"),
       getEntriesFunction("m")),
     "get value" -> List(getValueFunction(List("m", "key")),
-      getValueFunction(List("context", "key"))),
+      getValueFunction(List("context", "key")), getValueFunction2),
     "context put" -> List(contextPutFunction, contextPutFunction2),
     "put" -> List(contextPutFunction), // deprecated function name
     "context merge" -> List(contextMergeFunction),
@@ -36,6 +36,7 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
   private def getValueFunction(parameters: List[String]) = builtinFunction(
     params = parameters,
     invoke = {
+      case List(context: ValContext, keys: ValList) => getValueFunction2.invoke(List(context, keys))
       case List(ValContext(c), ValString(key)) =>
         c.variableProvider
           .getVariable(key)
@@ -43,6 +44,13 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
     }
   )
 
+  private def getValueFunction2 = builtinFunction(
+    params = List("context", "keys"),
+    invoke = {
+      case List(ValContext(context), ValList(keys)) if isListOfStrings(keys) => ???
+      case List(ValContext(_), ValList(_)) => ValNull
+    }
+  )
   private def contextPutFunction = builtinFunction(
     params = List("context", "key", "value"),
     invoke = {

--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -4,10 +4,11 @@ import org.camunda.feel.context.Context
 import org.camunda.feel.context.Context.{EmptyContext, StaticContext}
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
 import org.camunda.feel.syntaxtree.{Val, ValContext, ValError, ValList, ValNull, ValString}
+import org.camunda.feel.valuemapper.ValueMapper
 
 import scala.annotation.tailrec
 
-object ContextBuiltinFunctions {
+class ContextBuiltinFunctions(valueMapper: ValueMapper) {
 
   def functions = Map(
     "get entries" -> List(getEntriesFunction("context"),

--- a/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
@@ -18,19 +18,11 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.FeelEngineClock
 import org.camunda.feel.context.FunctionProvider
-import org.camunda.feel.impl.builtin.{
-  BooleanBuiltinFunctions,
-  ContextBuiltinFunctions,
-  ConversionBuiltinFunctions,
-  ListBuiltinFunctions,
-  NumericBuiltinFunctions,
-  StringBuiltinFunctions,
-  TemporalBuiltinFunctions,
-  RangeBuiltinFunction
-}
+import org.camunda.feel.impl.builtin.{BooleanBuiltinFunctions, ContextBuiltinFunctions, ConversionBuiltinFunctions, ListBuiltinFunctions, NumericBuiltinFunctions, RangeBuiltinFunction, StringBuiltinFunctions, TemporalBuiltinFunctions}
 import org.camunda.feel.syntaxtree.ValFunction
+import org.camunda.feel.valuemapper.ValueMapper
 
-class BuiltinFunctions(clock: FeelEngineClock) extends FunctionProvider {
+class BuiltinFunctions(clock: FeelEngineClock, valueMapper: ValueMapper) extends FunctionProvider {
 
   override def getFunctions(name: String): List[ValFunction] =
     functions.getOrElse(name, List.empty)
@@ -43,7 +35,7 @@ class BuiltinFunctions(clock: FeelEngineClock) extends FunctionProvider {
       StringBuiltinFunctions.functions ++
       ListBuiltinFunctions.functions ++
       NumericBuiltinFunctions.functions ++
-      ContextBuiltinFunctions.functions ++
+      new ContextBuiltinFunctions(valueMapper).functions ++
       RangeBuiltinFunction.functions ++
       new TemporalBuiltinFunctions(clock).functions
 

--- a/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
@@ -87,7 +87,7 @@ trait FeelIntegrationTest {
 
   val rootContext: EvalContext = EvalContext.wrap(
     Context.StaticContext(variables = Map.empty,
-                          functions = new BuiltinFunctions(clock).functions)
+                          functions = new BuiltinFunctions(clock, ValueMapper.defaultValueMapper).functions)
   )(ValueMapper.defaultValueMapper)
 
   def withClock(testCode: TimeTravelClock => Any): Unit = {


### PR DESCRIPTION
## Description

Add a new get value function with a new signature. With this function, a user can dynamically pass a path to obtain a nested property in a given context.

## Related issues

closes [#11293](https://github.com/camunda/zeebe/issues/11293)
