### PR TITLE
[Backport 1.16] fix(builtin-function): fix string conversion of years-months-durations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,11 @@
               <method>* $anonfun*(*)</method>
             </ignored>
             <ignored>
+              <className>org/camunda/feel/**</className>
+              <differenceType>7002</differenceType>
+              <method>* $anonfun*(*)</method>
+            </ignored>
+            <ignored>
               <!-- allow new methods in the interface-->
               <className>org/camunda/feel/**</className>
               <differenceType>7012</differenceType>

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -205,7 +205,7 @@ object ConversionBuiltinFunctions {
           .replaceAll("$1$3")
         ValString(dateTimeWithOffsetOrZoneId)
       }
-      case List(ValYearMonthDuration(from)) => ValString(from.toString)
+      case List(duration: ValYearMonthDuration) => ValString(duration.toString)
       case List(duration: ValDayTimeDuration)   => ValString(duration.toString)
     }
   )

--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -171,6 +171,28 @@ case class ValDateTime(value: DateTime) extends Val {
 }
 
 case class ValYearMonthDuration(value: YearMonthDuration) extends Val {
+
+  override def toString: String = {
+    def makeString(sign: String, year: Long, month: Long): String = {
+      val y = Option(year).filterNot(_ == 0).map(_ + "Y").getOrElse("")
+      val m = Option(month).filterNot(_ == 0).map(_ + "M").getOrElse("")
+
+      val stringBuilder = new StringBuilder("")
+      stringBuilder.append(sign).append("P").append(y).append(m)
+      stringBuilder.toString()
+    }
+
+    val year = value.getYears
+    val month = value.getMonths % 12
+
+    if (year == 0 && month == 0)
+      "P0Y"
+    else if (year <= 0 && month <= 0)
+      makeString("-", -year, -month)
+    else
+      makeString("", year, month)
+  }
+
   override val properties: Map[String, Val] = Map(
     "years" -> ValNumber(value.getYears),
     "months" -> ValNumber(value.getMonths)

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -233,6 +233,18 @@ class BuiltinConversionFunctionsTest
     eval(""" string(@"P1DT2H3M4S") """) should be(ValString("P1DT2H3M4S"))
   }
 
+  it should "convert zero-length years-months-duration" in {
+
+    eval(""" string(@"P0Y") """) should be(ValString("P0Y"))
+    eval(""" string(@"-P0M") """) should be(ValString("P0Y"))
+    eval(""" string(@"P0Y0M") """) should be(ValString("P0Y"))
+  }
+  it should "convert negative years-months-duration" in {
+
+    eval(""" string(@"-P1Y") """) should be(ValString("-P1Y"))
+    eval(""" string(@"-P5M") """) should be(ValString("-P5M"))
+    eval(""" string(@"-P3Y1M") """) should be(ValString("-P3Y1M"))
+  }
   it should "convert years-months-duration" in {
 
     eval(""" string(@"P1Y") """) should be(ValString("P1Y"))

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -306,7 +306,7 @@ class DateTimeDurationPropertiesTest
 
     result shouldBe a[ValError]
     result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValYearMonthDuration(P2Y3M)'. Available properties:")
+      "No property found with name 'x' of value 'P2Y3M'. Available properties:")
   }
 
   it should "has properties with @-notation" in {


### PR DESCRIPTION
## Description

Backport of #636 to `1.16`.

## Related issues

relates to #631
