### PR TITLE
ci: Enable GitHub CI for merge-group

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,6 +3,8 @@ name: build-docs
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
 
 jobs:
   build-docs:

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -1,6 +1,7 @@
 name: Build project with Maven
 on:
   pull_request:
+  merge_group:
   schedule:
   - cron: '2 2 * * 1-5' # run nightly master builds on weekdays
 


### PR DESCRIPTION
## Description

Follow the [guide](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) to enable merge queues.

## Related issues


