### PR TITLE
feat: The invocation of a non-existing function returns null

### DIFF
--- a/src/main/scala/org/camunda/feel/api/EvaluationFailure.scala
+++ b/src/main/scala/org/camunda/feel/api/EvaluationFailure.scala
@@ -9,4 +9,7 @@ package org.camunda.feel.api
 case class EvaluationFailure(
                               failureType: EvaluationFailureType,
                               failureMessage: String
-                            )
+                            ) {
+
+  override def toString: String = s"[$failureType] $failureMessage"
+}

--- a/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
@@ -47,7 +47,7 @@ class EvalContext(val valueMapper: ValueMapper,
       .getFunctions(name)
       .find(filter)
       .getOrElse(ValError(
-        s"no function found with name '$name' and $paramCount parameters"))
+        s"No function found with name '$name' and $paramCount parameters"))
   }
 
   def function(name: String, parameters: Set[String]): Val = {
@@ -57,7 +57,7 @@ class EvalContext(val valueMapper: ValueMapper,
       .getFunctions(name)
       .find(filter)
       .getOrElse(ValError(
-        s"no function found with name '$name' and parameters: ${
+        s"No function found with name '$name' and parameters: ${
           parameters
             .mkString(",")
         }"))

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -686,9 +686,13 @@ class FeelInterpreter {
     )
 
   private def withFunction(x: Val, f: ValFunction => Val)(implicit context: EvalContext): Val = x match {
-    case x: ValFunction     => f(x)
-    case ValError(failure)  => error(EvaluationFailureType.NO_FUNCTION_FOUND, failure)
-    case _                  => error(s"expect Function but found '$x'")
+    case x: ValFunction => f(x)
+    case ValError(failure) =>
+      error(EvaluationFailureType.NO_FUNCTION_FOUND, failure)
+      ValNull
+    case _ =>
+      error(EvaluationFailureType.INVALID_TYPE, s"Expected function but found '$x'")
+      ValNull
   }
 
   private def invokeFunction(function: ValFunction, params: FunctionParameters)(

--- a/src/test/scala/org/camunda/feel/impl/EvaluationResultMatchers.scala
+++ b/src/test/scala/org/camunda/feel/impl/EvaluationResultMatchers.scala
@@ -1,0 +1,48 @@
+package org.camunda.feel.impl
+
+import org.camunda.feel.api.{EvaluationFailure, EvaluationFailureType, EvaluationResult, FailedEvaluationResult, SuccessfulEvaluationResult}
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+trait EvaluationResultMatchers {
+
+  def returnResult(expectedResult: Any) = new EvaluationResultValueMatcher(expectedResult)
+
+  def returnNull() = new EvaluationResultValueMatcher(expectedResult = null)
+
+  def reportFailure(failureType: EvaluationFailureType, failureMessage: String) =
+    new SuppressedFailureMatcher(EvaluationFailure(failureType, failureMessage))
+
+  class EvaluationResultValueMatcher(expectedResult: Any) extends Matcher[EvaluationResult] {
+    override def apply(evaluationResult: EvaluationResult): MatchResult = {
+      evaluationResult match {
+        case SuccessfulEvaluationResult(result, _) => MatchResult(
+          result == expectedResult,
+          s"the evaluation didn't returned '$expectedResult' but '${evaluationResult.result}'",
+          s"The evaluation returned '${evaluationResult.result}' as expected",
+        )
+        case FailedEvaluationResult(failure, _) => MatchResult(
+          false,
+          s"the evaluation didn't returned '$expectedResult' but failed with '${failure.message}'",
+          s"the evaluation didn't returned '$expectedResult' but failed with '${failure.message}'",
+        )
+      }
+    }
+  }
+
+  class SuppressedFailureMatcher(expectedFailure: EvaluationFailure) extends Matcher[EvaluationResult] {
+    override def apply(evaluationResult: EvaluationResult): MatchResult = {
+      val matchResult = (suppressedFailures: List[EvaluationFailure]) => MatchResult(
+        suppressedFailures.contains(expectedFailure),
+        s"the evaluation didn't report '$expectedFailure' but '$suppressedFailures'",
+        s"the evaluation reported '$expectedFailure' as expected",
+      )
+      evaluationResult match {
+        case SuccessfulEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
+        case FailedEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
+      }
+    }
+  }
+
+}
+
+object EvaluationResultMatchers extends EvaluationResultMatchers

--- a/src/test/scala/org/camunda/feel/impl/FeelEngineTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/FeelEngineTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.impl
+
+import org.camunda.feel.api.{EvaluationResult, FeelEngineApi, FeelEngineBuilder}
+import org.camunda.feel.context.Context
+import org.camunda.feel.syntaxtree.ValFunction
+
+trait FeelEngineTest {
+
+  val engine: FeelEngineApi = FeelEngineBuilder().build()
+
+  def evaluateExpression(
+      expression: String,
+      variables: Map[String, Any] = Map(),
+      functions: Map[String, ValFunction] = Map()
+  ): EvaluationResult = {
+    val context =
+      Context.StaticContext(
+        variables = variables,
+        functions = functions.map { case (n, f) => n -> List(f) })
+
+    engine.evaluateExpression(expression, context)
+  }
+
+}

--- a/src/test/scala/org/camunda/feel/impl/FeelEngineTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/FeelEngineTest.scala
@@ -39,6 +39,24 @@ trait FeelEngineTest {
     engine.evaluateExpression(expression, context)
   }
 
+  def evaluateUnaryTests(
+                          expression: String,
+                          inputValue: Any,
+                          variables: Map[String, Any] = Map(),
+                          functions: Map[String, ValFunction] = Map()
+                        ): EvaluationResult = {
+    val context =
+      Context.StaticContext(
+        variables = variables,
+        functions = functions.map { case (n, f) => n -> List(f) })
+
+    engine.evaluateUnaryTests(
+      expression = expression,
+      inputValue = inputValue,
+      context = context
+    )
+  }
+
   def evaluateFunction(function: String): ValFunction = {
     engine.evaluateExpression(function) match {
       case SuccessfulEvaluationResult(result: ValFunction, _) => result

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -33,14 +33,14 @@ class SuppressedFailuresTest extends AnyFlatSpec
   it should "report a suppressed failure for a non-existing function (with position arguments)" in {
     evaluateExpression("f(1, 2)") should reportFailure(
       failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
-      failureMessage = "no function found with name 'f' and 2 parameters"
+      failureMessage = "No function found with name 'f' and 2 parameters"
     )
   }
 
   it should "report a suppressed failure for a non-existing function (with named arguments)" in {
     evaluateExpression("f(x: 1, y: 2)") should reportFailure(
       failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
-      failureMessage = "no function found with name 'f' and parameters: x,y"
+      failureMessage = "No function found with name 'f' and parameters: x,y"
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -1,107 +1,106 @@
 package org.camunda.feel.impl
 
-import org.camunda.feel.api._
+import org.camunda.feel.api.{EvaluationFailureType, EvaluationFailure}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.matchers.{MatchResult, Matcher}
 
 class SuppressedFailuresTest extends AnyFlatSpec
-  with Matchers {
-
-  private val engine: FeelEngineApi = FeelEngineBuilder().build()
+  with FeelEngineTest
+  with Matchers
+  with EvaluationResultMatchers {
 
   "The engine" should "report a suppressed failure for a non-existing variable" in {
-    engine.evaluateExpression("x + 1") should reportFailure(
+    evaluateExpression("x + 1") should reportFailure(
       failureType = EvaluationFailureType.NO_VARIABLE_FOUND,
       failureMessage = "No variable found with name 'x'"
     )
   }
 
   it should "report a suppressed failure for a non-existing context entry" in {
-    engine.evaluateExpression("{x: 1}.y") should reportFailure(
+    evaluateExpression("{x: 1}.y") should reportFailure(
       failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
       failureMessage = "context contains no entry with key 'y'"
     )
   }
 
   it should "report a suppressed failure for a non-existing property" in {
-    engine.evaluateExpression(""" @"P1Y".days """) should reportFailure(
+    evaluateExpression(""" @"P1Y".days """) should reportFailure(
       failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
       failureMessage = "No property found with name 'days' of value 'P1Y'. Available properties: years,months"
     )
   }
 
   it should "report a suppressed failure for a non-existing function (with position arguments)" in {
-    engine.evaluateExpression("f(1, 2)") should reportFailure(
+    evaluateExpression("f(1, 2)") should reportFailure(
       failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
       failureMessage = "no function found with name 'f' and 2 parameters"
     )
   }
 
   it should "report a suppressed failure for a non-existing function (with named arguments)" in {
-    engine.evaluateExpression("f(x: 1, y: 2)") should reportFailure(
+    evaluateExpression("f(x: 1, y: 2)") should reportFailure(
       failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
       failureMessage = "no function found with name 'f' and parameters: x,y"
     )
   }
 
   it should "report a suppressed failure if a function invocation fails" in {
-    engine.evaluateExpression("number(null)") should reportFailure(
+    evaluateExpression("number(null)") should reportFailure(
       failureType = EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
       failureMessage = "Failed to invoke function 'number': Illegal arguments: List(ValNull)"
     )
   }
 
   it should "report a suppressed failure if input is not comparable with interval" in {
-    engine.evaluateUnaryTests("[2..5]", "NaN") should reportFailure(
+    evaluateUnaryTests("[2..5]", "NaN") should reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
       failureMessage = "Can't compare ValString(NaN) with ValNumber(2) and ValNumber(5)"
     )
   }
 
   it should "report a suppressed failure if values are not comparable" in {
-    engine.evaluateExpression("true < 2") should reportFailure(
+    evaluateExpression("true < 2") should reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
       failureMessage = "Can't compare ValBoolean(true) with ValNumber(2)"
     )
   }
 
   it should "report a suppressed failure if an addition has incompatible values" in {
-    engine.evaluateExpression("2 + true") should reportFailure(
+    evaluateExpression("2 + true") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Number but found 'ValBoolean(true)'"
     )
   }
 
   it should "report a suppressed failure if a condition is not a boolean" in {
-    engine.evaluateExpression("if 5 then 1 else 2") should reportFailure(
+    evaluateExpression("if 5 then 1 else 2") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Boolean but found 'ValNumber(5)'"
     )
 
-    engine.evaluateExpression("true and 2") should reportFailure(
+    evaluateExpression("true and 2") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Boolean but found 'ValNumber(2)'"
     )
 
-    engine.evaluateExpression("false or 3") should reportFailure(
+    evaluateExpression("false or 3") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Boolean but found 'ValNumber(3)'"
     )
 
-    engine.evaluateExpression("some x in [false, 2] satisfies x") should reportFailure(
+    evaluateExpression("some x in [false, 2] satisfies x") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Boolean but found 'ValNumber(2)'"
     )
 
-    engine.evaluateExpression("every x in [true, 3] satisfies x") should reportFailure(
+    evaluateExpression("every x in [true, 3] satisfies x") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
       failureMessage = "Expected Boolean but found 'ValNumber(3)'"
     )
   }
 
   it should "report a suppressed failure only once" in {
-    val evaluationResult = engine.evaluateExpression("1 + x")
+    val evaluationResult = evaluateExpression("1 + x")
 
     evaluationResult.hasSuppressedFailures should be (true)
     evaluationResult.suppressedFailures should have size(2)
@@ -116,25 +115,6 @@ class SuppressedFailuresTest extends AnyFlatSpec
         failureMessage = "Expected Number but found 'ValError(No variable found with name 'x')'"
       )
     )
-  }
-
-  // ========== test helpers =========
-
-  private def reportFailure(failureType: EvaluationFailureType, failureMessage: String) =
-    new SuppressedFailureMatcher(EvaluationFailure(failureType, failureMessage))
-
-  private class SuppressedFailureMatcher(expectedFailure: EvaluationFailure) extends Matcher[EvaluationResult] {
-    override def apply(evaluationResult: EvaluationResult): MatchResult = {
-      val matchResult = (suppressedFailures: List[EvaluationFailure]) => MatchResult(
-        suppressedFailures.contains(expectedFailure),
-        s"${evaluationResult.suppressedFailures} doesn't contain '$expectedFailure'",
-        s"$evaluationResult contains '$expectedFailure'",
-      )
-      evaluationResult match {
-        case SuccessfulEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
-        case FailedEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
-      }
-    }
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -30,27 +30,6 @@ class SuppressedFailuresTest extends AnyFlatSpec
     )
   }
 
-  it should "report a suppressed failure for a non-existing function (with position arguments)" in {
-    evaluateExpression("f(1, 2)") should reportFailure(
-      failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
-      failureMessage = "No function found with name 'f' and 2 parameters"
-    )
-  }
-
-  it should "report a suppressed failure for a non-existing function (with named arguments)" in {
-    evaluateExpression("f(x: 1, y: 2)") should reportFailure(
-      failureType = EvaluationFailureType.NO_FUNCTION_FOUND,
-      failureMessage = "No function found with name 'f' and parameters: x,y"
-    )
-  }
-
-  it should "report a suppressed failure if a function invocation fails" in {
-    evaluateExpression("number(null)") should reportFailure(
-      failureType = EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
-      failureMessage = "Failed to invoke function 'number': Illegal arguments: List(ValNull)"
-    )
-  }
-
   it should "report a suppressed failure if input is not comparable with interval" in {
     evaluateUnaryTests("[2..5]", "NaN") should reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -125,36 +125,36 @@ class InterpreterFunctionTest
 
     evaluateExpression(expression = "f()", functions = functions) should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and 0 parameters")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and 0 parameters")
       )
 
     evaluateExpression(expression = "f(1)", functions = functions) should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and 1 parameters")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and 1 parameters")
       )
 
     evaluateExpression(expression = "f(x:1,z:3)", functions = functions) should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and parameters: x,z")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and parameters: x,z")
       )
 
     evaluateExpression(expression = "f(x:1,y:2,z:3)", functions = functions) should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and parameters: x,y,z")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and parameters: x,y,z")
       )
   }
 
   it should "return null if no function exists with the name" in {
     evaluateExpression("f()") should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and 0 parameters")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and 0 parameters")
       )
   }
 
   it should "return null if the name doesn't resolve to a function" in {
     evaluateExpression(expression = "f()", variables = Map("x" -> "a variable")) should (
       returnNull() and
-        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "no function found with name 'f' and 0 parameters")
+        reportFailure(EvaluationFailureType.NO_FUNCTION_FOUND, "No function found with name 'f' and 0 parameters")
       )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -98,20 +98,16 @@ class InterpreterFunctionTest
     eval("a(b(1))", functions = functions) should be(ValNumber(4))
   }
 
-  it should "fail to invoke with wrong number of parameters" in {
+  it should "return null if invoked with wrong parameters" in {
 
     val functions =
       Map("f" -> eval("function(x,y) true").asInstanceOf[ValFunction])
 
-    eval("f()", functions = functions) should be(
-      ValError("no function found with name 'f' and 0 parameters"))
-    eval("f(1)", functions = functions) should be(
-      ValError("no function found with name 'f' and 1 parameters"))
+    eval("f()", functions = functions) should be(ValNull)
+    eval("f(1)", functions = functions) should be(ValNull)
 
-    eval("f(x:1,z:3)", functions = functions) should be(
-      ValError("no function found with name 'f' and parameters: x,z"))
-    eval("f(x:1,y:2,z:3)", functions = functions) should be(
-      ValError("no function found with name 'f' and parameters: x,y,z"))
+    eval("f(x:1,z:3)", functions = functions) should be(ValNull)
+    eval("f(x:1,y:2,z:3)", functions = functions) should be(ValNull)
   }
 
   it should "replace not set parameters with null" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -29,7 +29,7 @@ class InterpreterFunctionTest
     with Matchers
     with FeelIntegrationTest {
 
-  "A function definition" should "be interpeted" in {
+  "A function definition" should "be returned as a function" in {
 
     val function = eval("function(x) x + 1")
 
@@ -37,7 +37,7 @@ class InterpreterFunctionTest
     function.asInstanceOf[ValFunction].params should be(List("x"))
   }
 
-  it should "be invoked without parameter" in {
+  "A function invocation" should "invoke a function without parameter" in {
 
     val functions =
       Map("f" -> eval("""function() "invoked" """).asInstanceOf[ValFunction])
@@ -45,7 +45,7 @@ class InterpreterFunctionTest
     eval("f()", functions = functions) should be(ValString("invoked"))
   }
 
-  it should "be invoked with one positional parameter" in {
+  it should "invoke a function with a positional parameter" in {
 
     val functions =
       Map("f" -> eval("function(x) x + 1").asInstanceOf[ValFunction])
@@ -54,7 +54,7 @@ class InterpreterFunctionTest
     eval("f(2)", functions = functions) should be(ValNumber(3))
   }
 
-  it should "be invoked with positional parameters" in {
+  it should "invoke a function with positional parameters" in {
 
     val functions =
       Map("add" -> eval("function(x,y) x + y").asInstanceOf[ValFunction])
@@ -63,7 +63,7 @@ class InterpreterFunctionTest
     eval("add(2,3)", functions = functions) should be(ValNumber(5))
   }
 
-  it should "be invoked with one named parameter" in {
+  it should "invoke a function a named parameter" in {
 
     val functions =
       Map("f" -> eval("function(x) x + 1").asInstanceOf[ValFunction])
@@ -72,7 +72,7 @@ class InterpreterFunctionTest
     eval("f(x:2)", functions = functions) should be(ValNumber(3))
   }
 
-  it should "be invoked with named parameters" in {
+  it should "invoke a function with named parameters" in {
 
     val functions =
       Map("sub" -> eval("function(x,y) x - y").asInstanceOf[ValFunction])
@@ -81,7 +81,7 @@ class InterpreterFunctionTest
     eval("sub(y:2,x:4)", functions = functions) should be(ValNumber(2))
   }
 
-  it should "be invoked with an expression as parameter" in {
+  it should "take an expression as parameter" in {
 
     val functions =
       Map("f" -> eval("function(x) x + 1").asInstanceOf[ValFunction])
@@ -89,7 +89,7 @@ class InterpreterFunctionTest
     eval("f(2 + 3)", functions = functions) should be(ValNumber(6))
   }
 
-  it should "be invoked as parameter of another function" in {
+  it should "take another function as parameter" in {
 
     val functions =
       Map("a" -> eval("function(x) x + 1").asInstanceOf[ValFunction],
@@ -126,19 +126,19 @@ class InterpreterFunctionTest
     eval("f(x:1,y:1)", functions = functions) should be(ValString("ok"))
   }
 
-  it should "be invoked and followed by a path" in {
+  it should "be followed by a path" in {
     eval(""" date(2019,09,17).year """) should be(ValNumber(2019))
   }
 
-  it should "be invoked and followed by a filter" in {
+  it should "be followed by a filter" in {
     eval(""" index of([1,2,3,2],2)[1]  """) should be(ValNumber(2))
   }
 
-  it should "be properly evaluated when parameters contain whitespaces" in {
+  it should "invoke a function with parameters contain whitespaces" in {
     eval("""number(from: "1.000.000,01", decimal separator:",", grouping separator:".")""") should be(ValNumber(1_000_000.01))
   }
 
-  it should "be invoked with one named parameter containing whitespaces" in {
+  it should "invoke a function with a named parameter containing whitespaces" in {
     val functions =
       Map("f" -> eval("""function(test name) `test name` + 1""").asInstanceOf[ValFunction])
 
@@ -146,7 +146,7 @@ class InterpreterFunctionTest
     eval("f(test name:2)", functions = functions) should be(ValNumber(3))
   }
 
-  it should "be invoked with one named parameter containing more than one whitespace" in {
+  it should "invoke a function with a named parameter containing more than one whitespace" in {
     val functions =
       Map("f" -> eval("""function(test   name yada) `test   name yada` + 1""").asInstanceOf[ValFunction])
 
@@ -154,7 +154,7 @@ class InterpreterFunctionTest
     eval("f(test   name yada:2)", functions = functions) should be(ValNumber(3))
   }
 
-  "An external java function definition" should "be invoked with one double parameter" in {
+  "An external Java function invocation" should "invoke a function with a double parameter" in {
 
     val functions = Map(
       "cos" -> eval(
@@ -165,7 +165,7 @@ class InterpreterFunctionTest
     eval("cos(1)", functions = functions) should be(ValNumber(Math.cos(1)))
   }
 
-  it should "be invoked with two int parameters" in {
+  it should "invoke a function with two int parameters" in {
 
     val functions = Map(
       "max" -> eval(
@@ -175,7 +175,7 @@ class InterpreterFunctionTest
     eval("max(1,2)", functions = functions) should be(ValNumber(2))
   }
 
-  it should "be invoked with one long parameters" in {
+  it should "invoke a function with a long parameters" in {
 
     val functions = Map(
       "abs" -> eval(
@@ -185,7 +185,7 @@ class InterpreterFunctionTest
     eval("abs(-1)", functions = functions) should be(ValNumber(1))
   }
 
-  it should "be invoked with one float parameters" in {
+  it should "invoke a function with a float parameters" in {
 
     val functions = Map(
       "round" -> eval(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -110,6 +110,14 @@ class InterpreterFunctionTest
     eval("f(x:1,y:2,z:3)", functions = functions) should be(ValNull)
   }
 
+  it should "return null if no function exists with the name" in {
+    eval("f()") should be(ValNull)
+  }
+
+  it should "return null if the name doesn't resolve to a function" in {
+    eval("f()", variables = Map("x" -> "a variable")) should be(ValNull)
+  }
+
   it should "replace not set parameters with null" in {
 
     val functions = Map("f" -> eval("""

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -158,6 +158,15 @@ class InterpreterFunctionTest
       )
   }
 
+  it should "return null for a built-in function if invoked with wrong arguments" in {
+    evaluateExpression("number(null)") should (
+      returnNull() and
+        reportFailure(
+          failureType = EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
+          failureMessage = "Failed to invoke function 'number': Illegal arguments: List(ValNull)")
+      )
+  }
+
   it should "replace not set parameters with null" in {
     val functions = Map("f" -> evaluateFunction("""
       function(x,y)


### PR DESCRIPTION
## Description

* Change the behavior of the engine if an expression invokes a non-existing function. Instead of failing the evaluation, the invocation returns `null`. 
* Additionally, the evaluation reports a failure that the function doesn't exist. 
* Extend and refactor the test cases for the function invocation to verify the evaluation result and the reported failures.

## Related issues

closes #670
