### PR TITLE
[Backport] docs: fix descriptions and examples

### DIFF
--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -132,5 +132,5 @@ Returns `null` if one of the entries is not a context or if a context doesn't co
 
 ```js
 context([{"key":"a", "value":1}, {"key":"b", "value":2}])
-// {a:1, b:2}
+// {"a":1, "b":2}
 ```

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-list.md
@@ -237,7 +237,7 @@ concatenate([1],[2],[3])
 
 ```js
 insert before([1,3],1,2) 
-// [1,2,3]
+// [2,1,3]
 ```
 
 ## remove()

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-range.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-range.md
@@ -227,20 +227,20 @@ finishes([5..10], [1..10))
 - result: boolean
 
 ```js
-finishes by([5..10], 10)
+finished by([5..10], 10)
 // true
 
-finishes by([3..4], 2)
+finished by([3..4], 2)
 // false
 
-finishes by([3..5], [1..5])
+finished by([1..5], [3..5])
 // true
 
-finishes by((5..8], [1..5))
+finished by((5..8], [1..5))
 // false
 
-finishes by([5..10], (1..10))
-// true
+finished by([5..10], (1..10))
+// false
 ```
 
 ## includes()
@@ -308,10 +308,10 @@ starts(1, (1..8])
 starts((1..5], [1..5])
 // false
 
-starts([1..10], [1..10])
-// true
+starts([1..10], [1..5])
+// false
 
-starts((1..10), (1..10))
+starts((1..5), (1..10))
 // true
 ```
 

--- a/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/versioned_docs/version-1.15/reference/builtin-functions/feel-built-in-functions-temporal.md
@@ -69,7 +69,7 @@ week of year(date("2019-09-17"))
 
 ## month of year()
 
-Returns the month of the week according to the Gregorian calendar. Note that it always returns the English name of the month.
+Returns the month of the year according to the Gregorian calendar. Note that it always returns the English name of the month.
 
 - parameters:
   - `date`: date/date-time

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -65,7 +65,7 @@ context(entries: list<context>): context
 
 ```js
 context([{"key":"a", "value":1}, {"key":"b", "value":2}])
-// {a:1, b:2}
+// {"a":1, "b":2}
 ```
 
 

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-list.md
@@ -236,10 +236,10 @@ The parameter `list` can be passed as a list or as a sequence of elements.
 **Examples**
 
 ```js
-and([true,false])
+all([true,false])
 // false
 
-and(false,null,true)
+all(false,null,true)
 // false
 ```
 
@@ -265,10 +265,10 @@ The parameter `list` can be passed as a list or as a sequence of elements.
 **Examples**
 
 ```js
-or([false,true])
+any([false,true])
 // true
 
-or(false,null,true)
+any(false,null,true)
 // true
 ```
 
@@ -372,7 +372,7 @@ The `position` starts at the index `1`. The last position is `-1`.
 
 ```js
 insert before([1,3],1,2) 
-// [1,2,3]
+// [2,1,3]
 ```
 
 ## remove(list, position)

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-numeric.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-numeric.md
@@ -277,7 +277,7 @@ log(10)
 
 ## exp(number)
 
-Returns the Euler’s number e raised to the power of the given number .
+Returns the Euler’s number e raised to the power of the given number.
 
 **Function signature**
 

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-range.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-range.md
@@ -173,7 +173,6 @@ meets([1..3], [3..5])
 
 meets([1..5], (5..8])
 // false
-
 ```
 
 ## met by(range1, range2)
@@ -227,7 +226,7 @@ overlaps((5..8], [1..5))
 // false
 
 overlaps([4..10], [1..5))
-// treu
+// true
 ```
 
 ## overlaps before(range1, range2)
@@ -335,10 +334,10 @@ finished by(range: range, point: Any): boolean
 **Examples**
 
 ```js
-finishes by([5..10], 10)
+finished by([5..10], 10)
 // true
 
-finishes by([3..4], 2)
+finished by([3..4], 2)
 // false
 ```
 
@@ -353,14 +352,14 @@ finished by(range1: range, range2: range): boolean
 **Examples**
 
 ```js
-finishes by([3..5], [1..5])
+finished by([1..5], [3..5])
 // true
 
-finishes by((5..8], [1..5))
+finished by((5..8], [1..5))
 // false
 
-finishes by([5..10], (1..10))
-// true
+finished by([5..10], (1..10))
+// false
 ```
 
 ## includes(range, point)
@@ -473,10 +472,10 @@ starts(range1: range, range2: range): boolean
 starts((1..5], [1..5])
 // false
 
-starts([1..10], [1..10])
-// true
+starts([1..10], [1..5])
+// false
 
-starts((1..10), (1..10))
+starts((1..5), (1..10))
 // true
 ```
 

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-temporal.md
@@ -59,6 +59,9 @@ day of week(date: date and time): string
 ```js
 day of week(date("2019-09-17"))
 // "Tuesday"
+
+day of week(date and time("2019-09-17T12:00:00"))
+// "Tuesday"
 ```
 
 ## day of year(date)
@@ -79,6 +82,9 @@ day of year(date: date and time): number
 
 ```js
 day of year(date("2019-09-17"))
+// 260
+
+day of year(date and time("2019-09-17T12:00:00"))
 // 260
 ```
 
@@ -101,11 +107,14 @@ week of year(date: date and time): number
 ```js
 week of year(date("2019-09-17"))
 // 38
+
+week of year(date and time("2019-09-17T12:00:00"))
+// 38
 ```
 
 ## month of year(date)
 
-Returns the month of the week according to the Gregorian calendar. Note that it always returns the English name of the month.
+Returns the month of the year according to the Gregorian calendar. Note that it always returns the English name of the month.
 
 **Function signature**
 
@@ -121,6 +130,9 @@ month of year(date: date and time): string
 
 ```js
 month of year(date("2019-09-17"))
+// "September"
+
+month of year(date and time("2019-09-17T12:00:00"))
 // "September"
 ```
 


### PR DESCRIPTION
## Description

Backport changes of #645 to `1.16` and `1.15`.

## Related issues

related to #645 
