### PR TITLE
docs: split functions by their signatures 

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
@@ -6,18 +6,27 @@ description: "This document outlines current boolean functions and a few example
 
 import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
 
-## not()
+## not(negand)
 
-- parameters:
-  - `negand`: boolean
-- result: boolean
+Returns the logical negation of the given value.
+
+**Function signature**
+
+```js
+not(negand: boolean): boolean
+```
+
+**Examples**
 
 ```js
 not(true)
 // false
+
+not(null) 
+// null
 ```
 
-## is defined()
+## is defined(value)
 
 <MarkerCamundaExtension></MarkerCamundaExtension>
 
@@ -25,9 +34,13 @@ Checks if a given value is defined. A value is defined if it exists, and it is a
 
 The function can be used to check if a variable or a context entry (e.g. a property of a variable) exists. It allows differentiating between a `null` variable and a value that doesn't exist.
 
-- parameters:
-  - `value`: any
-- result: boolean
+**Function signature**
+
+```js
+is defined(value: Any): boolean
+```
+
+**Examples**
 
 ```js
 is defined(1)

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
@@ -6,27 +6,39 @@ description: "This document outlines context functions and a few examples."
 
 import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
 
-## get value()
+## get value(context, key)
 
 Returns the value of the context entry with the given key.
 
-- parameters:
-  - `context`: context
-  - `key`: string
-- result: any
+**Function signature**
+
+```js
+get value(context: context, key: string): Any
+```
+
+**Examples**
 
 ```js
 get value({foo: 123}, "foo") 
 // 123
+
+get value({a: 1}, "b")
+// null
 ```
 
-## get entries()
+## get entries(context)
 
 Returns the entries of the context as a list of key-value-pairs.
 
-- parameters:
-  - `context`: context
-- result: list of context which contains two entries for "key" and "value"
+**Function signature**
+
+```js
+get entries(context: context): list<context>
+```
+
+The return value is a list of contexts. Each context contains two entries for "key" and "value".
+
+**Examples**
 
 ```js
 get entries({foo: 123})

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -47,7 +47,7 @@ number("1500.5")
 
 ## context(entries)
 
-Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entries).
+Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entriescontext).
 
 Each key-value pair must be a context with two entries: `key` and `value`. The entry with name `key` must have a value of the type `string`.
 

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -4,64 +4,151 @@ title: Conversion functions
 description: "This document outlines conversion functions and a few examples."
 ---
 
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
+
 Convert a value into a different type.
 
-## date()
+## date(from)
 
-- parameters:
-  - `from`: string / date-time
-  - or `year`, `month`, `day`: number
-- result: date
+Returns a date from the given value.
+
+**Function signature**
 
 ```js
-date(birthday) 
+date(from: string): date
+```
+
+Parses the given string into a date.
+
+```js
+date(from: date and time): date
+```
+
+Extracts the date component from the given date and time.
+
+**Examples**
+
+```js
+date("2018-04-29") 
 // date("2018-04-29")
 
 date(date and time("2012-12-25T11:00:00"))
 // date("2012-12-25")
+```
 
+## date(year, month, day)
+
+Returns a date from the given components.
+
+**Function signature**
+
+```js
+date(year: number, month: number, day: number): date
+```
+
+**Examples**
+
+```js
 date(2012, 12, 25)
 // date("2012-12-25")
 ```
 
-## time()
+## time(from)
 
-- parameters:
-  - `from`: string / date-time
-  - or `hour`, `minute`, `second`: number
-    - (optional) `offset`: day-time-duration
-- result: time
+Returns a time from the given value.
+
+**Function signature**
 
 ```js
-time(lunchTime) 
+time(from: string): time
+```
+
+Parses the given string into a time.
+
+```js
+time(from: date and time): time
+```
+
+Extracts the time component from the given date and time.
+
+**Examples**
+
+```js
+time("12:00:00") 
 // time("12:00:00")
 
 time(date and time("2012-12-25T11:00:00"))
 // time("11:00:00")
-
-time(23, 59, 0)
-// time("23:59:00")
-
-time(14, 30, 0, duration("PT1H"))
-// time("15:30:00")
 ```
 
-## date and time()
+## time(hour, minute, second)
 
-Constructs a data-time value from the given parameters.
+Returns a time from the given components.
 
-- parameters (different options):
-  - (`date`: date, `time`: time)
-    - combines `date` and `time`
-  - (`date`: date-time, `time`: time)
-    - takes the date component of `date` and combines with `time`
-  - (`date`: date-time, `timezone`: string)
-    - combines `date` and `timezone`
-    - if `date` has a different timezone than `timezone` then it adjusts the time
-  - (`from`: string) 
-    - parses `from` into a date-time
-    - the string should match the format of a [date-time](../language-guide/feel-data-types.md#date-time) literal 
-- result: date-time
+**Function signature**
+
+```js
+time(hour: number, minute: number, second: number): time
+```
+
+**Examples**
+
+```js
+time(23, 59, 0)
+// time("23:59:00")
+```
+
+## time(hour, minute, second, offset)
+
+Returns a time from the given components, including a timezone offset.
+
+**Function signature**
+
+```js
+time(hour: number, minute: number, second: number, offset: days and time duration): time
+```
+
+**Examples**
+
+```js
+time(14, 30, 0, duration("PT1H"))
+// time("14:30:00+01:00")
+```
+
+## date and time(from)
+
+Parses the given string into a date and time.
+
+**Function signature**
+
+```js
+date and time(from: string): date and time
+```
+
+**Examples**
+
+```js
+date and time("2018-04-29T009:30:00") 
+// date and time("2018-04-29T009:30:00")
+```
+
+## date and time(date, time)
+
+Returns a date and time from the given components.
+
+**Function signature**
+
+```js
+date and time(date: date, time: time): date and time
+```
+
+```js
+date and time(date: date and time, time: time): date and time
+```
+
+Returns a date and time value that consists of the date component of `date` combined with `time`. 
+
+**Examples**
 
 ```js
 date and time(date("2012-12-24"),time("T23:59:00")) 
@@ -69,59 +156,101 @@ date and time(date("2012-12-24"),time("T23:59:00"))
 
 date and time(date and time("2012-12-25T11:00:00"),time("T23:59:00"))
 // date and time("2012-12-25T23:59:00")
+```
 
-date and time(birthday) 
-// date and time("2018-04-29T009:30:00")
+## date and time(date, timezone)
 
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
+Returns the given date and time value at the given timezone.
+
+If `date` has a different timezone than `timezone` then it adjusts the time to match the local time of `timezone`.
+ 
+**Function signature**
+
+```js
+date and time(date: date and time, timezone: string): date and time
+```
+
+**Examples**
+
+```js
 date and time(@"2020-07-31T14:27:30@Europe/Berlin", "America/Los_Angeles")
 // date and time("2020-07-31T05:27:30@America/Los_Angeles")
 
 date and time(@"2020-07-31T14:27:30", "Z")
-// date and time("2020-07-31T05:27:30Z")
+// date and time("2020-07-31T12:27:30Z")
 ```
 
-## duration()
+## duration(from)
 
-- parameters:
-  - `from`: string
-- result: day-time-duration or year-month-duration
+Parses the given string into a duration. The duration is either a days and time duration or a years and months duration.
+
+**Function signature**
 
 ```js
-duration(weekDays)
+duration(from: string): days and time duration
+```
+
+```js
+duration(from: string): years and months duration
+```
+
+**Examples**
+
+```js
+duration("P5D")
 // duration("P5D")
 
-duration(age)
+duration("P32Y")
 // duration("P32Y")
 ```
 
-## years and months duration()
+## years and months duration(from, to)
 
-- parameters:
-  - `from`: date
-  - `to`: date
-- result: year-month-duration
+Returns the years and months duration between `from` and `to`.
+
+**Function signature**
+
+```js
+years and months duration(from: date, to: date): years and months duration
+```
+
+**Examples**
 
 ```js
 years and months duration(date("2011-12-22"), date("2013-08-24"))
 // duration("P1Y8M")
 ```
 
-## number()
+## number(from)
 
-- parameters:
-  - `from`: string
-- result: number
+Parses the given string to a number.
+
+**Function signature**
+
+```js
+number(from: string): number
+```
+
+**Examples**
 
 ```js
 number("1500.5") 
 // 1500.5
 ```
 
-## string()
+## string(from)
 
-- parameters:
-  - `from`: any
-- result: string
+Returns the given value as a string representation.
+
+**Function signature**
+
+```js
+string(from: Any): string
+```
+
+**Examples**
 
 ```js
 string(1.1) 
@@ -131,7 +260,7 @@ string(date("2012-12-25"))
 // "2012-12-25"
 ```
 
-## context()
+## context(entries)
 
 Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entries).
 
