### PR TITLE
fix: Unary-test expression with null value

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -356,21 +356,14 @@ class FeelInterpreter {
   }
 
   private def unaryOpDual(
-      x: Val,
-      y: Val,
-      c: (Val, Val, Val) => Boolean,
-      f: Boolean => Val)(implicit context: EvalContext): Val =
+                           x: Val,
+                           y: Val,
+                           c: (Val, Val, Val) => Boolean,
+                           f: Boolean => Val)(implicit context: EvalContext): Val =
     withVal(
-      input,
-      _ match {
-        case ValNull                             => f(false)
-        case _ if (x == ValNull || y == ValNull) => f(false)
-        case i if (!i.isComparable)              => ValError(s"$i is not comparable")
-        case _ if (!x.isComparable)              => ValError(s"$x is not comparable")
-        case _ if (!y.isComparable)              => ValError(s"$y is not comparable")
-        case i if (i.getClass != x.getClass) =>
-          ValError(s"$i can not be compared to $x")
-        case i if (i.getClass != y.getClass) =>
+      input, {
+        case i if (!i.isComparable || !x.isComparable || !y.isComparable) => ValNull
+        case i if (i.getClass != x.getClass || i.getClass != y.getClass) =>
           ValError(s"$i can not be compared to $y")
         case i => f(c(i, x, y))
       }

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -581,9 +581,15 @@ object FeelParser {
       case tests       => AtLeastOne(tests.toList)
     }
 
-  // boolean literals are ambiguous for unary-tests. give precedence to comparison with input.
+  // Expressions are a subset of positive-unary-test. However, we need to give precedence to the
+  // following cases to avoid ambiguous behavior:
+  // - comparison with a boolean (e.g. `true`, `false`)
+  // - comparison with less or greater than (e.g. `< 3`, `>= 5`)
+  // - comparison with an interval (e.g. `[2..5]`)
   private def positiveUnaryTest[_: P]: P[Exp] =
-    (boolean.map(InputEqualTo) ~ End) | expression.map(UnaryTestExpression)
+    (boolean.map(InputEqualTo) ~ End) |
+      simplePositiveUnaryTest |
+      expression.map(UnaryTestExpression)
 
   private def anyInput[_: P]: P[Exp] =
     P(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterNumberExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterNumberExpressionTest.scala
@@ -184,7 +184,7 @@ class InterpreterNumberExpressionTest
     eval("null < 2") should be(ValNull)
   }
 
-  ignore should "compare with 'null in'" in {
+  it should "compare null with 'in' operator" in {
     eval("null in < 2") should be(ValNull)
     eval("null in (2..4)") should be(ValNull)
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -133,9 +133,14 @@ class InterpreterUnaryTest
     evalUnaryTests(null, "3") should be(ValBoolean(false))
   }
 
-  ignore should "compare to null with < or >" in {
+  it should "compare null with less/greater than" in {
     evalUnaryTests(null, "< 3") should be(ValNull)
+    evalUnaryTests(null, "<= 3") should be(ValNull)
     evalUnaryTests(null, "> 3") should be(ValNull)
+    evalUnaryTests(null, ">= 3") should be(ValNull)
+  }
+
+  it should "compare null with interval" in {
     evalUnaryTests(null, "(0..10)") should be(ValNull)
   }
 


### PR DESCRIPTION
## Description

Align the behavior of unary-tests with a comparison to `null`. In both cases, the engine returns `null`. 

For example, the evaluation of `< 3` with `null` as the input value returns `null`. Same as the comparison `null < 3` returns `null`. 

Fixing the behavior in the parser by introducing a special case for simple-positive-unary-test (i.e. comparison with the input value).

## Related issues

closes #679 
