### PR TITLE
docs: function invocation with wrong argument types

### DIFF
--- a/docs/docs/reference/language-guide/feel-functions.md
+++ b/docs/docs/reference/language-guide/feel-functions.md
@@ -21,6 +21,13 @@ contains(string: "me@camunda.com", match: ".de")
 // false
 ```
 
+:::info GOOD TO KNOW
+
+If an expression invokes a built-in function but the argument types don't match the function 
+signature, the invocation returns `null`. 
+
+:::
+
 ### User-defined
 
 ```js

--- a/docs/versioned_docs/version-1.14/reference/language-guide/feel-functions.md
+++ b/docs/versioned_docs/version-1.14/reference/language-guide/feel-functions.md
@@ -20,7 +20,14 @@ contains(string: "me@camunda.com", match: ".de")
 // false
 ```
 
-### User-Defined
+:::info GOOD TO KNOW
+
+If an expression invokes a built-in function but the argument types don't match the function 
+signature, the invocation returns `null`. 
+
+:::
+
+### User-defined
 
 ```js
 function(a,b) e

--- a/docs/versioned_docs/version-1.15/reference/language-guide/feel-functions.md
+++ b/docs/versioned_docs/version-1.15/reference/language-guide/feel-functions.md
@@ -21,6 +21,13 @@ contains(string: "me@camunda.com", match: ".de")
 // false
 ```
 
+:::info GOOD TO KNOW
+
+If an expression invokes a built-in function but the argument types don't match the function 
+signature, the invocation returns `null`. 
+
+:::
+
 ### User-defined
 
 ```js


### PR DESCRIPTION
## Description

Describe the result of a function invocation if the argument types don't match the signature.

## Related issues

contributes to #581 