@@ -141,9 +270,13 @@ It might override context entries if the keys are equal. The entries are overrid
 
 Returns `null` if one of the entries is not a context or if a context doesn't contain the required entries.
 
-- parameters:
-  - `entries`: list of contexts
-- result: context
+**Function signature**
+
+```js
+context(entries: list<context>): context
+```
+
+**Examples**
 
 ```js
 context([{"key":"a", "value":1}, {"key":"b", "value":2}])

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -8,6 +8,67 @@ import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension"
 
 Convert a value into a different type.
 
+## string(from)
+
+Returns the given value as a string representation.
+
+**Function signature**
+
+```js
+string(from: Any): string
+```
+
+**Examples**
+
+```js
+string(1.1) 
+// "1.1"
+
+string(date("2012-12-25"))
+// "2012-12-25"
+```
+
+## number(from)
+
+Parses the given string to a number.
+
+**Function signature**
+
+```js
+number(from: string): number
+```
+
+**Examples**
+
+```js
+number("1500.5") 
+// 1500.5
+```
+
+## context(entries)
+
+Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entries).
+
+Each key-value pair must be a context with two entries: `key` and `value`. The entry with name `key` must have a value of the type `string`.
+
+It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts in the given list.
+
+Returns `null` if one of the entries is not a context or if a context doesn't contain the required entries.
+
+**Function signature**
+
+```js
+context(entries: list<context>): context
+```
+
+**Examples**
+
+```js
+context([{"key":"a", "value":1}, {"key":"b", "value":2}])
+// {a:1, b:2}
+```
+
+
 ## date(from)
 
 Returns a date from the given value.
@@ -221,64 +282,4 @@ years and months duration(from: date, to: date): years and months duration
 ```js
 years and months duration(date("2011-12-22"), date("2013-08-24"))
 // duration("P1Y8M")
-```
-
-## number(from)
-
-Parses the given string to a number.
-
-**Function signature**
-
-```js
-number(from: string): number
-```
-
-**Examples**
-
-```js
-number("1500.5") 
-// 1500.5
-```
-
-## string(from)
-
-Returns the given value as a string representation.
-
-**Function signature**
-
-```js
-string(from: Any): string
-```
-
-**Examples**
-
-```js
-string(1.1) 
-// "1.1"
-
-string(date("2012-12-25"))
-// "2012-12-25"
-```
-
-## context(entries)
-
-Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entries).
-
-Each key-value pair must be a context with two entries: `key` and `value`. The entry with name `key` must have a value of the type `string`.
-
-It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts in the given list.
-
-Returns `null` if one of the entries is not a context or if a context doesn't contain the required entries.
-
-**Function signature**
-
-```js
-context(entries: list<context>): context
-```
-
-**Examples**
-
-```js
-context([{"key":"a", "value":1}, {"key":"b", "value":2}])
-// {a:1, b:2}
 ```

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-list.md
@@ -4,35 +4,57 @@ title: List functions
 description: "This document outlines built-in list functions and examples."
 ---
 
-## list contains()
+import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
 
-- parameters:
-  - `list`: list
-  - `element`: any
-- result: boolean
+## list contains(list, element)
+
+Returns `true` if the given list contains the element. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+list contains(list: list, element: Any): boolean
+```
+
+**Examples**
 
 ```js
 list contains([1,2,3], 2) 
 // true
 ```
 
-## count()
+## count(list)
 
-- parameters:
-  - `list`: list
-- result: number
+Returns the number of elements of the given list.
+
+**Function signature**
+
+```js
+count(list: list): number
+```
+
+**Examples**
 
 ```js
 count([1,2,3]) 
 // 3
 ```
 
-## min()
+## min(list)
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+Returns the minimum of the given list.
+
+**Function signature**
+
+```js
+min(list: list): Any
+```
+
+All elements in `list` should have the same type and be comparable. 
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 min([1,2,3]) 
@@ -42,13 +64,21 @@ min(1,2,3)
 // 1
 ```
 
-## max()
+## max(list)
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+Returns the maximum of the given list.
 
+**Function signature**
+
+```js
+max(list: list): Any
+```
+
+All elements in `list` should have the same type and be comparable.
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 ```js
 max([1,2,3]) 
 // 3
