### PR TITLE
Improve null handling in filter expressions

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -789,9 +789,9 @@ class FeelInterpreter {
     val withBooleanFilter = (list: List[Val]) => mapEither[Val, Val](
       list,
       item =>
-        withBoolean(filter(item), {
-          case true => item
-          case false => conditionNotFulfilled
+        (filter(item) match {
+          case ValBoolean(true) => item
+          case _ => conditionNotFulfilled
         }).toEither,
       items => ValList(items.filterNot(_ == conditionNotFulfilled))
     )
@@ -809,7 +809,10 @@ class FeelInterpreter {
           case fulFilledItems: ValList => fulFilledItems
           case error => error
         }
-        case other => error(s"Expected boolean filter or number but found '$other'")
+        case _ => withBooleanFilter(list.tail) match {
+          case ValList(fulFilledItems) => ValList(fulFilledItems)
+          case error => error
+        }
       })
     ).getOrElse(
       // Return always an empty list if the given list is empty. Note that we would return `null`

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -106,7 +106,9 @@ class InterpreterListExpressionTest
 
     eval("xs [item > 2]", Map("xs" -> List(1, 2, 3, 4))) should be(
       ValList(List(ValNumber(3), ValNumber(4))))
+  }
 
+  it should "be filtered via comparison with null" in {
     // items that are not comparable to null are ignored
     eval("[1,2,3,4][item > null]") should be(
       ValList(List()))
@@ -114,7 +116,9 @@ class InterpreterListExpressionTest
     // items that are not comparable to null are ignored
     eval("[1,2,3,4][item < null]") should be(
       ValList(List()))
+  }
 
+  it should "be filtered via comparison with null elements" in {
     // null is not comparable to 2, so it's ignored
     eval("[1,2,null,4][item > 2]") should be(
       ValList(List(ValNumber(4))))

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -260,15 +260,12 @@ class InterpreterListExpressionTest
       ValNumber(1))
   }
 
-  it should "fail if the filter doesn't return a boolean or a number" in {
+  it should "be filtered if the filter doesn't always return a boolean or a number" in {
     eval(""" [1,2,3,4]["not a valid filter"] """) should be (
-      ValError("Expected boolean filter or number but found 'ValString(not a valid filter)'")
+      ValList(List())
     )
-  }
-
-  it should "fail if the filter doesn't return always a boolean" in {
     eval("[1,2,3,4][if item < 3 then true else null]") should be (
-      ValError("Expected Boolean but found 'ValNull'")
+      ValList(List(ValNumber(1), ValNumber(2)))
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -122,7 +122,9 @@ class InterpreterListExpressionTest
     // null is the only item for which the comparison returns true
     eval("[1,2,null,4][item = null]") should be(
       ValList(List(ValNull)))
+  }
 
+  ignore should "be filtered via comparison with missing variable" in {
     // null is the only item for which the comparison returns true
     eval("[1,2,x,4][item = null]") should be(
       ValList(List(ValNull)))

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -106,6 +106,30 @@ class InterpreterListExpressionTest
 
     eval("xs [item > 2]", Map("xs" -> List(1, 2, 3, 4))) should be(
       ValList(List(ValNumber(3), ValNumber(4))))
+
+    // items that are not comparable to null are ignored
+    eval("[1,2,3,4][item > null]") should be(
+      ValList(List()))
+
+    // items that are not comparable to null are ignored
+    eval("[1,2,3,4][item < null]") should be(
+      ValList(List()))
+
+    // null is not comparable to 2, so it's ignored
+    eval("[1,2,null,4][item > 2]") should be(
+      ValList(List(ValNumber(4))))
+
+    // null is the only item for which the comparison returns true
+    eval("[1,2,null,4][item = null]") should be(
+      ValList(List(ValNull)))
+
+    // null is the only item for which the comparison returns true
+    eval("[1,2,x,4][item = null]") should be(
+      ValList(List(ValNull)))
+
+    // missing variable becomes null, so same as direct null item
+    eval("[1,2,x,4][item > 2]") should be(
+      ValList(List(ValNumber(4))))
   }
 
   it should "be filtered via index" in {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This changes the behavior of filter expressions to be more lenient.

Filter expressions now filter the list even when the filter expression is not evaluating to a boolean (for item comparison) or a number (for direct access).

When the filter expression would previously cause an error, the error is now suppressed and a list with only those values that match the filter expression is returned.

Please note that this pull request does not fully resolve issue #582. It does not yet deal with lists of contexts where the filter expression refers to missing properties of those contexts. This should be resolved in another pull request.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

partially deals with #582 (filters over context lists are not yet covered)
