### PR TITLE
feat: Non-existing context entries result in `null`

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -873,7 +873,7 @@ class FeelInterpreter {
           case _: ValError =>
             val detailedMessage = ctx.context.variableProvider.keys match {
               case Nil => "The context is empty"
-              case keys => s"Available keys: ${keys.mkString(", ")}"
+              case keys => s"Available keys: ${keys.map("'" + _ + "'").mkString(", ")}"
             }
             error(
               failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
@@ -891,7 +891,7 @@ class FeelInterpreter {
         ValNull
       case value =>
         value.property(key).getOrElse {
-          val propertyNames: String = value.propertyNames().mkString(",")
+          val propertyNames: String = value.propertyNames().map("'" + _ + "'").mkString(", ")
           error(
             failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
             failureMessage = s"No property found with name '$key' of value '$value'. Available properties: $propertyNames"

--- a/src/test/scala/org/camunda/feel/impl/EvaluationResultMatchers.scala
+++ b/src/test/scala/org/camunda/feel/impl/EvaluationResultMatchers.scala
@@ -25,6 +25,13 @@ trait EvaluationResultMatchers {
 
   def returnNull() = new EvaluationResultValueMatcher(expectedResult = null)
 
+  def failWith(expectedFailureMessage: String) =
+    new EvaluationResultFailureMatcher(expectedFailureMessage)
+
+  def failToParse() = new EvaluationResultFailureMatcher(
+    expectedFailureMessage = "failed to parse"
+  )
+
   def reportFailure(failureType: EvaluationFailureType, failureMessage: String) =
     new SuppressedFailureMatcher(EvaluationFailure(failureType, failureMessage))
 
@@ -55,6 +62,23 @@ trait EvaluationResultMatchers {
       evaluationResult match {
         case SuccessfulEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
         case FailedEvaluationResult(_, suppressedFailures) => matchResult(suppressedFailures)
+      }
+    }
+  }
+
+  class EvaluationResultFailureMatcher(expectedFailureMessage: String) extends Matcher[EvaluationResult] {
+    override def apply(evaluationResult: EvaluationResult): MatchResult = {
+      evaluationResult match {
+        case SuccessfulEvaluationResult(result, _) => MatchResult(
+          false,
+          s"the evaluation didn't fail with '$expectedFailureMessage' but returned '${result}'",
+          s"the evaluation didn't fail with '$expectedFailureMessage' but returned '${result}'"
+        )
+        case FailedEvaluationResult(failure, _) => MatchResult(
+          failure.message.contains(expectedFailureMessage),
+          s"the evaluation failure message didn't contain '$expectedFailureMessage' but was '${failure.message}'",
+          s"the evaluation failure message contained '${failure.message}' as expected",
+        )
       }
     }
   }

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -35,7 +35,7 @@ class SuppressedFailuresTest extends AnyFlatSpec
   it should "report a suppressed failure for a non-existing context entry" in {
     evaluateExpression("{x: 1}.y") should reportFailure(
       failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-      failureMessage = "context contains no entry with key 'y'"
+      failureMessage = "No context entry found with key 'y'. Available keys: x"
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -35,14 +35,14 @@ class SuppressedFailuresTest extends AnyFlatSpec
   it should "report a suppressed failure for a non-existing context entry" in {
     evaluateExpression("{x: 1}.y") should reportFailure(
       failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-      failureMessage = "No context entry found with key 'y'. Available keys: x"
+      failureMessage = "No context entry found with key 'y'. Available keys: 'x'"
     )
   }
 
   it should "report a suppressed failure for a non-existing property" in {
     evaluateExpression(""" @"P1Y".days """) should reportFailure(
       failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-      failureMessage = "No property found with name 'days' of value 'P1Y'. Available properties: years,months"
+      failureMessage = "No property found with name 'days' of value 'P1Y'. Available properties: 'years', 'months'"
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionTest.scala
@@ -52,11 +52,12 @@ class BuiltinFunctionsTest
     eval(""" is defined( {"a":1}.a ) """) should be(ValBoolean(true))
   }
 
-  it should "return false if the value is not present" in {
-
+  it should "return false if a variable doesn't exist" in {
     eval("is defined(a)") should be(ValBoolean(false))
     eval("is defined(a.b)") should be(ValBoolean(false))
+  }
 
+  ignore should "return false if a context entry doesn't exist" in {
     eval("is defined({}.a)") should be(ValBoolean(false))
     eval("is defined({}.a.b)") should be(ValBoolean(false))
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterBeanExpressionTest.scala
@@ -104,7 +104,7 @@ class InterpreterBeanExpressionTest
     ) should (returnNull() and
       reportFailure(
         failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-        failureMessage = "No context entry found with key 'result'. Available keys: x"
+        failureMessage = "No context entry found with key 'result'. Available keys: 'x'"
       ))
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -134,7 +134,7 @@ class InterpreterContextExpressionTest
       returnNull() and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'z'. Available keys: x, y"
+          failureMessage = "No context entry found with key 'z'. Available keys: 'x', 'y'"
         )
       )
   }
@@ -156,7 +156,7 @@ class InterpreterContextExpressionTest
       returnNull() and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'b'. Available keys: a") and
+          failureMessage = "No context entry found with key 'b'. Available keys: 'a'") and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
           failureMessage = "No context entry found with key 'c'. The context is null")
@@ -217,24 +217,24 @@ class InterpreterContextExpressionTest
       returnResult(List(1, null)) and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'a'. Available keys: b")
+          failureMessage = "No context entry found with key 'a'. Available keys: 'b'")
       )
 
     evaluateExpression("[ {a:1}, {b:2} ].b") should (
       returnResult(List(null, 2)) and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'b'. Available keys: a")
+          failureMessage = "No context entry found with key 'b'. Available keys: 'a'")
       )
 
     evaluateExpression("[ {a:1}, {b:2} ].c") should (
       returnResult(List(null, null)) and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'c'. Available keys: a") and
+          failureMessage = "No context entry found with key 'c'. Available keys: 'a'") and
         reportFailure(
           failureType = EvaluationFailureType.NO_CONTEXT_ENTRY_FOUND,
-          failureMessage = "No context entry found with key 'c'. Available keys: b")
+          failureMessage = "No context entry found with key 'c'. Available keys: 'b'")
       )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -275,8 +275,8 @@ class InterpreterListExpressionTest
 
   it should "fail if one element fails" in {
 
-    eval("[1, {}.x]") should be(
-      ValError("context contains no entry with key 'x'"))
+    eval("[1, x]") should be(
+      ValError("No variable found with name 'x'"))
   }
 
   it should "be compared with '='" in {


### PR DESCRIPTION
## Description

* Change the behavior to return `null` if a context doesn't contain an entry with the given key, or if the context is null. Previously, the evaluation failed in this case.
* Write new test cases and adjust the expected behavior of existing test cases. Use the new evaluation result matcher in all test cases to verify reported failures, improve readability, and align the testing style.  

## Related issues

contributes to #674
