### PR TITLE
Fix variable name should not be keyword test

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/interpreter/EvaluationErrorMatcher.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/EvaluationErrorMatcher.scala
@@ -1,0 +1,28 @@
+package org.camunda.feel.impl.interpreter
+
+import org.camunda.feel.syntaxtree.{Val, ValError}
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+
+trait EvaluationErrorMatcher {
+  class EvaluationErrorMatcher(expectedMessage: String) extends BeMatcher[Val] {
+    override def apply(result: Val): MatchResult =
+      result match {
+        case ValError(failure) => MatchResult(
+          failure.startsWith(expectedMessage),
+          s"$result doesn't start with '$expectedMessage'",
+          s"$result starts with '$expectedMessage'",
+        )
+        case _ => MatchResult(
+          false,
+          s"$result is not an error",
+          s"$result is an error"
+        )
+      }
+  }
+
+  def anError(expectedMessage: String) = new EvaluationErrorMatcher(expectedMessage)
+
+  def aParseError: EvaluationErrorMatcher = anError(expectedMessage = "failed to parse expression")
+}
+
+object EvaluationErrorMatcher extends EvaluationErrorMatcher

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -272,6 +272,9 @@ class InterpreterExpressionTest
     eval("and") shouldBe aParseError
     eval("or") shouldBe aParseError
     eval("return") shouldBe aParseError
+    eval("{ null: 1 }.null") shouldBe aParseError
+    eval("{ true: 1}.true") shouldBe aParseError
+    eval("{ false: 1}.false") shouldBe aParseError
   }
 
 //  Ignored as these keywords are not listed as reserved keywords yet

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -18,15 +18,16 @@ package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel.FeelEngine.UnaryTests
 import org.camunda.feel.impl.FeelIntegrationTest
+import org.camunda.feel.impl.interpreter.EvaluationErrorMatcher._
 import org.camunda.feel.syntaxtree._
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
-  * @author Philipp Ossler
-  */
+ * @author Philipp Ossler
+ */
 class InterpreterExpressionTest
-    extends AnyFlatSpec
+  extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
 
@@ -73,14 +74,14 @@ class InterpreterExpressionTest
 
   it should "be an if-then-else (with variable and function call -> then)" in {
     eval("if 7 > var then flatten(xs) else []",
-         Map("xs" -> List(1, 2), "var" -> 3)) should be(
+      Map("xs" -> List(1, 2), "var" -> 3)) should be(
       ValList(List(ValNumber(1), ValNumber(2)))
     )
   }
 
   it should "be an if-then-else (with variable and function call -> else)" in {
     eval("if false then var else flatten(xs)",
-         Map("xs" -> List(1, 2), "var" -> 3)) should be(
+      Map("xs" -> List(1, 2), "var" -> 3)) should be(
       ValList(List(ValNumber(1), ValNumber(2)))
     )
   }
@@ -263,23 +264,26 @@ class InterpreterExpressionTest
   }
 
   "A variable name" should "not be a key-word" in {
+    eval("then") shouldBe aParseError
+    eval("else") shouldBe aParseError
+    eval("function") shouldBe aParseError
+    eval("in") shouldBe aParseError
+    eval("satisfies") shouldBe aParseError
+    eval("and") shouldBe aParseError
+    eval("or") shouldBe aParseError
+    eval("return") shouldBe aParseError
+  }
 
-    eval("some = true", Map("some" -> 1)) shouldBe a[ValError]
-    eval("every = true", Map("every" -> 1)) shouldBe a[ValError]
-    eval("if = true", Map("if" -> 1)) shouldBe a[ValError]
-    eval("then = true", Map("then" -> 1)) shouldBe a[ValError]
-    eval("else = true", Map("else" -> 1)) shouldBe a[ValError]
-    eval("function = true", Map("function" -> 1)) shouldBe a[ValError]
-    eval("for = true", Map("for" -> 1)) shouldBe a[ValError]
-    eval("between = true", Map("between" -> 1)) shouldBe a[ValError]
-    eval("instance = true", Map("instance" -> 1)) shouldBe a[ValError]
-    eval("of = true", Map("of" -> 1)) shouldBe a[ValError]
-    eval("not = true", Map("not" -> 1)) shouldBe a[ValError]
-    eval("in = true", Map("in" -> 1)) shouldBe a[ValError]
-    eval("satisfies = true", Map("satisfies" -> 1)) shouldBe a[ValError]
-    eval("and = true", Map("and" -> 1)) shouldBe a[ValError]
-    eval("or = true", Map("or" -> 1)) shouldBe a[ValError]
-    eval("return = true", Map("return" -> 1)) shouldBe a[ValError]
+//  Ignored as these keywords are not listed as reserved keywords yet
+  ignore should "not be a key-word (ignored)" in {
+    eval("some") shouldBe aParseError
+    eval("every") shouldBe aParseError
+    eval("if") shouldBe aParseError
+    eval("for") shouldBe aParseError
+    eval("between") shouldBe aParseError
+    eval("instance") shouldBe aParseError
+    eval("of") shouldBe aParseError
+    eval("not") shouldBe aParseError
   }
 
   List(
@@ -320,14 +324,16 @@ class InterpreterExpressionTest
   }
 
   it should "be written as single line comments /* .. */" in {
-    eval("""
+    eval(
+      """
         /* the first item */
         [1,2,3][1]
         """) should be(ValNumber(1))
   }
 
   it should "be written as block comments /* .. */" in {
-    eval("""
+    eval(
+      """
         /*
          * the first item
          */

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -264,17 +264,17 @@ class InterpreterExpressionTest
   }
 
   "A variable name" should "not be a key-word" in {
-    eval("then") shouldBe aParseError
-    eval("else") shouldBe aParseError
-    eval("function") shouldBe aParseError
-    eval("in") shouldBe aParseError
-    eval("satisfies") shouldBe aParseError
-    eval("and") shouldBe aParseError
-    eval("or") shouldBe aParseError
-    eval("return") shouldBe aParseError
     eval("{ null: 1 }.null") shouldBe aParseError
     eval("{ true: 1}.true") shouldBe aParseError
     eval("{ false: 1}.false") shouldBe aParseError
+    eval("function") shouldBe aParseError
+    eval("in") shouldBe aParseError
+    eval("return") shouldBe aParseError
+    eval("then") shouldBe aParseError
+    eval("else") shouldBe aParseError
+    eval("satisfies") shouldBe aParseError
+    eval("and") shouldBe aParseError
+    eval("or") shouldBe aParseError
   }
 
 //  Ignored as these keywords are not listed as reserved keywords yet


### PR DESCRIPTION
## Description

This test should verify that a variable should not be allowed to be a key word. This should fail at parse time.
As we only checked if it returned an ValError this all succeeded. However, this is not accurate as the error wasn't always thrown at parse-time.

What would happen is that the expression got evaluated. It turned out the variable didn't exist and also throw the ValError. This means the assertion would succeed, but the test would actually be a false-positive.

With this custom matcher we can verify that we actually get the error we expect, by verifying if it's a parse error or not.
The keywords that have not been listed are now added to an ignore test case.


I tried adding the missing key words to the list and that broke a lot of tests. I figured there was a reason why they weren't there 😄 

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

I didn't create one, but it was mentioned [here](https://github.com/camunda/feel-scala/pull/676#discussion_r1258134087) 