@@ -57,12 +87,19 @@ max(1,2,3)
 // 3
 ```
 
-## sum()
+## sum(list)
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+Returns the sum of the given list of numbers.
+
+**Function signature**
+
+```js
+sum(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 sum([1,2,3]) 
@@ -72,12 +109,19 @@ sum(1,2,3)
 // 6
 ```
 
-## product()
+## product(list)
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+Returns the product of the given list of numbers.
+
+**Function signature**
+
+```js
+product(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 product([2, 3, 4])
@@ -87,14 +131,19 @@ product(2, 3, 4)
 // 24
 ```
 
-## mean()
+## mean(list)
 
-Returns the arithmetic mean (i.e. average).
+Returns the arithmetic mean (i.e. average) of the given list of numbers.
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+**Function signature**
+
+```js
+mean(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 mean([1,2,3])
@@ -104,14 +153,19 @@ mean(1,2,3)
 // 2
 ```
 
-## median()
+## median(list)
 
-Returns the median element of the list of numbers.
+Returns the median element of the given list of numbers.
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+**Function signature**
+
+```js
+median(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 median(8, 2, 5, 3, 4)
@@ -121,14 +175,19 @@ median([6, 1, 2, 3])
 // 2.5
 ```
 
-## stddev()
+## stddev(list)
 
-Returns the standard deviation.
+Returns the standard deviation of the given list of numbers.
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: number
+**Function signature**
+
+```js
+stddev(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 stddev(2, 4, 7, 5)
@@ -138,14 +197,19 @@ stddev([2, 4, 7, 5])
 // 2.0816659994661326
 ```
 
-## mode()
+## mode(list)
 
-Returns the mode of the list of numbers.
+Returns the mode of the given list of numbers.
 
-- parameters:
-  - `list`: list of numbers
-  - or numbers as varargs
-- result: list of numbers
+**Function signature**
+
+```js
+mode(list: list<number>): number
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 mode(6, 3, 9, 6, 6) 
@@ -155,12 +219,21 @@ mode([6, 1, 9, 6, 1])
 // [1, 6]
 ```
 
-## and() / all()
+## all(list)
 
-- parameters:
-  - `list`: list of booleans
-  - or booleans as varargs
-- result: boolean
+Returns `false` if any element of the given list is `false`. Otherwise, returns `true`.
+
+If the given list is empty, it returns `true`. 
+
+**Function signature**
+
+```js
+all(list: list<boolean>): boolean
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 and([true,false])
@@ -170,12 +243,26 @@ and(false,null,true)
 // false
 ```
 
-## or() / any()
+:::info
+The function `all()` replaced the previous function `and()`. The previous function is deprecated and 
+should not be used anymore.
+:::
 
-- parameters:
-  - `list`: list of booleans
-  - or booleans as varargs
-- result: boolean
+## any(list)
+
+Returns `true` if any element of the given list is `true`. Otherwise, returns `false`.
+
+If the given list is empty, it returns `false`.
+
+**Function signature**
+
+```js
+any(list: list<boolean>): boolean
+```
+
+The parameter `list` can be passed as a list or as a sequence of elements.
+
+**Examples**
 
 ```js
 or([false,true])
@@ -185,39 +272,81 @@ or(false,null,true)
 // true
 ```
 
-## sublist()
+:::info
+The function `any()` replaced the previous function `or()`. The previous function is deprecated and
+should not be used anymore.
+:::
 
-- parameters:
-  - `list`: list
-  - `start position`: number
-  - (optional) `length`: number
-- result: list
+## sublist(list, start position)
+
+Returns a partial list of the given value starting at `start position`.
+
+**Function signature**
+
+```js
+sublist(list: list, start position: number): list
+```
+
+The `start position` starts at the index `1`. The last position is `-1`.
+
+**Examples**
 
 ```js
 sublist([1,2,3], 2)
 // [2,3]
+```
 
+## sublist(list, start position, length)
+
+Returns a partial list of the given value starting at `start position`.
+
+**Function signature**
+
+```js
+sublist(list: list, start position: number, length: number): list
+```
+
+The `start position` starts at the index `1`. The last position is `-1`.
+
+**Examples** 
+
+```js
 sublist([1,2,3], 1, 2)
 // [1,2]
 ```
 
-## append()
+## append(list, items)
 
-- parameters:
-  - `list`: list
-  - `items`: elements as varargs
-- result: list
+Returns the given list with all `items` appended.
+
+**Function signature**
+
+```js
+append(list: list, items: Any): list
+```
+
+The parameter `items` can be a single element or a sequence of elements.
+
+**Examples**
 
 ```js
 append([1], 2, 3)
 // [1,2,3]
 ```
 
-## concatenate()
+## concatenate(lists)
 
-- parameters:
-  - `lists`: lists as varargs
-- result: list
+Returns a list that includes all elements of the given lists.
+
+**Function signature**
+
+```js
+concatenate(lists: list): list
+```
+
+The parameter `lists` is a sequence of lists.
+
+**Examples**
 
 ```js
 concatenate([1,2],[3]) 
@@ -227,128 +356,226 @@ concatenate([1],[2],[3])
 // [1,2,3]
 ```
 
-## insert before()
+## insert before(list, position, newItem)
 
-- parameters:
-  - `list`: list
-  - `position`: number
-  - `newItem`: any
-- result: list
+Returns the given list with `newItem` inserted at `position`.
+
+**Function signature**
+
+```js
+insert before(list: list, position: number, newItem: Any): list
+```
+
+The `position` starts at the index `1`. The last position is `-1`.
+
+**Examples**
 
 ```js
 insert before([1,3],1,2) 
 // [1,2,3]
 ```
 
-## remove()
+## remove(list, position)
 
-- parameters:
-  - `list`: list
-  - `position`: number
-- result: list
+Returns the given list without the element at `position`.
+
+**Function signature**
+
+```js
+remove(list: list, position: number): list
+```
+
+The `position` starts at the index `1`. The last position is `-1`.
+
+**Examples**
 
 ```js
 remove([1,2,3], 2) 
 // [1,3]
 ```
 
-## reverse()
+## reverse(list)
 
-- parameters:
-  - `list`: list
-- result: list
+Returns the given list in revered order.
+
+**Function signature**
+
+```js
+reverse(list: list): list
+```
+
+**Examples**
 
 ```js
 reverse([1,2,3]) 
 // [3,2,1]
 ```
 
-## index of()
+## index of(list, match)
 
-- parameters:
-  - `list`: list
-  - `match`: any
-- result: list of numbers
+Returns an ascending list of positions containing `match`.
+
+**Function signature**
+
+```js
+index of(list: list, match: Any): list<number>
+```
+
+**Examples**
 
 ```js
 index of([1,2,3,2],2) 
 // [2,4]
 ```
 
-## union()
+## union(list)
 
-- parameters:
-  - `lists`: lists as varargs
-- result: list
+Returns a list that includes all elements of the given lists without duplicates.
+
+**Function signature**
+
+```js
+union(list: list): list
+```
+
+The parameter `list` is a sequence of lists.
+
+**Examples**
 
 ```js
 union([1,2],[2,3])
 // [1,2,3]
 ```
 
-## distinct values()
+## distinct values(list)
 
-- parameters:
-  - `list`: list
-- result: list
+Returns the given list without duplicates.
+
+**Function signature**
+
+```js
+distinct values(list: list): list
+```
+
+**Examples**
 
 ```js
 distinct values([1,2,3,2,1])
 // [1,2,3]
 ```
 
-## flatten()
+## flatten(list)
 
-- parameters:
-  - `list`: list
-- result: list
+Returns a list that includes all elements of the given list without nested lists. 
+
+**Function signature**
+
+```js
+flatten(list: list): list
+```
+
+**Examples**
 
 ```js
 flatten([[1,2],[[3]], 4])
 // [1,2,3,4]
 ```
 
-## sort()
+## sort(list, precedes)
 
-- parameters:
-  - `list`: list
-  - `precedes`: function with two arguments and boolean result
-- result: list
+Returns the given list sorted by the `precedes` function.
+
+**Function signature**
+
+```js
+sort(list: list, precedes: function<(Any, Any) -> boolean>): list
+```
+
+**Examples**
 
 ```js
 sort(list: [3,1,4,5,2], precedes: function(x,y) x < y) 
 // [1,2,3,4,5]
 ```
 
-## string join()
+## string join(list)
 
-This joins a list of strings into a single string. This is similar to
+Joins a list of strings into a single string. This is similar to
 Java's [joining](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Collectors.html#joining(java.lang.CharSequence,java.lang.CharSequence,java.lang.CharSequence)>)
 function.
 
 If an item of the list is `null`, the item is ignored for the result string. If an item is
 neither a string nor `null`, the function returns `null` instead of a string.
 
-- Parameters:
-  - `list`: The list of strings to join
-  - `delimiter`: (Optional) The string used between each element (default: empty string)
-  - `prefix`: (Optional) The string used at the beginning of the joined result (default:
-    empty string)
-  - `suffix`: (Optional) The string used at the end of the joined result (default: empty
-    string)
-- Result: The joined list as a string
+**Function signature**
+
+```js
+string join(list: list<string>): string
+```
+
+**Examples**
 
 ```js
 string join(["a","b","c"])
 // "abc"
-string join(["a"], "X")
-// "a"
-string join(["a","b","c"], ", ")
-// "a, b, c"
-string join(["a","b","c"], ", ", "[", "]")
-// "[a, b, c]"
+
 string join(["a",null,"c"])
 // "ac"
+
 string join([])
 // ""
+```
+
+## string join(list, delimiter)
+
+Joins a list of strings into a single string. This is similar to
+Java's [joining](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Collectors.html#joining(java.lang.CharSequence,java.lang.CharSequence,java.lang.CharSequence)>)
+function.
+
+If an item of the list is `null`, the item is ignored for the result string. If an item is
+neither a string nor `null`, the function returns `null` instead of a string.
+
+The resulting string contains a `delimiter` between each element.
+
+**Function signature**
+
+```js
+string join(list: list<string>, delimiter: string): string
+```
+
+**Examples**
+
+```js
+string join(["a"], "X")
+// "a"
+
+string join(["a","b","c"], ", ")
+// "a, b, c"
+```
+
+## string join(list, delimiter, prefix, suffix)
+
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
+Joins a list of strings into a single string. This is similar to
+Java's [joining](<https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Collectors.html#joining(java.lang.CharSequence,java.lang.CharSequence,java.lang.CharSequence)>)
+function.
+
+If an item of the list is `null`, the item is ignored for the result string. If an item is
+neither a string nor `null`, the function returns `null` instead of a string.
+
+The resulting string starts with `prefix`, contains a `delimiter` between each element, and ends 
+with `suffix`.
+
+**Function signature**
+
+```js
+string join(list: list<string>, delimiter: string, prefix: string, suffix: string): string
+```
+
+**Examples**
+
+```js
+string join(["a","b","c"], ", ", "[", "]")
+// "[a, b, c]"
 ```

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-numeric.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-numeric.md
@@ -6,15 +6,17 @@ description: "This document outlines built-in numeric functions and examples."
 
 import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
 
-## decimal()
+## decimal(n, scale)
 
-Round the given number at the given scale using the given rounding mode. If no rounding mode is passed in, it uses `HALF_EVEN` as default.
+Rounds the given value at the given scale.
 
-- parameters:
-  - `n`: number
-  - `scale`: number
-  - (optional) `mode`: string - one of `UP, DOWN, CEILING, FLOOR, HALF_UP, HALF_DOWN, HALF_EVEN, UNNECESSARY` (default: `HALF_EVEN`)
-- result: number
+**Function signature**
+
+```js
+decimal(n: number, scale: number): number
+```
+
+**Examples**
 
 ```js
 decimal(1/3, 2)
@@ -22,16 +24,19 @@ decimal(1/3, 2)
 
 decimal(1.5, 0) 
 // 2
-
-decimal(2.5, 0, "half_up")
-// 3
 ```
 
-## floor()
+## floor(n)
 
-- parameters:
-  - `n`: number
-- result: number
+Rounds the given value with rounding mode flooring.
+
+**Function signature**
+
+```js
+floor(n: number): number
+```
+
+**Examples**
 
 ```js
 floor(1.5)
@@ -39,19 +44,36 @@ floor(1.5)
 
 floor(-1.5)
 // -2
+```
 
+## floor(n, scale)
+
+Rounds the given value with rounding mode flooring at the given scale.
+
+**Function signature**
+
+```js
+floor(n: number, scale: number): number
+```
+
+**Examples**
+
+```js
 floor(-1.56, 1)
 // -1.6
 ```
 
-## ceiling()
+## ceiling(n)
 
-Round the given number at the given scale using the ceiling rounding mode.
+Rounds the given value with rounding mode ceiling.
 
-- parameters:
-  - `n`: number
-  -(optional) `scale`: number (default: `0`)
-- result: number
+**Function signature**
+
+```js
+ceiling(n: number): number
+```
+
+**Examples**
 
 ```js
 ceiling(1.5)
@@ -59,19 +81,56 @@ ceiling(1.5)
 
 ceiling(-1.5)
 // -1
+```
 
+## ceiling(n, scale)
+
+Rounds the given value with rounding mode ceiling at the given scale.
+
+**Function signature**
+
+```js
+ceiling(n: number, scale: number): number
+```
+
+**Examples**
+
+```js
 ceiling(-1.56, 1)
 // -1.5
 ```
 
-## round up()
+## round up(n)
 
-Round the given number at the given scale using the round-up rounding mode.
+Rounds the given value with the rounding mode round-up.
 
-* parameters:
-  * `n`: number
-  *  (optional) `scale`: number (default: `0`)
-* result: number
+**Function signature**
+
+```js
+round up(n: number): number
+```
+
+**Examples**
+
+```js
+round up(5.5) 
+// 6
+
+round up(-5.5)
+// -6
+```
+
+## round up(n, scale)
+
+Rounds the given value with the rounding mode round-up at the given scale.
+
+**Function signature**
+
+```js
+round up(n: number, scale: number): number
+```
+
+**Examples**
 
 ```js
 round up(5.5) 
@@ -86,15 +145,17 @@ round up(1.121, 2)
 round up(-1.126, 2)
 // -1.13
 ```
+## round down(n)
 
-## round down()
+Rounds the given value with the rounding mode round-down.
 
-Round the given number at the given scale using the round-down rounding mode.
+**Function signature**
 
-* parameters:
-  * `n`: number
-  *  (optional) `scale`: number (default: `0`)
-* result: number
+```js
+round down(n: number): number
+```
+
+**Examples**
 
 ```js
 round down(5.5)
@@ -102,7 +163,21 @@ round down(5.5)
 
 round down (-5.5)
 // -5
+```
 
+## round down(n, scale)
+
+Rounds the given value with the rounding mode round-down at the given scale.
+
+**Function signature**
+
+```js
+round down(n: number, scale: number): number
+```
+
+**Examples**
+
+```js
 round down (1.121, 2)
 // 1.12
 
@@ -110,14 +185,17 @@ round down (-1.126, 2)
 // -1.12
 ```
 
-## round half up()
+## round half up(n)
 
-Round the given number at the given scale using the round-half-up rounding mode.
+Rounds the given value with the rounding mode round-half-up.
 
-* parameters:
-  * `n`: number
-  *  (optional) `scale`: number (default: `0`)
-* result: number
+**Function signature**
+
+```js
+round half up(n: number): number
+```
+
+**Examples**
 
 ```js
 round half up(5.5) 
@@ -125,7 +203,21 @@ round half up(5.5)
 
 round half up(-5.5)
 // -6
+```
 
+## round half up(n, scale)
+
+Rounds the given value with the rounding mode round-half-up at the given scale.
+
+**Function signature**
+
+```js
+round half up(n: number, scale: number): number
+```
+
+**Examples**
+
+```js
 round half up(1.121, 2) 
 // 1.12
 
@@ -133,14 +225,17 @@ round half up(-1.126, 2)
 // -1.13
 ```
 
-## round half down()
+## round half down(n)
 
-Round the given number at the given scale using the round-half-down rounding mode.
+Rounds the given value with the rounding mode round-half-down.
 
--parameters:
-  - `n`: number
-  -(optional) `scale`: number (default: `0`)
-- result: number
+**Function signature**
+
+```js
+round half down(n: number): number
+```
+
+**Examples**
 
 ```js
 round half down (5.5)
@@ -148,7 +243,21 @@ round half down (5.5)
 
 round half down (-5.5)
 // -5
+```
 
+## round half down(n, scale)
+
+Rounds the given value with the rounding mode round-half-down at the given scale.
+
+**Function signature**
+
+```js
+round half down(n: number, scale: number): number
+```
+
+**Examples**
+
+```js
 round half down (1.121, 2)
 // 1.12
 
@@ -156,13 +265,17 @@ round half down (-1.126, 2)
 // -1.13
 ```
 
-## abs()
+## abs(number)
 
 Returns the absolute value of the given numeric value.
 
-- parameters:
-  - `number`: number
-- result: number
+**Function signature**
+
+```js
+abs(number: number): number
+```
+
+**Examples**
 
 ```js
 abs(10)
@@ -172,66 +285,85 @@ abs(-10)
 // 10
 ```
 
-## modulo()
+## modulo(dividend, divisor)
 
 Returns the remainder of the division of dividend by divisor.
 
-- parameters:
-  - `dividend`: number
-  - `divisor`: number
-- result: number
+**Function signature**
+
+```js
+modulo(dividend: number, divisor: number): number
+```
+
+**Examples**
 
 ```js
 modulo(12, 5)
 // 2
 ```
 
-## sqrt()
+## sqrt(number)
 
-Returns the square root.
+Returns the square root of the given value.
 
-- parameters:
-  - `number`: number
-- result: number
+**Function signature**
+
+```js
+sqrt(number: number): number
+```
+
+**Examples**
 
 ```js
 sqrt(16)
 // 4
 ```
 
-## log()
+## log(number)
 
-Returns the natural logarithm (base e) of the number.
+Returns the natural logarithm (base e) of the given value.
 
-- parameters:
-  - `number`: number
-- result: number
+**Function signature**
+
+```js
+log(number: number): number
+```
+
+**Examples**
 
 ```js
 log(10)
 // 2.302585092994046
 ```
 
-## exp()
+## exp(number)
 
-Returns the Euler’s number e raised to the power of number .
+Returns the Euler’s number e raised to the power of the given number .
 
-- parameters:
-  - `number`: number
-- result: number
+**Function signature**
+
+```js
+exp(number: number): number
+```
+
+**Examples**
 
 ```js
 exp(5)
 // 148.4131591025766
 ```
 
-## odd()
+## odd(number)
 
-Returns `true` if the given numeric value is odd. Otherwise, it returns `false`.
+Returns `true` if the given value is odd. Otherwise, returns `false`.
 
-- parameters:
-  - `number`: number
-- result: boolean
+**Function signature**
+
+```js
+odd(number: number): boolean
+```
+
+**Examples**
 
 ```js
 odd(5)
@@ -241,13 +373,17 @@ odd(2)
 // false
 ```
 
-## even()
+## even(number)
 
-Returns `true` if the given numeric value is even. Otherwise, it returns `false`.
+Returns `true` if the given is even. Otherwise, returns `false`.
 
-- parameters:
-  - `number`: number
-- result: boolean
+**Function signature**
+
+```js
+even(number: number): boolean
+```
+
+**Examples**
 
 ```js
 even(5)
@@ -263,8 +399,13 @@ even(2)
 
 Returns a random number between `0` and `1`. 
 
-- parameters: none
-- result: number
+**Function signature**
+
+```js
+random number(): number
+```
+
+**Examples**
 
 ```js
 random number()

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-range.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-range.md
@@ -19,14 +19,15 @@ A scalar value must be of the following type:
 
 ![range functions overview](../assets/feel-built-in-functions-range-overview.png)
 
-## before()
+## before(point1, point2)
 
-- parameters:
-  - `point1`, `point2`: any
-  - or `range`: range, `point`: any
-  - or `point`: any, `range`: range
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+before(point1: Any, point2: Any): boolean
+```
+
+**Examples**
 
 ```js
 before(1, 10)
@@ -34,13 +35,49 @@ before(1, 10)
 
 before(10, 1)
 // false
+```
 
-before(1, [2..5])
-// true
+## before(range, point)
 
+**Function signature**
+
+```js
+before(range: range, point: Any): boolean
+```
+
+**Examples**
+
+```js
 before([1..5], 10)
 // true
+```
 
+## before(point, range)
+
+**Function signature**
+
+```js
+before(point: Any, range: range): boolean
+```
+
+**Examples**
+
+```js
+before(1, [2..5])
+// true
+```
+
+## before(range1, range2)
+
+**Function signature**
+
+```js
+before(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 before([1..5], [6..10])
 // true
 
@@ -48,14 +85,15 @@ before([1..5),[5..10])
 // true
 ```
 
-## after()
+## after(point1, point2)
 
-- parameters:
-  - `point1`, `point2`: any
-  - or `range`: range, `point`: any
-  - or `point`: any, `range`: range
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+after(point1: Any, point2: Any): boolean
+```
+
+**Examples**
 
 ```js
 after(10, 1)
@@ -63,26 +101,65 @@ after(10, 1)
 
 after(1, 10)
 // false
+```
 
-after(12, [2..5])
-// true
+## after(range, point)
 
-([1..5], 10)
+**Function signature**
+
+```js
+after(range: range, point: Any): boolean
+```
+
+**Examples**
+
+```js
+after([1..5], 10)
 // false
+```
 
-before([6..10], [1..5])
-// true
+## after(point, range)
 
-before([5..10], [1..5))
+**Function signature**
+
+```js
+after(point: Any, range: range): boolean
+```
+
+**Examples**
+
+```js
+after(12, [2..5])
 // true
 ```
 
-## meets()
+## after(range1, range2)
 
-- parameters:
-  - `range1`: range
-  - `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+after(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
+after([6..10], [1..5])
+// true
+
+after([5..10], [1..5))
+// true
+```
+
+## meets(range1, range2)
+
+**Function signature**
+
+```js
+meets(range1: range, range2: range): boolean
+```
+
+**Examples**
 
 ```js
 meets([1..5], [5..10])
@@ -99,12 +176,15 @@ meets([1..5], (5..8])
 
 ```
 
-## met by()
+## met by(range1, range2)
 
-- parameters:
-  - `range1`: range
-  - `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+met by(range1: range, range2: range): boolean
+```
+
+**Examples**
 
 ```js
 met by([5..10], [1..5])
@@ -123,12 +203,15 @@ met by([5..10], [1..5))
 // false
 ```
 
-## overlaps()
+## overlaps(range1, range2)
 
-- parameters:
-  - `range1`: range
-  - `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+overlaps(range1: range, range2: range): boolean
+```
+
+**Examples**
 
 ```js
 overlaps([5..10], [1..6])
@@ -147,12 +230,15 @@ overlaps([4..10], [1..5))
 // treu
 ```
 
-## overlaps before()
+## overlaps before(range1, range2)
 
-- parameters:
-  - `range1`: range
-  - `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+overlaps before(range1: range, range2: range): boolean
+```
+
+**Examples**
 
 ```js
 overlaps before([1..5], [4..10])
@@ -171,12 +257,15 @@ overlaps before([1..5), [5..10])
 // false
 ```
 
-## overlaps after()
+## overlaps after(range1, range2)
 
-- parameters:
-  - `range1`: range
-  - `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+overlaps after(range1: range, range2: range): boolean
+```
+
+**Examples**
 
 ```js
 overlaps after([4..10], [1..5])
@@ -195,12 +284,16 @@ overlaps after([4..10], [1..5))
 // true
 ```
 
-## finishes()
+## finishes(point, range)
 
-- parameters:
-  - `point`: any, `range`: range
-  - or `range1`, `range2`: range
-- result: boolean
+
+**Function signature**
+
+```js
+finishes(point: Any, range: range): boolean
+```
+
+**Examples**
 
 ```js
 finishes(5, [1..5])
@@ -208,7 +301,19 @@ finishes(5, [1..5])
 
 finishes(10, [1..7])
 // false
+```
 
+## finishes(range1, range2)
+
+**Function signature**
+
+```js
+finishes(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 finishes([3..5], [1..5])
 // true
 
@@ -219,12 +324,15 @@ finishes([5..10], [1..10))
 // false
 ```
 
-## finished by()
+## finished by(range, point)
 
-- parameters:
-  - `range`: range, `point`: any
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+finished by(range: range, point: Any): boolean
+```
+
+**Examples**
 
 ```js
 finishes by([5..10], 10)
@@ -232,7 +340,19 @@ finishes by([5..10], 10)
 
 finishes by([3..4], 2)
 // false
+```
 
+## finished by(range1, range2)
+
+**Function signature**
+
+```js
+finished by(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 finishes by([3..5], [1..5])
 // true
 
@@ -243,12 +363,15 @@ finishes by([5..10], (1..10))
 // true
 ```
 
-## includes()
+## includes(range, point)
 
-- parameters:
-  - `range`: range, `point`: any
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+includes(range: range, point: Any): boolean
+```
+
+**Examples**
 
 ```js
 includes([5..10], 6)
@@ -256,7 +379,19 @@ includes([5..10], 6)
 
 includes([3..4], 5)
 // false
+```
 
+## includes(range1, range2)
+
+**Function signature**
+
+```js
+includes(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 includes([1..10], [4..6])
 // true
 
@@ -267,12 +402,15 @@ includes([1..10], [1..5))
 // true
 ```
 
-## during()
+## during(point, range)
 
-- parameters:
-  - `point`: any, `range`: range
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+during(point: Any, range: range): boolean
+```
+
+**Examples**
 
 ```js
 during(5, [1..10])
@@ -283,7 +421,19 @@ during(12, [1..10])
 
 during(1, (1..10])
 // false
+```
 
+## during(range1, range2)
+
+**Function signature**
+
+```js
+during(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 during([4..6], [1..10))
 // true
 
@@ -291,12 +441,15 @@ during((1..5], (1..10])
 // true
 ```
 
-## starts()
+## starts(point, range)
 
-- parameters:
-  - `point`: any, `range`: range
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+starts(point: Any, range: range): boolean
+```
+
+**Examples**
 
 ```js
 starts(1, [1..5])
@@ -304,7 +457,19 @@ starts(1, [1..5])
 
 starts(1, (1..8])
 // false
+```
 
+## starts(range1, range2)
+
+**Function signature**
+
+```js
+starts(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 starts((1..5], [1..5])
 // false
 
@@ -315,12 +480,15 @@ starts((1..10), (1..10))
 // true
 ```
 
-## started by()
+## started by(range, point)
 
-- parameters:
-  - `range`: range, `point`: any
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+started by(range: range, point: Any): boolean
+```
+
+**Examples**
 
 ```js
 started by([1..10], 1)
@@ -328,7 +496,19 @@ started by([1..10], 1)
 
 started by((1..10], 1)
 // false
+```
 
+## started by(range1, range2)
+
+**Function signature**
+
+```js
+started by(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 started by([1..10], [1..5])
 // true
 
@@ -339,12 +519,15 @@ started by([1..10], [1..10))
 // true
 ```
 
-## coincides()
+## coincides(point1, point2)
 
-- parameters:
-  - `point1`, `point2`: any
-  - or `range1`, `range2`: range
-- result: boolean
+**Function signature**
+
+```js
+coincides(point1: Any, point2: Any): boolean
+```
+
+**Examples**
 
 ```js
 coincides(5, 5)
@@ -352,7 +535,19 @@ coincides(5, 5)
 
 coincides(3, 4)
 // false
+```
 
+## coincides(range1, range2)
+
+**Function signature**
+
+```js
+coincides(range1: range, range2: range): boolean
+```
+
+**Examples**
+
+```js
 coincides([1..5], [1..5])
 // true
 

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-string.md
@@ -6,135 +6,240 @@ description: "This document outlines built-in string functions and examples."
 
 import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension";
 
-## substring()
+## substring(string, start position)
 
-- parameters:
-  - `string`: string
-  - `start position`: number
-  - (optional) `length`: number
-- result: string
+Returns a substring of the given value starting at `start position`. 
+
+**Function signature**
 
 ```js
-substring("foobar",3) 
-// "obar"
+substring(string: string, start position: number): string
+```
 
-substring("foobar",3,3) 
+The `start position` starts at the index `1`. The last position is `-1`.
+
+**Examples**
+
+```js
+substring("foobar", 3) 
+// "obar"
+```
+
+## substring(string, start position, length)
+
+Returns a substring of the given value starting at `start position`.
+
+**Function signature**
+
+```js
+substring(string: string, start position: number, length: number): string
+```
+
+The `start position` starts at the index `1`. The last position is `-1`.
+
+**Examples**
+
+```js
+substring("foobar", 3, 3) 
 // "oba"
 ```
 
-## string length()
+## string length(string)
 
-- parameters:
-  - `string`: string
-- result: number
+Returns the number of characters in the given value.
+
+**Function signature**
+
+```js
+string length(string: string): number
+```
+
+**Examples**
 
 ```js
 string length("foo") 
 // 3
 ```
 
-## upper case()
+## upper case(string)
 
-- parameters:
-  - `string`: string
-- result: string
+Returns the given value with all characters are uppercase.
+
+**Function signature**
+
+```js
+upper case(string: string): string
+```
+
+**Examples**
 
 ```js
 upper case("aBc4") 
 // "ABC4"
 ```
 
-## lower case()
+## lower case(string)
 
-- parameters:
-  - `string`: string
-- result: string
+Returns the given value with all characters are lowercase.
+
+**Function signature**
+
+```js
+lower case(string: string): string
+```
+
+**Examples**
 
 ```js
 lower case("aBc4") 
 // "abc4"
 ```
 
-## substring before()
+## substring before(string, match)
 
-- parameters:
-  - `string`: string
-  - `match`: string
-- result: string
+Returns a substring of the given value that contains all characters before `match`.
+
+**Function signature**
+
+```js
+substring before(string: string, match: string): string
+```
+
+**Examples**
 
 ```js
 substring before("foobar", "bar") 
 // "foo"
 ```
 
-## substring after()
+## substring after(string, match)
 
-- parameters:
-  - `string`: string
-  - `match`: string
-- result: string
+Returns a substring of the given value that contains all characters after `match`.
+
+**Function signature**
+
+```js
+substring after(string: string, match: string): string
+```
+
+**Examples**
 
 ```js
 substring after("foobar", "ob") 
 // "ar"
 ```
 
-## contains()
+## contains(string, match)
 
-- parameters:
-  - `string`: string
-  - `match`: string
-- result: boolean
+Returns `true` if the given value contains the substring `match`. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+contains(string: string, match: string): boolean
+```
+
+**Examples**
 
 ```js
 contains("foobar", "of") 
 // false
 ```
 
-## starts with()
+## starts with(string, match)
 
-- parameters:
-  - `input`: string
-  - `match`: string
-- result: boolean
+Returns `true` if the given value starts with the substring `match`. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+starts with(string: string, match: string): boolean
+```
+
+**Examples**
 
 ```js
 starts with("foobar", "fo") 
 // true
 ```
 
-## ends with()
+## ends with(string, match)
 
-- parameters:
-  - `input`: string
-  - `match`: string
-- result: boolean
+Returns `true` if the given value ends with the substring `match`. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+ends with(string: string, match: string): boolean
+```
+
+**Examples**
 
 ```js
 ends with("foobar", "r") 
 // true
 ```
 
-## matches()
+## matches(input, pattern)
 
-- parameters:
-  - `input`: string
-  - `pattern`: string (regular expression)
-- result: boolean
+Returns `true` if the given value matches the `pattern`. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+matches(input: string, pattern: string): boolean
+```
+
+The `pattern` is a string that contains a regular expression. 
+
+**Examples**
 
 ```js
 matches("foobar", "^fo*bar") 
 // true
 ```
 
-## replace()
+## matches(input, pattern, flags)
 
-- parameters:
-  - `input`: string
-  - `pattern`: string (regular expression)
-  - `replacement`: string (e.g. `$1` returns the first match group)
-  - (optional) `flags`: string ("s", "m", "i", "x")
-- result: string
+Returns `true` if the given value matches the `pattern`. Otherwise, returns `false`.
+
+**Function signature**
+
+```js
+matches(input: string, pattern: string, flags: string): boolean
+```
+
+The `pattern` is a string that contains a regular expression.
+
+The `flags` can contain one or more of the following characters:
+- `s` (dot-all)
+- `m` (multi-line)
+- `i` (case insensitive)
+- `x` (comments)
+
+**Examples**
+
+```js
+matches("FooBar", "foo", "i")
+// true
+```
+
+## replace(input, pattern, replacement)
+
+Returns the resulting string after replacing all occurrences of `pattern` with `replacement`.
+
+**Function signature**
+
+```js
+replace(input: string, pattern: string, replacement: string): string
+```
+
+The `pattern` is a string that contains a regular expression.
+
+The `replacement` can access the match groups by using `$` and the number of the group, for example, 
+`$1` to access the first group.
+
+**Examples**
 
 ```js
 replace("abcd", "(ab)|(a)", "[1=$1][2=$2]")
@@ -144,12 +249,47 @@ replace("0123456789", "(\d{3})(\d{3})(\d{4})", "($1) $2-$3")
 // "(012) 345-6789"
 ```
 
-## split()
+## replace(input, pattern, replacement, flags)
 
-- parameters:
-  - `string`: string
-  - `delimiter`: string (regular expression)
-- result: list of strings
+Returns the resulting string after replacing all occurrences of `pattern` with `replacement`.
+
+**Function signature**
+
+```js
+replace(input: string, pattern: string, replacement: string, flags: string): string
+```
+
+The `pattern` is a string that contains a regular expression.
+
+The `replacement` can access the match groups by using `$` and the number of the group, for example,
+`$1` to access the first group.
+
+The `flags` can contain one or more of the following characters:
+- `s` (dot-all)
+- `m` (multi-line)
+- `i` (case insensitive)
+- `x` (comments)
+
+**Examples**
+
+```js
+replace("How do you feel?", "Feel", "FEEL", "i")
+// "How do you FEEL?"
+```
+
+## split(string, delimiter)
+
+Splits the given value into a list of substrings, breaking at each occurrence of the `delimiter` pattern.
+
+**Function signature**
+
+```js
+split(string: string, delimiter: string): list<string>
+```
+
+The `delimiter` is a string that contains a regular expression.
+
+**Examples**
 
 ```js
 split("John Doe", "\s" ) 
@@ -159,17 +299,22 @@ split("a;b;c;;", ";")
 // ["a", "b", "c", "", ""]
 ```
 
-## extract()
+## extract(string, pattern)
 
 <MarkerCamundaExtension></MarkerCamundaExtension>
 
 Returns all matches of the pattern in the given string. Returns an empty list if the pattern doesn't
 match.
 
-- parameters:
-  - `string`: string
-  - `pattern`: string (regular expression)
-- result: list of strings
+**Function signature**
+
+```js
+extract(string: string, pattern: string): list<string>
+```
+
+The `pattern` is a string that contains a regular expression.
+
+**Examples**
 
 ```js
 extract("references are 1234, 1256, 1378", "12[0-9]*")

--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-temporal.md
@@ -10,8 +10,13 @@ import MarkerCamundaExtension from "@site/src/components/MarkerCamundaExtension"
 
 Returns the current date and time including the timezone.
 
-- parameters: no
-- result: date-time with timezone
+**Function signature**
+
+```js
+now(): date and time
+```
+
+**Examples**
 
 ```js
 now()
@@ -22,73 +27,118 @@ now()
 
 Returns the current date.
 
-- parameters: no
-- result: date
+**Function signature**
+
+```js
+today(): date
+```
+
+**Examples**
 
 ```js
 today()
 // date("2020-07-31")
 ```
 
-## day of week()
+## day of week(date)
 
 Returns the day of the week according to the Gregorian calendar. Note that it always returns the English name of the day.
 
-- parameters:
-  - `date`: date/date-time
-- result: string
+**Function signature**
+
+```js
+day of week(date: date): string
+```
+
+```js
+day of week(date: date and time): string
+```
+
+**Examples**
 
 ```js
 day of week(date("2019-09-17"))
 // "Tuesday"
 ```
 
-## day of year()
+## day of year(date)
 
 Returns the Gregorian number of the day within the year.
 
-- parameters:
-  - `date`: date/date-time
-- result: number
+**Function signature**
+
+```js
+day of year(date: date): number
+```
+
+```js
+day of year(date: date and time): number
+```
+
+**Examples**
 
 ```js
 day of year(date("2019-09-17"))
 // 260
 ```
 
-## week of year()
+## week of year(date)
 
 Returns the Gregorian number of the week within the year, according to ISO 8601.
 
-- parameters:
-  - `date`: date/date-time
-- result: number
+**Function signature**
+
+```js
+week of year(date: date): number
+```
+
+```js
+week of year(date: date and time): number
+```
+
+**Examples**
 
 ```js
 week of year(date("2019-09-17"))
 // 38
 ```
 
-## month of year()
+## month of year(date)
 
 Returns the month of the week according to the Gregorian calendar. Note that it always returns the English name of the month.
 
-- parameters:
-  - `date`: date/date-time
-- result: string
+**Function signature**
+
+```js
+month of year(date: date): string
+```
+
+```js
+month of year(date: date and time): string
+```
+
+**Examples**
 
 ```js
 month of year(date("2019-09-17"))
 // "September"
 ```
 
-## abs()
+## abs(n)
 
 Returns the absolute value of a given duration.
 
-- parameters:
-  - `n`: days-time-duration/years-months-duration
-- result: duration
+**Function signature**
+
+```js
+abs(n: days and time duration): days and time duration
+```
+
+```js
+abs(n: years and months duration): years and months duration
+```
+
+**Examples**
 
 ```js
 abs(duration("-PT5H"))
@@ -101,15 +151,23 @@ abs(duration("-P2M"))
 // duration("P2M")
 ```
 
-## last day of month()
+## last day of month(date)
 
 <MarkerCamundaExtension></MarkerCamundaExtension>
 
 Takes the month of the given date or date-time value and returns the last day of this month.
 
-- parameters:
-  - `date`: date/date-time
-- result: date
+**Function signature**
+
+```js
+last day of month(date: date): date
+```
+
+```js
+last day of month(date: date and time): date
+```
+
+**Examples**
 
 ```js
 last day of month(date("2022-10-01"))

--- a/docs/docs/reference/language-guide/feel-boolean-expressions.md
+++ b/docs/docs/reference/language-guide/feel-boolean-expressions.md
@@ -126,7 +126,7 @@ null = null
 :::tip
 
 The built-in
-function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#is-defined) can be
+function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#is-definedvalue) can be
 used to differentiate between a value that is `null` and a variable or context entry that doesn't
 exist.
 

--- a/docs/docs/reference/language-guide/feel-functions.md
+++ b/docs/docs/reference/language-guide/feel-functions.md
@@ -7,7 +7,7 @@ description: "This document outlines various functions and examples."
 ### Invocation
 
 Invokes a built-in function (
-e.g. [contains()](../builtin-functions/feel-built-in-functions-string#contains)) or user-defined
+e.g. [contains()](../builtin-functions/feel-built-in-functions-string#containsstring-match)) or user-defined
 function by its name. The arguments of the function can be passed positional or named.
 
 - Positional: Only the values, in the same order as defined by the function (e.g. `f(1,2)`).

--- a/docs/docs/reference/language-guide/feel-string-expressions.md
+++ b/docs/docs/reference/language-guide/feel-string-expressions.md
@@ -24,7 +24,7 @@ An addition concatenates the strings. The result is a string containing the char
 :::tip
 
 The concatenation is only available for string values. For other types, you can use
-the [string()](../builtin-functions/feel-built-in-functions-conversion#string) function to convert
+the [string()](../builtin-functions/feel-built-in-functions-conversion#stringfrom) function to convert
 the value into a string first.
 
 ```js

--- a/docs/docs/reference/language-guide/feel-variables.md
+++ b/docs/docs/reference/language-guide/feel-variables.md
@@ -65,7 +65,7 @@ order.`total price`
 ```
 
 :::tip
-Use the [`get value()`](../builtin-functions/feel-built-in-functions-context.md#get-value) function 
+Use the [`get value()`](../builtin-functions/feel-built-in-functions-context.md#get-valuecontext-key) function 
 to retrieve the context value of an arbitrary key.
 
 ```js


### PR DESCRIPTION
## Description

Split the built-in functions in the docs by their signature.

---

### New style

![image](https://user-images.githubusercontent.com/4305769/225280928-8168556a-6ce5-4779-878e-d6c8ce3a518c.png)

---

### Old style

![image](https://user-images.githubusercontent.com/4305769/225281113-902701f6-716b-4e72-af24-0bc2b7234742.png)

## Related issues

closes #555
