### PR TITLE
fix: Preserve the order of a context

### DIFF
--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -124,11 +124,12 @@ class FeelEngine(
       s"configuration: $configuration]"
   )
 
-  private val rootContext: EvalContext = new EvalContext(
+  private val rootContext: EvalContext = EvalContext.create(
     valueMapper = valueMapper,
-    variableProvider = VariableProvider.EmptyVariableProvider,
-    functionProvider = FunctionProvider.CompositeFunctionProvider(
-      List(new BuiltinFunctions(clock, valueMapper), functionProvider))
+    functionProvider = FunctionProvider.CompositeFunctionProvider(List(
+      new BuiltinFunctions(clock, valueMapper),
+      functionProvider
+    ))
   )
 
   def evalExpression(
@@ -201,7 +202,7 @@ class FeelEngine(
 
   def eval(exp: ParsedExpression, context: Context): EvalExpressionResult =
     Try {
-      validate(exp).flatMap(_ => eval(exp, rootContext + context))
+      validate(exp).flatMap(_ => eval(exp, rootContext.merge(context)))
     }.recover(failure =>
         Left(
           Failure(s"failed to evaluate expression '${exp.text}' : $failure")))

--- a/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
@@ -24,7 +24,7 @@ import org.camunda.feel.impl.interpreter.EvalContext.{mergeFunctionProviders, me
 import org.camunda.feel.syntaxtree.{Val, ValError, ValFunction}
 import org.camunda.feel.valuemapper.ValueMapper
 
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.SeqMap
 
 class EvalContext(val valueMapper: ValueMapper,
                   val variableProvider: VariableProvider,
@@ -162,9 +162,9 @@ object EvalContext {
   }
 
   private def toSortedVariableProvider(variables: Map[String, Any]): VariableProvider =
-    StaticVariableProvider(SortedMap[String, Any]() ++ variables)
+    StaticVariableProvider(SeqMap[String, Any]() ++ variables)
 
   private def toSortedVariableProvider(entry: (String, Any)): VariableProvider =
-    StaticVariableProvider(SortedMap(entry))
+    StaticVariableProvider(SeqMap(entry))
 
 }

--- a/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
@@ -16,16 +16,19 @@
  */
 package org.camunda.feel.impl.interpreter
 
-import org.camunda.feel.context.FunctionProvider.StaticFunctionProvider
-import org.camunda.feel.context.VariableProvider.StaticVariableProvider
+import org.camunda.feel.context.Context.{EmptyContext, StaticContext}
+import org.camunda.feel.context.FunctionProvider.{CompositeFunctionProvider, EmptyFunctionProvider, StaticFunctionProvider}
+import org.camunda.feel.context.VariableProvider.{CompositeVariableProvider, EmptyVariableProvider, StaticVariableProvider}
 import org.camunda.feel.context.{Context, FunctionProvider, VariableProvider}
+import org.camunda.feel.impl.interpreter.EvalContext.{mergeFunctionProviders, mergeVariableProvider, toSortedVariableProvider, wrap}
 import org.camunda.feel.syntaxtree.{Val, ValError, ValFunction}
 import org.camunda.feel.valuemapper.ValueMapper
 
+import scala.collection.immutable.SortedMap
+
 class EvalContext(val valueMapper: ValueMapper,
                   val variableProvider: VariableProvider,
-                  val functionProvider: FunctionProvider)
-    extends Context {
+                  val functionProvider: FunctionProvider) extends Context {
 
   def variable(name: String): Val = {
     variableProvider
@@ -35,65 +38,69 @@ class EvalContext(val valueMapper: ValueMapper,
   }
 
   def function(name: String, paramCount: Int): Val = {
+    val filter = (f: ValFunction) => f.params.size == paramCount ||
+      (f.params.size < paramCount && f.hasVarArgs)
+
     functionProvider
       .getFunctions(name)
-      .find(f =>
-        f.params.size == paramCount || (f.params.size < paramCount && f.hasVarArgs))
+      .find(filter)
       .getOrElse(ValError(
         s"no function found with name '$name' and $paramCount parameters"))
   }
 
   def function(name: String, parameters: Set[String]): Val = {
+    val filter = (f: ValFunction) => f.paramSet == parameters || parameters.subsetOf(f.paramSet)
+
     functionProvider
       .getFunctions(name)
-      .find(f => f.paramSet == parameters || parameters.subsetOf(f.paramSet))
+      .find(filter)
       .getOrElse(ValError(
-        s"no function found with name '$name' and parameters: ${parameters
-          .mkString(",")}"))
+        s"no function found with name '$name' and parameters: ${
+          parameters
+            .mkString(",")
+        }"))
   }
 
-  def +(context: EvalContext): EvalContext = new EvalContext(
+  def merge(otherContext: EvalContext): EvalContext = new EvalContext(
     valueMapper = valueMapper,
-    variableProvider = VariableProvider.CompositeVariableProvider(
-      List(context.variableProvider, variableProvider)),
-    functionProvider = FunctionProvider.CompositeFunctionProvider(
-      List(context.functionProvider, functionProvider))
+    variableProvider = mergeVariableProvider(variableProvider, otherContext.variableProvider),
+    functionProvider = mergeFunctionProviders(functionProvider, otherContext.functionProvider)
   )
 
-  def +(context: Context): EvalContext = new EvalContext(
-    valueMapper = valueMapper,
-    variableProvider = VariableProvider.CompositeVariableProvider(
-      List(context.variableProvider, variableProvider)),
-    functionProvider = FunctionProvider.CompositeFunctionProvider(
-      List(context.functionProvider, functionProvider))
-  )
+  def merge(otherContext: Context): EvalContext = {
+    val wrappedContext = wrap(otherContext)(valueMapper)
+    merge(wrappedContext)
+  }
 
-  def +(entry: (String, Any)): EvalContext = entry match {
+  def add(entry: (String, Val)): EvalContext = entry match {
     case (k: String, f: ValFunction) => addFunction(k, f)
-    case (k: String, v)              => addVariable(k, v)
+    case (k: String, v) => addVariable(k, v)
   }
 
-  def addVariable(key: String, variable: Any): EvalContext = new EvalContext(
+  private def addVariable(key: String, variable: Val): EvalContext = new EvalContext(
     valueMapper = valueMapper,
-    variableProvider = VariableProvider.CompositeVariableProvider(
-      List(StaticVariableProvider(Map(key -> variable)), variableProvider)),
+    variableProvider = mergeVariableProvider(
+      variableProvider,
+      toSortedVariableProvider(key, variable)
+    ),
     functionProvider = functionProvider
   )
 
-  def addFunction(key: String, function: ValFunction): EvalContext =
-    new EvalContext(
-      valueMapper = valueMapper,
-      variableProvider = variableProvider,
-      functionProvider = FunctionProvider.CompositeFunctionProvider(
-        List(StaticFunctionProvider(Map(key -> List(function))),
-             functionProvider)
-      )
-    )
-
-  def ++(variables: Map[String, Any]): EvalContext = new EvalContext(
+  private def addFunction(key: String, function: ValFunction): EvalContext = new EvalContext(
     valueMapper = valueMapper,
-    variableProvider = VariableProvider.CompositeVariableProvider(
-      List(StaticVariableProvider(variables), variableProvider)),
+    variableProvider = variableProvider,
+    functionProvider = mergeFunctionProviders(
+      functionProvider,
+      StaticFunctionProvider(Map(key -> List(function)))
+    )
+  )
+
+  def addAll(newVariables: Map[String, Val]): EvalContext = new EvalContext(
+    valueMapper = valueMapper,
+    variableProvider = mergeVariableProvider(
+      variableProvider,
+      toSortedVariableProvider(newVariables)
+    ),
     functionProvider = functionProvider
   )
 
@@ -101,11 +108,63 @@ class EvalContext(val valueMapper: ValueMapper,
 
 object EvalContext {
 
+  def empty(valueMapper: ValueMapper): EvalContext = create(
+    valueMapper = valueMapper,
+    functionProvider = EmptyFunctionProvider
+  )
+
+  def create(valueMapper: ValueMapper, functionProvider: FunctionProvider): EvalContext = new EvalContext(
+    valueMapper = valueMapper,
+    variableProvider = EmptyVariableProvider,
+    functionProvider = functionProvider
+  )
+
   def wrap(context: Context)(implicit valueMapper: ValueMapper): EvalContext =
-    new EvalContext(
-      valueMapper = valueMapper,
-      variableProvider = context.variableProvider,
-      functionProvider = context.functionProvider
-    )
+    context match {
+      case evalContext: EvalContext => evalContext
+      case EmptyContext => empty(valueMapper)
+      case StaticContext(variables, functions) => new EvalContext(
+        valueMapper = valueMapper,
+        variableProvider = toSortedVariableProvider(variables),
+        functionProvider = StaticFunctionProvider(functions)
+      )
+      case _ => new EvalContext(
+        valueMapper = valueMapper,
+        variableProvider = context.variableProvider,
+        functionProvider = context.functionProvider
+      )
+    }
+
+  private def mergeVariableProvider(provider: VariableProvider, otherProvider: VariableProvider): VariableProvider = {
+    (provider, otherProvider) match {
+      case (EmptyVariableProvider, EmptyVariableProvider) => EmptyVariableProvider
+      case (EmptyVariableProvider, otherProvider) => otherProvider
+      case (thisProvider, EmptyVariableProvider) => thisProvider
+      case (StaticVariableProvider(thisVariables), StaticVariableProvider(otherVariables)) =>
+        StaticVariableProvider(thisVariables ++ otherVariables)
+      case (thisProvider, otherProvider) => CompositeVariableProvider(List(thisProvider, otherProvider))
+    }
+  }
+
+  private def mergeFunctionProviders(provider: FunctionProvider, otherProvider: FunctionProvider): FunctionProvider = {
+    (provider, otherProvider) match {
+      case (EmptyFunctionProvider, EmptyFunctionProvider) => EmptyFunctionProvider
+      case (EmptyFunctionProvider, otherProvider) => otherProvider
+      case (thisProvider, EmptyFunctionProvider) => thisProvider
+      case (StaticFunctionProvider(thisFunctions), StaticFunctionProvider(otherFunctions)) => {
+        val allKeys = thisFunctions.keys ++ otherFunctions.keys
+        val functionsByKey = (key: String) => thisFunctions.getOrElse(key, List.empty) ++ otherFunctions.getOrElse(key, List.empty)
+        val allFunctions = allKeys.map(key => key -> functionsByKey(key)).toMap
+        StaticFunctionProvider(allFunctions)
+      }
+      case (thisProvider, otherProvider) => CompositeFunctionProvider(List(thisProvider, otherProvider))
+    }
+  }
+
+  private def toSortedVariableProvider(variables: Map[String, Any]): VariableProvider =
+    StaticVariableProvider(SortedMap[String, Any]() ++ variables)
+
+  private def toSortedVariableProvider(entry: (String, Any)): VariableProvider =
+    StaticVariableProvider(SortedMap(entry))
 
 }

--- a/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
@@ -68,7 +68,7 @@ class EvalContext(val valueMapper: ValueMapper,
   )
 
   def merge(otherContext: Context): EvalContext = {
-    val wrappedContext = wrap(otherContext)(valueMapper)
+    val wrappedContext = wrap(otherContext, valueMapper)
     merge(wrappedContext)
   }
 
@@ -119,7 +119,7 @@ object EvalContext {
     functionProvider = functionProvider
   )
 
-  def wrap(context: Context)(implicit valueMapper: ValueMapper): EvalContext =
+  def wrap(context: Context, valueMapper: ValueMapper): EvalContext =
     context match {
       case evalContext: EvalContext => evalContext
       case EmptyContext => empty(valueMapper)

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -141,10 +141,10 @@ class FeelInterpreter {
 
       case ConstContext(entries) =>
         foldEither[(String, Exp), EvalContext](
-          EvalContext.wrap(Context.EmptyContext)(context.valueMapper),
+          EvalContext.empty(context.valueMapper),
           entries, {
             case (ctx, (key, value)) =>
-              eval(value)(context + ctx).toEither.map(v => ctx + (key -> v))
+              eval(value)(context.merge(ctx)).toEither.map(v => ctx.add(key -> v))
           },
           ValContext
         )
@@ -212,7 +212,7 @@ class FeelInterpreter {
                                eval(elseStatement)
                            })
       case In(x, test) =>
-        withVal(eval(x), x => eval(test)(context + (inputKey -> x)))
+        withVal(eval(x), x => eval(test)(context.add(inputKey -> x)))
       case InstanceOf(x, typeName) =>
         withVal(eval(x), x => {
           typeName match {
@@ -233,13 +233,13 @@ class FeelInterpreter {
         withCartesianProduct(
           iterators,
           p =>
-            atLeastOne(p.map(vars => () => eval(condition)(context ++ vars)),
+            atLeastOne(p.map(vars => () => eval(condition)(context.addAll(vars))),
                        ValBoolean))
       case EveryItem(iterators, condition) =>
         withCartesianProduct(
           iterators,
           p =>
-            all(p.map(vars => () => eval(condition)(context ++ vars)),
+            all(p.map(vars => () => eval(condition)(context.addAll(vars))),
                 ValBoolean))
       case For(iterators, exp) =>
         withCartesianProduct(
@@ -247,7 +247,7 @@ class FeelInterpreter {
           p =>
             ValList((List[Val]() /: p) {
               case (partial, vars) => {
-                val iterationContext = context ++ vars + ("partial" -> partial)
+                val iterationContext = context.addAll(vars).add("partial" -> ValList(partial))
                 val value = eval(exp)(iterationContext)
                 partial ++ (value :: Nil)
               }
@@ -309,7 +309,7 @@ class FeelInterpreter {
                                    arguments,
                                    paramValues,
                                    context.valueMapper)
-              case _ => eval(body)(context ++ (params zip paramValues).toMap)
+              case _ => eval(body)(context.addAll((params zip paramValues).toMap))
           }
         )
 
@@ -996,8 +996,8 @@ class FeelInterpreter {
   private def filterContext(x: Val)(
       implicit context: EvalContext): EvalContext =
     x match {
-      case ValContext(ctx: Context) => context + ("item" -> x) + ctx
-      case v                        => context + ("item" -> v)
+      case ValContext(ctx: Context) => context.add("item" -> x).merge(ctx)
+      case v                        => context.add("item" -> v)
     }
 
   private def ref(x: Val, names: List[String])(

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -294,7 +294,7 @@ class FeelInterpreter {
           eval(path),
           c =>
             withFunction(
-              findFunction(EvalContext.wrap(c.context)(context.valueMapper),
+              findFunction(EvalContext.wrap(c.context, context.valueMapper),
                            name,
                            params),
               f => invokeFunction(f, params)))
@@ -1014,7 +1014,7 @@ class FeelInterpreter {
   private def path(v: Val, key: String)(implicit context: EvalContext): Val =
     v match {
       case ctx: ValContext =>
-        EvalContext.wrap(ctx.context)(context.valueMapper).variable(key) match {
+        EvalContext.wrap(ctx.context, context.valueMapper).variable(key) match {
           case _: ValError =>
             ValError(s"context contains no entry with key '$key'")
           case x: Val => x

--- a/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
@@ -90,9 +90,11 @@ trait FeelIntegrationTest {
   }
 
   val rootContext: EvalContext = EvalContext.wrap(
-    Context.StaticContext(variables = Map.empty,
-                          functions = new BuiltinFunctions(clock, ValueMapper.defaultValueMapper).functions)
-  )(ValueMapper.defaultValueMapper)
+    Context.StaticContext(
+      variables = Map.empty,
+      functions = new BuiltinFunctions(clock, ValueMapper.defaultValueMapper).functions),
+    ValueMapper.defaultValueMapper
+  )
 
   def withClock(testCode: TimeTravelClock => Any): Unit = {
     try {

--- a/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/FeelIntegrationTest.scala
@@ -63,7 +63,7 @@ trait FeelIntegrationTest {
 
     FeelParser.parseExpression(expression) match {
       case Parsed.Success(exp, _) =>
-        interpreter.eval(exp)(rootContext + context)
+        interpreter.eval(exp)(rootContext.merge(context))
       case Parsed.Failure(_, _, extra) => {
         ValError(
           s"failed to parse expression '$expression':\n${extra.trace().aggregateMsg}")
@@ -75,7 +75,11 @@ trait FeelIntegrationTest {
                      expression: String,
                      variables: Map[String, Any] = Map()): Val = {
 
-    val ctx = rootContext ++ variables + (UnaryTests.defaultInputVariable -> input)
+    val inputEntry = UnaryTests.defaultInputVariable -> input
+    val variableValues = (variables + inputEntry).map{ case (key,value) =>
+      key -> rootContext.valueMapper.toVal(value)
+    }
+    val ctx = rootContext.addAll(variableValues)
 
     FeelParser.parseUnaryTests(expression) match {
       case Parsed.Success(exp, _) => interpreter.eval(exp)(ctx)

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -68,6 +68,10 @@ class BuiltinContextFunctionsTest
     eval("""get entries({a: "foo", b: "bar"}).key""") should be(ValList(
       List(ValString("a"), ValString("b"))
     ))
+
+    eval("get entries({c: 1, b: 2, a: 3}).key") should be(ValList(
+      List(ValString("c"), ValString("b"), ValString("a"))
+    ))
   }
 
   "A get value function" should "return the value" in {
@@ -160,6 +164,12 @@ class BuiltinContextFunctionsTest
         List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
       )
     )
+
+    eval(""" get entries(context put({c: 1, b: 2, a: 3}, "d", 4)).key """) should be(
+      ValList(
+        List(ValString("c"), ValString("b"), ValString("a"), ValString("d"))
+      )
+    )
   }
 
   it should "override an entry of an existing context" in {
@@ -174,6 +184,18 @@ class BuiltinContextFunctionsTest
     eval(""" get entries(context put({a: 1, b: 2, c: 3}, "b", 20)).key """) should be(
       ValList(
         List(ValString("a"), ValString("b"), ValString("c"))
+      )
+    )
+
+    eval(""" get entries(context put({c: 1, b: 2, a: 3}, "c", 10)).key """) should be(
+      ValList(
+        List(ValString("c"), ValString("b"), ValString("a"))
+      )
+    )
+
+    eval(""" get entries(context put({c: 1, b: 2, a: 3}, "a", 30)).key """) should be(
+      ValList(
+        List(ValString("c"), ValString("b"), ValString("a"))
       )
     )
   }
@@ -312,6 +334,12 @@ class BuiltinContextFunctionsTest
         List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
       )
     )
+
+    eval(" get entries(context merge({d: 1, c: 2}, {b: 3, a: 4})).key ") should be(
+      ValList(
+        List(ValString("d"), ValString("c"), ValString("b"), ValString("a"))
+      )
+    )
   }
 
   it should "override an entry of the existing context" in {
@@ -335,6 +363,12 @@ class BuiltinContextFunctionsTest
     eval(" get entries(context merge({a: 1, b: 2, c: 3}, {b: 20, d: 4})).key ") should be(
       ValList(
         List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
+      )
+    )
+
+    eval(" get entries(context merge({c: 1, b: 2, a: 3}, {b: 20, d: 4})).key ") should be(
+      ValList(
+        List(ValString("c"), ValString("b"), ValString("a"), ValString("d"))
       )
     )
   }
@@ -438,6 +472,15 @@ class BuiltinContextFunctionsTest
          {"key":"c","value":3}
          ])).key""") should be(
       ValList(List(ValString("a"), ValString("b"), ValString("c")))
+    )
+
+    eval(
+      """get entries(context([
+         {"key":"c","value":1},
+         {"key":"b","value":2},
+         {"key":"a","value":3}
+         ])).key""") should be(
+      ValList(List(ValString("c"), ValString("b"), ValString("a")))
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -60,6 +60,16 @@ class BuiltinContextFunctionsTest
     eval(""" get entries({}) """) should be(ValList(List()))
   }
 
+  it should "return all entries in the same order as in the context" in {
+    eval("get entries({a: 1, b: 2, c: 3}).key") should be(ValList(
+      List(ValString("a"), ValString("b"), ValString("c"))
+    ))
+
+    eval("""get entries({a: "foo", b: "bar"}).key""") should be(ValList(
+      List(ValString("a"), ValString("b"))
+    ))
+  }
+
   "A get value function" should "return the value" in {
     eval(""" get value({foo: 123}, "foo") """) should be(ValNumber(123))
   }
@@ -144,6 +154,14 @@ class BuiltinContextFunctionsTest
       ))
   }
 
+  it should "add a new entry at the end of the context" in {
+    eval(""" get entries(context put({a: 1, b: 2, c: 3}, "d", 4)).key """) should be(
+      ValList(
+        List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
+      )
+    )
+  }
+
   it should "override an entry of an existing context" in {
 
     eval(""" context put({x:1}, "x", 2) """) should be(
@@ -153,8 +171,10 @@ class BuiltinContextFunctionsTest
   }
 
   it should "override an entry and keep the original order" in {
-    eval(""" context put({x:1, y:0, z:0}, "y", 2) = {x:1, y:2, z:0} """) should be (
-      ValBoolean(true)
+    eval(""" get entries(context put({a: 1, b: 2, c: 3}, "b", 20)).key """) should be(
+      ValList(
+        List(ValString("a"), ValString("b"), ValString("c"))
+      )
     )
   }
 
@@ -175,7 +195,7 @@ class BuiltinContextFunctionsTest
     )
   }
 
-  it should "add an a context entry with list argument" in {
+  it should "add a context entry with list argument" in {
     eval(""" context put({x:1}, ["y"], 2) = {x:1, y:2} """) should be (
       ValBoolean(true)
     )
@@ -286,6 +306,14 @@ class BuiltinContextFunctionsTest
       ))
   }
 
+  it should "add all entries at the end of the context" in {
+    eval(" get entries(context merge({a: 1, b: 2}, {c: 3, d: 4})).key ") should be(
+      ValList(
+        List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
+      )
+    )
+  }
+
   it should "override an entry of the existing context" in {
 
     eval(""" context merge({x:1}, {x:2}) """) should be(
@@ -301,6 +329,14 @@ class BuiltinContextFunctionsTest
         StaticContext(variables =
           Map("x" -> ValNumber(3), "y" -> ValNumber(1), "z" -> ValNumber(2)))
       ))
+  }
+
+  it should "override entries and keep the original order" in {
+    eval(" get entries(context merge({a: 1, b: 2, c: 3}, {b: 20, d: 4})).key ") should be(
+      ValList(
+        List(ValString("a"), ValString("b"), ValString("c"), ValString("d"))
+      )
+    )
   }
 
   it should "combine three contexts" in {
@@ -392,6 +428,17 @@ class BuiltinContextFunctionsTest
 
     eval(""" context([{"key":"a", "value": {x:1} }]) = {a: {x:1}} """) should be(
       ValBoolean(true))
+  }
+
+  it should "return a context with the same order as the given entries" in {
+    eval(
+      """get entries(context([
+         {"key":"a","value":1},
+         {"key":"b","value":2},
+         {"key":"c","value":3}
+         ])).key""") should be(
+      ValList(List(ValString("a"), ValString("b"), ValString("c")))
+    )
   }
 
   it should "override entries in order" in {


### PR DESCRIPTION
## Description

Fix an issue that did not store the context entries in the same order as defined in the literal (i.e. `{a: 1, b: 2}` is stored as `{b: 2, a: 1}`). The issue could be observed by using the `get entries()` function.

The root cause was not in the context functions but in how the context is created in the engine via `EvalContext`. Fixing the behavior by using a sorted map for storing the context entries and by avoiding the nesting of the `VariableProvider`s.

As a result, the code of the `EvalContext` is a bit more complex but easier to debug. All variables and functions are stored in one provider instead of a chain with one provider per variable/function.

## Related issues

closes #161 
based on a previous try #340
