### PR TITLE
docs: Mark get-value() function as a Camunda extension

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-context.md
@@ -28,6 +28,8 @@ get value({a: 1}, "b")
 
 ## get value(context, keys)
 
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
 Returns the value of the context entry for a context path defined by the given keys.
 
 If `keys` contains the keys `[k1, k2]` then it returns the value at the nested entry `k1.k2` of the context.

--- a/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/versioned_docs/version-1.16/reference/builtin-functions/feel-built-in-functions-context.md
@@ -28,6 +28,8 @@ get value({a: 1}, "b")
 
 ## get value(context, keys)
 
+<MarkerCamundaExtension></MarkerCamundaExtension>
+
 Returns the value of the context entry for a context path defined by the given keys.
 
 If `keys` contains the keys `[k1, k2]` then it returns the value at the nested entry `k1.k2` of the context.


### PR DESCRIPTION
## Description

Add the Camunda extension marker for the built-in function [get value(context, keys)](https://camunda.github.io/feel-scala/docs/reference/builtin-functions/feel-built-in-functions-context#get-valuecontext-keys). 

This function is new since version `1.16.0`.

## Related issues


