### PR TITLE
feat: Return null on accessing a non-existing property

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -903,6 +903,7 @@ class FeelInterpreter {
             failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
             failureMessage = s"No property found with name '$key' of value '$value'. Available properties: $propertyNames"
           )
+          ValNull
         }
     }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -16,14 +16,12 @@
  */
 package org.camunda.feel.impl.interpreter
 
-import org.camunda.feel._
 import org.camunda.feel.api.EvaluationFailureType
-import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest, FeelIntegrationTest}
-import org.camunda.feel.syntaxtree._
-import org.scalatest.matchers.should.Matchers
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import java.time.ZonedDateTime
+import java.time.{Duration, ZonedDateTime}
 
 /**
   * @author Philipp Ossler
@@ -31,28 +29,27 @@ import java.time.ZonedDateTime
 class DateTimeDurationPropertiesTest
     extends AnyFlatSpec
     with Matchers
-    with FeelIntegrationTest
     with FeelEngineTest
     with EvaluationResultMatchers {
 
   "A date" should "has a year property" in {
 
-    eval(""" date("2017-03-10").year """) should be(ValNumber(2017))
+    evaluateExpression(""" date("2017-03-10").year """) should returnResult(2017)
   }
 
   it should "has a month property" in {
 
-    eval(""" date("2017-03-10").month """) should be(ValNumber(3))
+    evaluateExpression(""" date("2017-03-10").month """) should returnResult(3)
   }
 
   it should "has a day property" in {
 
-    eval(""" date("2017-03-10").day """) should be(ValNumber(10))
+    evaluateExpression(""" date("2017-03-10").day """) should returnResult(10)
   }
 
   it should "has a weekday property" in {
 
-    eval(""" date("2020-09-30").weekday """) should be(ValNumber(3))
+    evaluateExpression(""" date("2020-09-30").weekday """) should returnResult(3)
   }
 
   it should "return null if the property is not available" in {
@@ -65,39 +62,42 @@ class DateTimeDurationPropertiesTest
   }
 
   it should "has properties with @-notation" in {
-    eval(""" @"2017-03-10".year """) should be(ValNumber(2017))
-    eval(""" @"2017-03-10".month """) should be(ValNumber(3))
-    eval(""" @"2017-03-10".day """) should be(ValNumber(10))
+    evaluateExpression(""" @"2017-03-10".year """) should returnResult(2017)
+    evaluateExpression(""" @"2017-03-10".month """) should returnResult(3)
+    evaluateExpression(""" @"2017-03-10".day """) should returnResult(10)
   }
 
   ///// -----
 
   "A time" should "has a hour property" in {
 
-    eval(""" time("11:45:30+02:00").hour """) should be(ValNumber(11))
+    evaluateExpression(""" time("11:45:30+02:00").hour """) should returnResult(11)
   }
 
   it should "has a minute property" in {
 
-    eval(""" time("11:45:30+02:00").minute """) should be(ValNumber(45))
+    evaluateExpression(""" time("11:45:30+02:00").minute """) should returnResult(45)
   }
 
   it should "has a second property" in {
 
-    eval(""" time("11:45:30+02:00").second """) should be(ValNumber(30))
+    evaluateExpression(""" time("11:45:30+02:00").second """) should returnResult(30)
   }
 
   it should "has a time offset property" in {
 
-    eval(""" time("11:45:30+02:00").time offset """) should be(
-      ValDayTimeDuration("PT2H"))
+    evaluateExpression(""" time("11:45:30+02:00").time offset """) should returnResult(
+      Duration.parse("PT2H")
+    )
   }
 
   it should "has a timezone property" in {
 
-    eval(""" time("11:45:30@Europe/Paris").timezone """) should be(
-      ValString("Europe/Paris"))
-    eval(""" time("11:45:30+02:00").timezone """) should be(ValNull)
+    evaluateExpression(""" time("11:45:30@Europe/Paris").timezone """) should returnResult(
+      "Europe/Paris"
+    )
+    
+    evaluateExpression(""" time("11:45:30+02:00").timezone """) should returnNull()
   }
 
   it should "return null if the property is not available" in {
@@ -110,36 +110,36 @@ class DateTimeDurationPropertiesTest
   }
 
   it should "has properties with @-notation" in {
-    eval(""" @"11:45:30+02:00".hour """) should be(ValNumber(11))
-    eval(""" @"11:45:30+02:00".minute """) should be(ValNumber(45))
-    eval(""" @"11:45:30+02:00".second """) should be(ValNumber(30))
+    evaluateExpression(""" @"11:45:30+02:00".hour """) should returnResult(11)
+    evaluateExpression(""" @"11:45:30+02:00".minute """) should returnResult(45)
+    evaluateExpression(""" @"11:45:30+02:00".second """) should returnResult(30)
   }
 
   ///// -----
 
   "A local time" should "has a hour property" in {
 
-    eval(""" time("11:45:30").hour """) should be(ValNumber(11))
+    evaluateExpression(""" time("11:45:30").hour """) should returnResult(11)
   }
 
   it should "has a minute property" in {
 
-    eval(""" time("11:45:30").minute """) should be(ValNumber(45))
+    evaluateExpression(""" time("11:45:30").minute """) should returnResult(45)
   }
 
   it should "has a second property" in {
 
-    eval(""" time("11:45:30").second """) should be(ValNumber(30))
+    evaluateExpression(""" time("11:45:30").second """) should returnResult(30)
   }
 
   it should "has a time offset property = null" in {
 
-    eval(""" time("11:45:30").time offset """) should be(ValNull)
+    evaluateExpression(""" time("11:45:30").time offset """) should returnNull()
   }
 
   it should "has a timezone property = null" in {
 
-    eval(""" time("11:45:30").timezone """) should be(ValNull)
+    evaluateExpression(""" time("11:45:30").timezone """) should returnNull()
   }
 
   it should "return null if the property is not available" in {
@@ -155,67 +155,59 @@ class DateTimeDurationPropertiesTest
 
   "A date-time" should "has a year property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").year """) should be(
-      ValNumber(2017))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").year """) should returnResult(2017)
   }
 
   it should "has a month property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").month """) should be(
-      ValNumber(3))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").month """) should returnResult(3)
   }
 
   it should "has a day property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").day """) should be(
-      ValNumber(10))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").day """) should returnResult(10)
   }
 
   it should "has a weekday property" in {
 
-    eval(""" date and time("2020-09-30T22:50:30+02:00").weekday """) should be(
-      ValNumber(3))
+    evaluateExpression(""" date and time("2020-09-30T22:50:30+02:00").weekday """) should returnResult(3)
   }
 
   it should "has a hour property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").hour """) should be(
-      ValNumber(11))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").hour """) should returnResult(11)
   }
 
   it should "has a minute property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").minute """) should be(
-      ValNumber(45))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").minute """) should returnResult(45)
   }
 
   it should "has a second property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").second """) should be(
-      ValNumber(30))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").second """) should returnResult(30)
   }
 
   it should "has a time offset property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30+02:00").time offset """) should be(
-      ValDayTimeDuration("PT2H"))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").time offset """) should returnResult(
+      Duration.parse("PT2H")
+    )
   }
 
   it should "has a variable with a time offset property" in {
 
-    eval(""" dateTime.time offset """,
-         Map(
-           "dateTime" -> ValDateTime(
-             ZonedDateTime.parse("2017-03-10T11:45:30+02:00")))) should be(
-      ValDayTimeDuration("PT2H"))
+    evaluateExpression(
+      expression = """ dateTime.time offset """,
+      variables = Map("dateTime" -> ZonedDateTime.parse("2017-03-10T11:45:30+02:00"))
+      ) should returnResult(Duration.parse("PT2H"))
   }
 
   it should "has a timezone property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30@Europe/Paris").timezone """) should be(
-      ValString("Europe/Paris"))
-    eval(""" date and time("2017-03-10T11:45:30+02:00").timezone """) should be(
-      ValNull)
+    evaluateExpression(""" date and time("2017-03-10T11:45:30@Europe/Paris").timezone """) should returnResult("Europe/Paris")
+
+    evaluateExpression(""" date and time("2017-03-10T11:45:30+02:00").timezone """) should returnNull()
   }
 
   it should "return null if the property is not available" in {
@@ -228,64 +220,55 @@ class DateTimeDurationPropertiesTest
   }
 
   it should "has properties with @-notation" in {
-    eval(""" @"2017-03-10T11:45:30+02:00".year """) should be(ValNumber(2017))
-    eval(""" @"2017-03-10T11:45:30+02:00".month """) should be(ValNumber(3))
-    eval(""" @"2017-03-10T11:45:30+02:00".day """) should be(ValNumber(10))
+    evaluateExpression(""" @"2017-03-10T11:45:30+02:00".year """) should returnResult(2017)
+    evaluateExpression(""" @"2017-03-10T11:45:30+02:00".month """) should returnResult(3)
+    evaluateExpression(""" @"2017-03-10T11:45:30+02:00".day """) should returnResult(10)
   }
 
   ///// -----
 
   "A local date-time" should "has a year property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").year """) should be(
-      ValNumber(2017))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").year """) should returnResult(2017)
   }
 
   it should "has a month property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").month """) should be(
-      ValNumber(3))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").month """) should returnResult(3)
   }
 
   it should "has a day property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").day """) should be(
-      ValNumber(10))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").day """) should returnResult(10)
   }
 
   it should "has a hour property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").hour """) should be(
-      ValNumber(11))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").hour """) should returnResult(11)
   }
 
   it should "has a minute property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").minute """) should be(
-      ValNumber(45))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").minute """) should returnResult(45)
   }
 
   it should "has a second property" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").second """) should be(
-      ValNumber(30))
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").second """) should returnResult(30)
   }
 
   it should "has a time offset property = null" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").time offset """) should be(
-      ValNull)
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").time offset """) should returnNull()
   }
 
   it should "has a timezone property = null" in {
 
-    eval(""" date and time("2017-03-10T11:45:30").timezone """) should be(
-      ValNull)
+    evaluateExpression(""" date and time("2017-03-10T11:45:30").timezone """) should returnNull()
   }
 
   it should "has a weekday property" in {
-    eval(""" date and time("2020-09-30T22:50:30").weekday """) should be(
-      ValNumber(3))
+    evaluateExpression(""" date and time("2020-09-30T22:50:30").weekday """) should returnResult(3)
   }
 
   it should "return null if the property is not available" in {
@@ -301,12 +284,12 @@ class DateTimeDurationPropertiesTest
 
   "A year-month-duration" should "has a years property" in {
 
-    eval(""" duration("P2Y3M").years """) should be(ValNumber(2))
+    evaluateExpression(""" duration("P2Y3M").years """) should returnResult(2)
   }
 
   it should "has a months property" in {
 
-    eval(""" duration("P2Y3M").months """) should be(ValNumber(3))
+    evaluateExpression(""" duration("P2Y3M").months """) should returnResult(3)
   }
 
   it should "return null if the property is not available" in {
@@ -319,30 +302,30 @@ class DateTimeDurationPropertiesTest
   }
 
   it should "has properties with @-notation" in {
-    eval(""" @"P2Y3M".years """) should be(ValNumber(2))
-    eval(""" @"P2Y3M".months """) should be(ValNumber(3))
+    evaluateExpression(""" @"P2Y3M".years """) should returnResult(2)
+    evaluateExpression(""" @"P2Y3M".months """) should returnResult(3)
   }
 
   ///// -----
 
   "A day-time-duration" should "has a days property" in {
 
-    eval(""" duration("P1DT2H10M30S").days """) should be(ValNumber(1))
+    evaluateExpression(""" duration("P1DT2H10M30S").days """) should returnResult(1)
   }
 
   it should "has a hours property" in {
 
-    eval(""" duration("P1DT2H10M30S").hours """) should be(ValNumber(2))
+    evaluateExpression(""" duration("P1DT2H10M30S").hours """) should returnResult(2)
   }
 
   it should "has a minutes property" in {
 
-    eval(""" duration("P1DT2H10M30S").minutes """) should be(ValNumber(10))
+    evaluateExpression(""" duration("P1DT2H10M30S").minutes """) should returnResult(10)
   }
 
   it should "has a seconds property" in {
 
-    eval(""" duration("P1DT2H10M30S").seconds """) should be(ValNumber(30))
+    evaluateExpression(""" duration("P1DT2H10M30S").seconds """) should returnResult(30)
   }
 
   it should "return null if the property is not available" in {
@@ -355,10 +338,10 @@ class DateTimeDurationPropertiesTest
   }
 
   it should "has properties with @-notation" in {
-    eval(""" @"P1DT2H10M30S".days """) should be(ValNumber(1))
-    eval(""" @"P1DT2H10M30S".hours """) should be(ValNumber(2))
-    eval(""" @"P1DT2H10M30S".minutes """) should be(ValNumber(10))
-    eval(""" @"P1DT2H10M30S".seconds """) should be(ValNumber(30))
+    evaluateExpression(""" @"P1DT2H10M30S".days """) should returnResult(1)
+    evaluateExpression(""" @"P1DT2H10M30S".hours """) should returnResult(2)
+    evaluateExpression(""" @"P1DT2H10M30S".minutes """) should returnResult(10)
+    evaluateExpression(""" @"P1DT2H10M30S".seconds """) should returnResult(30)
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -17,7 +17,8 @@
 package org.camunda.feel.impl.interpreter
 
 import org.camunda.feel._
-import org.camunda.feel.impl.FeelIntegrationTest
+import org.camunda.feel.api.EvaluationFailureType
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest, FeelIntegrationTest}
 import org.camunda.feel.syntaxtree._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -30,7 +31,9 @@ import java.time.ZonedDateTime
 class DateTimeDurationPropertiesTest
     extends AnyFlatSpec
     with Matchers
-    with FeelIntegrationTest {
+    with FeelIntegrationTest
+    with FeelEngineTest
+    with EvaluationResultMatchers {
 
   "A date" should "has a year property" in {
 
@@ -52,12 +55,13 @@ class DateTimeDurationPropertiesTest
     eval(""" date("2020-09-30").weekday """) should be(ValNumber(3))
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" date("2020-09-30").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValDate(2020-09-30)'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" date("2020-09-30").seconds """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'seconds' of value 'ValDate(2020-09-30)'. Available properties: 'year', 'month', 'day', 'weekday'"
+      )
+    )
   }
 
   it should "has properties with @-notation" in {
@@ -96,12 +100,13 @@ class DateTimeDurationPropertiesTest
     eval(""" time("11:45:30+02:00").timezone """) should be(ValNull)
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" time("11:45:30+02:00").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValTime(ZonedTime(11:45:30,+02:00,None))'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" time("11:45:30+02:00").day """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'day' of value 'ValTime(ZonedTime(11:45:30,+02:00,None))'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
+      )
+    )
   }
 
   it should "has properties with @-notation" in {
@@ -137,12 +142,13 @@ class DateTimeDurationPropertiesTest
     eval(""" time("11:45:30").timezone """) should be(ValNull)
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" time("11:45:30").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValLocalTime(11:45:30)'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" time("11:45:30").day """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'day' of value 'ValLocalTime(11:45:30)'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
+      )
+    )
   }
 
   ///// -----
@@ -212,12 +218,13 @@ class DateTimeDurationPropertiesTest
       ValNull)
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" date and time("2020-09-30T22:50:30+02:00").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValDateTime(2020-09-30T22:50:30+02:00)'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" date and time("2020-09-30T22:50:30+02:00").days """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'days' of value 'ValDateTime(2020-09-30T22:50:30+02:00)'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
+      )
+    )
   }
 
   it should "has properties with @-notation" in {
@@ -281,12 +288,13 @@ class DateTimeDurationPropertiesTest
       ValNumber(3))
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" date and time("2020-09-30T22:50:30").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'ValLocalDateTime(2020-09-30T22:50:30)'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" date and time("2020-09-30T22:50:30").days """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'days' of value 'ValLocalDateTime(2020-09-30T22:50:30)'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
+      )
+    )
   }
 
   ///// -----
@@ -301,12 +309,13 @@ class DateTimeDurationPropertiesTest
     eval(""" duration("P2Y3M").months """) should be(ValNumber(3))
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" duration("P2Y3M").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'P2Y3M'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" duration("P2Y3M").day """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'day' of value 'P2Y3M'. Available properties: 'years', 'months'"
+      )
+    )
   }
 
   it should "has properties with @-notation" in {
@@ -336,12 +345,13 @@ class DateTimeDurationPropertiesTest
     eval(""" duration("P1DT2H10M30S").seconds """) should be(ValNumber(30))
   }
 
-  it should "return an error if the property is not available" in {
-    val result = eval(""" duration("P1DT2H10M30S").x """)
-
-    result shouldBe a[ValError]
-    result.asInstanceOf[ValError].error should startWith(
-      "No property found with name 'x' of value 'P1DT2H10M30S'. Available properties:")
+  it should "return null if the property is not available" in {
+    evaluateExpression(""" duration("P1DT2H10M30S").day """) should (
+      returnNull() and reportFailure(
+        failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
+        failureMessage = "No property found with name 'day' of value 'P1DT2H10M30S'. Available properties: 'days', 'hours', 'minutes', 'seconds'"
+      )
+      )
   }
 
   it should "has properties with @-notation" in {


### PR DESCRIPTION
## Description

Change the behavior for accessing a non-existing property. Instead of failing the evaluation, it returns `null`. A failure with a descriptive message is reported.

This change is aligned with the DMN specification and the new direction to be more null-friendly.

## Related issues

closes #707
