### PR TITLE
build: Ignore inner methods for Clirr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,11 @@
               <method>* $anonfun*(*)</method>
             </ignored>
             <ignored>
+              <className>org/camunda/feel/**</className>
+              <differenceType>7002</differenceType>
+              <method>* $anonfun*(*)</method>
+            </ignored>
+            <ignored>
               <!-- allow new methods in the interface-->
               <className>org/camunda/feel/**</className>
               <differenceType>7012</differenceType>


### PR DESCRIPTION
## Description

Clirr reports a false positive if an inner method is changed. Adjust the configuration of the Clirr plugin to ignore these errors.

## Related issues

