### PR TITLE
feat: update date and time() function with new param input types

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-conversion.md
@@ -185,12 +185,18 @@ Parses the given string into a date and time.
 ```js
 date and time(from: string): date and time
 ```
+```js
+date and time(from: date and time): date and time
+```
 
 **Examples**
 
 ```js
 date and time("2018-04-29T009:30:00") 
-// date and time("2018-04-29T009:30:00")
+// date and time("2018-04-29T09:30:00")
+
+date and time(now())
+// date and time("2023-08-03T15:30:00.12345")
 ```
 
 ## date and time(date, time)

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -63,6 +63,9 @@ object ConversionBuiltinFunctions {
   private def dateTime =
     builtinFunction(params = List("from"), invoke = {
       case List(ValString(from)) => parseDateTime(from)
+      case List(ValDate(from)) => parseDateTime(from.format(dateFormatter))
+      case List(ValLocalDateTime(from)) =>
+        parseDateTime(from.format(localDateTimeFormatter))
       case List(ValDateTime(from)) =>
         val formattedDateTime = from.format(dateTimeFormatter)
         // remove offset-id if zone-id is present

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -63,6 +63,13 @@ object ConversionBuiltinFunctions {
   private def dateTime =
     builtinFunction(params = List("from"), invoke = {
       case List(ValString(from)) => parseDateTime(from)
+      case List(ValDateTime(from)) =>
+        val formattedDateTime = from.format(dateTimeFormatter)
+        // remove offset-id if zone-id is present
+        val dateTimeWithOffsetOrZoneId = dateTimeOffsetZoneIdPattern
+          .matcher(formattedDateTime)
+          .replaceAll("$1$3")
+        parseDateTime(dateTimeWithOffsetOrZoneId)
     })
 
   private def dateTime2 = builtinFunction(

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -22,7 +22,7 @@ import org.camunda.feel.syntaxtree._
 import org.camunda.feel._
 import org.camunda.feel.impl.FeelIntegrationTest
 
-import java.time.ZonedDateTime
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZonedDateTime}
 import scala.math.BigDecimal.double2bigDecimal
 import scala.math.BigDecimal.int2bigDecimal
 
@@ -33,6 +33,12 @@ class BuiltinConversionFunctionsTest
     extends AnyFlatSpec
     with Matchers
     with FeelIntegrationTest {
+
+  private val now = ZonedDateTime.of(
+    LocalDate.parse("2023-08-04"),
+    LocalTime.parse("14:31:30.123456789"),
+    ZoneId.of("Europe/Berlin")
+  )
 
   "A date() function" should "convert String" in {
 
@@ -61,6 +67,10 @@ class BuiltinConversionFunctionsTest
 
     eval(""" date and time(x) """, Map("x" -> "2012-12-24T23:59:00+01:00")) should be(
       ValDateTime("2012-12-24T23:59:00+01:00"))
+
+    eval(""" date and time(x) """, Map("x" -> ValDateTime(now))) should be(
+      ValDateTime(now))
+
   }
 
   it should "convert (DateTime, Timezone)" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -68,6 +68,14 @@ class BuiltinConversionFunctionsTest
     eval(""" date and time(x) """, Map("x" -> "2012-12-24T23:59:00+01:00")) should be(
       ValDateTime("2012-12-24T23:59:00+01:00"))
 
+    eval(""" date and time(x) """, Map("x" -> ValDate("2023-08-04"))) should be(
+      ValLocalDateTime("2023-08-04T00:00")
+    )
+
+    eval(""" date and time(x) """, Map("x" -> ValLocalDateTime("2023-08-04T15:45:00"))) should be(
+      ValLocalDateTime("2023-08-04T15:45:00")
+    )
+
     eval(""" date and time(x) """, Map("x" -> ValDateTime(now))) should be(
       ValDateTime(now))
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Update `date and time` conversion function. Now can accept not only `ValString` but also `ValDate`, `ValLocalDateTime` and `ValDateTime`.

This PR should resolve the related issue, but as I said in this [comment](https://github.com/camunda/feel-scala/issues/697#issuecomment-1663669104) to me is not a bug, is a new feature. And I don't know if we want to proceed with this.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #697 
