### PR TITLE
fix: `is defined()` function returns false if the value is null 

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
@@ -30,9 +30,8 @@ not(null)
 
 <MarkerCamundaExtension></MarkerCamundaExtension>
 
-Checks if a given value is defined. A value is defined if it exists, and it is an instance of one of the FEEL data types including `null`.
-
-The function can be used to check if a variable or a context entry (e.g. a property of a variable) exists. It allows differentiating between a `null` variable and a value that doesn't exist.
+Checks if a given value is not `null`. If the value is `null` then the function returns `false`. 
+Otherwise, the function returns `true`.
 
 **Function signature**
 
@@ -47,7 +46,7 @@ is defined(1)
 // true
 
 is defined(null)
-// true
+// false
 
 is defined(x)
 // false - if no variable "x" exists
@@ -55,6 +54,13 @@ is defined(x)
 is defined(x.y)
 // false - if no variable "x" exists or it doesn't have a property "y"
 ```
+
+:::caution Breaking change
+
+This function worked differently in previous versions. It returned `true` if the value was `null`.
+Since this version, the function returns `false` if the value is `null`. 
+
+:::
 
 ## get or else(value, default)
 

--- a/src/main/scala/org/camunda/feel/impl/builtin/BooleanBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/BooleanBuiltinFunctions.scala
@@ -38,8 +38,8 @@ object BooleanBuiltinFunctions {
   private def isDefinedFunction = builtinFunction(
     params = List("value"),
     invoke = {
-      case (value: ValError) :: Nil => ValBoolean(false)
-      case _                        => ValBoolean(true)
+      case List(ValNull)  => ValBoolean(false)
+      case _              => ValBoolean(true)
     }
   )
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
@@ -74,10 +74,10 @@ class BuiltinFunctionsTest
     ) should returnResult(true)
   }
 
-  it should "return true if the value is null" in {
+  it should "return false if the value is null" in {
     evaluateExpression(
       expression = "is defined(null)"
-    ) should returnResult(true)
+    ) should returnResult(false)
   }
 
   it should "return false if a variable doesn't exist" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
@@ -53,11 +53,6 @@ class BuiltinFunctionsTest
   }
 
   "A is defined() function" should "return true if the value is present" in {
-
-    evaluateExpression(
-      expression = "is defined(null)"
-    ) should returnResult(true)
-
     evaluateExpression(
       expression = "is defined(1)"
     ) should returnResult(true)
@@ -76,6 +71,12 @@ class BuiltinFunctionsTest
 
     evaluateExpression(
       expression = """ is defined( {"a":1}.a ) """
+    ) should returnResult(true)
+  }
+
+  it should "return true if the value is null" in {
+    evaluateExpression(
+      expression = "is defined(null)"
     ) should returnResult(true)
   }
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinFunctionsTest.scala
@@ -79,9 +79,7 @@ class BuiltinFunctionsTest
     ) should returnResult(true)
   }
 
-  // see: https://github.com/camunda/feel-scala/issues/695
-  ignore should "return false if a variable doesn't exist" in {
-
+  it should "return false if a variable doesn't exist" in {
     evaluateExpression(
       expression = "is defined(a)"
     ) should returnResult(false)
@@ -91,9 +89,7 @@ class BuiltinFunctionsTest
     ) should returnResult(false)
   }
 
-  // see: https://github.com/camunda/feel-scala/issues/695
-  ignore should "return false if a context entry doesn't exist" in {
-
+  it should "return false if a context entry doesn't exist" in {
     evaluateExpression(
       expression = "is defined({}.a)"
     ) should returnResult(false)


### PR DESCRIPTION
## Description

Change the behavior of the function `is defined()` to return `true` if the value is not `null`. Previously, the function returned `true` if the value was `null`. It returned `false` if the value was a non-existing variable or context entry (i.e. a ValError).

The changes in the null-handling of the FEEL engine to replace a non-existing variable or context entry with `null` made this function useless. It returned always `true`.

A complete fix of the function is not possible because of the new null-handling. However, this change in the semantics of the function reduces the impact on the users (i.e. the regression).

The function still works as before for non-existing variables and context entries. But it may break for variables and context entries with a `null` value. See [here](https://github.com/camunda/feel-scala/issues/695#issuecomment-1711563232) for details.

## Related issues

closes #695
