### PR TITLE
feat: Make failure messages more readable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,17 @@
               <differenceType>7009</differenceType>
               <method>* validator()</method>
             </ignored>
+            <!-- ignore auto-generated Scala functions -->
+            <ignored>
+              <className>org/camunda/feel/syntaxtree/**</className>
+              <differenceType>7002</differenceType>
+              <method>scala.Function1 andThen(scala.Function1)</method>
+            </ignored>
+            <ignored>
+              <className>org/camunda/feel/syntaxtree/**</className>
+              <differenceType>7002</differenceType>
+              <method>scala.Function1 compose(scala.Function1)</method>
+            </ignored>
           </ignored>
         </configuration>
       </plugin>

--- a/src/main/scala/org/camunda/feel/impl/builtin/BuiltinFunction.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/BuiltinFunction.scala
@@ -32,9 +32,11 @@ object BuiltinFunction {
   }
 
   private def error: PartialFunction[List[Val], Any] = {
-    case vars if (vars.exists(_.isInstanceOf[ValError])) =>
-      vars.filter(_.isInstanceOf[ValError]).head.asInstanceOf[ValError]
-    case e => ValError(s"Illegal arguments: $e")
+    case args if (args.exists(_.isInstanceOf[ValError])) =>
+      args.filter(_.isInstanceOf[ValError]).head.asInstanceOf[ValError]
+    case args =>
+      val argumentList = args.map("'" + _ + "'").mkString(", ")
+      ValError(s"Illegal arguments: $argumentList")
   }
 
 }

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -194,31 +194,10 @@ object ConversionBuiltinFunctions {
   private def isValidDecimalSeparator(separator: String) =
     separator == "," || separator == "."
 
-  private lazy val dateTimeOffsetZoneIdPattern =
-    Pattern.compile("(.*)([+-]\\d{2}:\\d{2}|Z)(@.*)")
-
   private def stringFunction = builtinFunction(
     params = List("from"),
     invoke = {
-      case List(ValString(from))  => ValString(from)
-      case List(ValBoolean(from)) => ValString(from.toString)
-      case List(ValNumber(from))  => ValString(from.toString)
-      case List(ValDate(from))    => ValString(from.format(dateFormatter))
-      case List(ValLocalTime(from)) =>
-        ValString(from.format(localTimeFormatter))
-      case List(ValTime(from)) => ValString(from.format)
-      case List(ValLocalDateTime(from)) =>
-        ValString(from.format(localDateTimeFormatter))
-      case List(ValDateTime(from)) => {
-        val formattedDateTime = from.format(dateTimeFormatter)
-        // remove offset-id if zone-id is present
-        val dateTimeWithOffsetOrZoneId = dateTimeOffsetZoneIdPattern
-          .matcher(formattedDateTime)
-          .replaceAll("$1$3")
-        ValString(dateTimeWithOffsetOrZoneId)
-      }
-      case List(duration: ValYearMonthDuration) => ValString(duration.toString)
-      case List(duration: ValDayTimeDuration)   => ValString(duration.toString)
+      case List(from)  => ValString(from.toString)
     }
   )
 

--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -240,7 +240,7 @@ class FeelInterpreter {
         )
 
       // unsupported expression
-      case exp => error(s"Unsupported expression '$exp'")
+      case exp => error(EvaluationFailureType.UNKNOWN, s"Unsupported expression '$exp'")
 
     }
 
@@ -268,11 +268,6 @@ class FeelInterpreter {
     }
   }
 
-  private def error(message: String)(implicit context: EvalContext): ValError = error(
-    failureType = EvaluationFailureType.UNKNOWN,
-    failureMessage = message
-  )
-
   private def error(failureType: EvaluationFailureType, failureMessage: String)(implicit context: EvalContext): ValError = {
       context.addFailure(failureType, failureMessage)
       ValError(failureMessage)
@@ -291,7 +286,7 @@ class FeelInterpreter {
     withVal(
       input, {
         case i if !isComparable(i, x, y) || !hasSameType(i, x, y) =>
-          error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare $input with $x and $y")
+          error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare '$input' with '$x' and '$y'")
           ValNull
         case i => f(c(i, x, y))
       }
@@ -306,69 +301,69 @@ class FeelInterpreter {
 
   private def withNumber(x: Val, f: Number => Val)(implicit context: EvalContext): Val = x match {
     case ValNumber(x) => f(x)
-    case _            => error(EvaluationFailureType.INVALID_TYPE, s"Expected Number but found '$x'")
+    case _            => error(EvaluationFailureType.INVALID_TYPE, s"Expected number but found '$x'")
   }
 
   private def withBoolean(x: Val, f: Boolean => Val)(implicit context: EvalContext): Val = x match {
     case ValBoolean(x) => f(x)
-    case _             => error(EvaluationFailureType.INVALID_TYPE,s"Expected Boolean but found '$x'")
+    case _             => error(EvaluationFailureType.INVALID_TYPE,s"Expected boolean but found '$x'")
   }
 
   private def withBooleanOrNull(x: Val, f: Boolean => Val)(implicit context: EvalContext): Val = x match {
     case ValBoolean(x) => f(x)
     case _             =>
-      error(EvaluationFailureType.INVALID_TYPE, s"Expected Boolean but found '$x'")
+      error(EvaluationFailureType.INVALID_TYPE, s"Expected boolean but found '$x'")
       ValNull
   }
 
   private def withBooleanOrFalse(x: Val, f: Boolean => Val)(implicit context: EvalContext): Val = x match {
     case ValBoolean(x) => f(x)
     case _ =>
-      error(EvaluationFailureType.INVALID_TYPE, s"Expected Boolean but found '$x'")
+      error(EvaluationFailureType.INVALID_TYPE, s"Expected boolean but found '$x'")
       f(false)
   }
 
   private def withString(x: Val, f: String => Val)(implicit context: EvalContext): Val = x match {
     case ValString(x) => f(x)
-    case _            => error(EvaluationFailureType.INVALID_TYPE, s"expected String but found '$x'")
+    case _            => error(EvaluationFailureType.INVALID_TYPE, s"Expected string but found '$x'")
   }
 
   private def withDate(x: Val, f: Date => Val)(implicit context: EvalContext): Val = x match {
     case ValDate(x) => f(x)
-    case _          => error(EvaluationFailureType.INVALID_TYPE, s"Expected Date but found '$x'")
+    case _          => error(EvaluationFailureType.INVALID_TYPE, s"Expected date but found '$x'")
   }
 
   private def withLocalTime(x: Val, f: LocalTime => Val)(implicit context: EvalContext): Val = x match {
     case ValLocalTime(x) => f(x)
-    case _               => error(EvaluationFailureType.INVALID_TYPE, s"Expected Local Time but found '$x'")
+    case _               => error(EvaluationFailureType.INVALID_TYPE, s"Expected local time but found '$x'")
   }
 
   private def withTime(x: Val, f: Time => Val)(implicit context: EvalContext): Val = x match {
     case ValTime(x) => f(x)
-    case _          => error(EvaluationFailureType.INVALID_TYPE, s"Expected Time but found '$x'")
+    case _          => error(EvaluationFailureType.INVALID_TYPE, s"Expected time but found '$x'")
   }
 
   private def withDateTime(x: Val, f: DateTime => Val)(implicit context: EvalContext): Val = x match {
     case ValDateTime(x) => f(x)
-    case _              => error(EvaluationFailureType.INVALID_TYPE, s"Expected Date Time but found '$x'")
+    case _              => error(EvaluationFailureType.INVALID_TYPE, s"Expected date-and-time but found '$x'")
   }
 
   private def withLocalDateTime(x: Val, f: LocalDateTime => Val)(implicit context: EvalContext): Val =
     x match {
       case ValLocalDateTime(x) => f(x)
-      case _                   => error(EvaluationFailureType.INVALID_TYPE, s"Expected Local Date Time but found '$x'")
+      case _                   => error(EvaluationFailureType.INVALID_TYPE, s"Expected local date-and-time but found '$x'")
     }
 
   private def withYearMonthDuration(x: Val, f: YearMonthDuration => Val)(implicit context: EvalContext): Val =
     x match {
       case ValYearMonthDuration(x) => f(x)
-      case _                       => error(EvaluationFailureType.INVALID_TYPE, s"Expected Years-Months-Duration but found '$x'")
+      case _                       => error(EvaluationFailureType.INVALID_TYPE, s"Expected years-months-duration but found '$x'")
     }
 
   private def withDayTimeDuration(x: Val, f: DayTimeDuration => Val)(implicit context: EvalContext): Val =
     x match {
       case ValDayTimeDuration(x) => f(x)
-      case _                     => error(EvaluationFailureType.INVALID_TYPE, s"Expected Days-Time-Duration but found '$x'")
+      case _                     => error(EvaluationFailureType.INVALID_TYPE, s"Expected days-time-duration but found '$x'")
     }
 
   private def withVal(x: Val, f: Val => Val): Val = x match {
@@ -446,7 +441,7 @@ class FeelInterpreter {
       f: Number => Val)(implicit context: EvalContext): Val =
     x match {
       case ValNumber(x) => withNumber(y, y => f(op(x, y)))
-      case _            => error(s"expected Number but found '$x'")
+      case _            => error(EvaluationFailureType.INVALID_TYPE, s"Expected number but found '$x'")
     }
 
   private def checkEquality(
@@ -460,7 +455,7 @@ class FeelInterpreter {
       case _ : ValError            => f(c(ValNull, y.toOption.getOrElse(ValNull)))
       case _ if (y.isInstanceOf[ValError]) => f(c(ValNull, x.toOption.getOrElse(ValNull)))
       case _ if !hasSameType(x, y) =>
-        error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare $x with $y")
+        error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare '$x' with '$y'")
         ValNull
       case ValNumber(x)            => withNumber(y, y => f(c(x, y)))
       case ValBoolean(x)           => withBoolean(y, y => f(c(x, y)))
@@ -521,8 +516,8 @@ class FeelInterpreter {
           }
         )
       case _ =>
-        error(
-          s"expected Number, Boolean, String, Date, Time, Duration, List or Context but found '$x'")
+        error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare '$x' with '$y'")
+        ValNull
     }
 
   private def dualOp(x: Val,
@@ -531,7 +526,7 @@ class FeelInterpreter {
                      f: Boolean => Val)(implicit context: EvalContext): Val =
     x match {
       case _ if !isComparable(x, y) || !hasSameType(x, y) =>
-        error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare $x with $y")
+        error(EvaluationFailureType.NOT_COMPARABLE, s"Can't compare '$x' with '$y'")
         ValNull
       case _ => f(c(x, y))
     }
@@ -545,14 +540,13 @@ class FeelInterpreter {
       y match {
         case ValYearMonthDuration(y) => ValLocalDateTime(x.plus(y))
         case ValDayTimeDuration(y)   => ValLocalDateTime(x.plus(y))
-        case _ =>
-          error(s"expect Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
       }
     case ValDateTime(x) =>
       y match {
         case ValYearMonthDuration(y) => ValDateTime(x.plus(y))
         case ValDayTimeDuration(y)   => ValDateTime(x.plus(y))
-        case _ => error(s"expect Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
       }
     case ValYearMonthDuration(x) =>
       y match {
@@ -561,8 +555,7 @@ class FeelInterpreter {
         case ValLocalDateTime(y) => ValLocalDateTime(y.plus(x))
         case ValDateTime(y)      => ValDateTime(y.plus(x))
         case ValDate(y)          => ValDate(y.plus(x))
-        case _ => error(
-            s"expect Date-Time, Date, or Year-Month-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
       }
     case ValDayTimeDuration(x) =>
       y match {
@@ -572,19 +565,16 @@ class FeelInterpreter {
         case ValLocalTime(y)       => ValLocalTime(y.plus(x))
         case ValTime(y)            => ValTime(y.plus(x))
         case ValDate(y)            => ValDate(y.atStartOfDay().plus(x).toLocalDate())
-        case _ => error(
-            s"expect Date-Time, Date, Time, or Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
       }
     case ValDate(x) =>
       y match {
         case ValDayTimeDuration(y) =>
           ValDate(x.atStartOfDay().plus(y).toLocalDate())
         case ValYearMonthDuration(y) => ValDate(x.plus(y))
-        case _ =>
-          error(s"expect Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
       }
-    case _ =>
-      error(s"expected Number, String, Date, Time or Duration but found '$x'")
+    case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't add '$y' to '$x'")
   }
 
   private def subOp(x: Val, y: Val)(implicit context: EvalContext): Val = x match {
@@ -593,29 +583,27 @@ class FeelInterpreter {
       y match {
         case ValLocalTime(y)       => ValDayTimeDuration(Duration.between(y, x))
         case ValDayTimeDuration(y) => ValLocalTime(x.minus(y))
-        case _                     => error(s"expect Time, or Day-Time-Duration but found '$x'")
+        case _                     => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
       }
     case ValTime(x) =>
       y match {
         case ValTime(y)            => ValDayTimeDuration(ZonedTime.between(x, y))
         case ValDayTimeDuration(y) => ValTime(x.minus(y))
-        case _                     => error(s"expect Time, or Day-Time-Duration but found '$x'")
+        case _                     => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
       }
     case ValLocalDateTime(x) =>
       y match {
         case ValLocalDateTime(y)     => ValDayTimeDuration(Duration.between(y, x))
         case ValYearMonthDuration(y) => ValLocalDateTime(x.minus(y))
         case ValDayTimeDuration(y)   => ValLocalDateTime(x.minus(y))
-        case _ =>
-          error(s"expect Time, or Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
       }
     case ValDateTime(x) =>
       y match {
         case ValDateTime(y)          => ValDayTimeDuration(Duration.between(y, x))
         case ValYearMonthDuration(y) => ValDateTime(x.minus(y))
         case ValDayTimeDuration(y)   => ValDateTime(x.minus(y))
-        case _ =>
-          error(s"expect Time, or Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
       }
     case ValDate(x) =>
       y match {
@@ -624,15 +612,13 @@ class FeelInterpreter {
         case ValYearMonthDuration(y) => ValDate(x.minus(y))
         case ValDayTimeDuration(y) =>
           ValDate(x.atStartOfDay.minus(y).toLocalDate())
-        case _ =>
-          error(s"expect Date, or Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
       }
     case ValYearMonthDuration(x) =>
       withYearMonthDuration(y, y => ValYearMonthDuration(x.minus(y).normalized))
     case ValDayTimeDuration(x) =>
       withDayTimeDuration(y, y => ValDayTimeDuration(x.minus(y)))
-    case _ =>
-      error(s"expected Number, Date, Time or Duration but found '$x'")
+    case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't subtract '$y' from '$x'")
   }
 
   private def mulOp(x: Val, y: Val)(implicit context: EvalContext): Val = x match {
@@ -643,9 +629,7 @@ class FeelInterpreter {
           ValYearMonthDuration(y.multipliedBy(x.intValue).normalized)
         case ValDayTimeDuration(y) =>
           ValDayTimeDuration(y.multipliedBy(x.intValue))
-        case _ =>
-          error(
-            s"expect Number, or Year-Month-/Day-Time-Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't multiply '$x' by '$y'")
       }
     case ValYearMonthDuration(x) =>
       withNumber(
@@ -653,7 +637,7 @@ class FeelInterpreter {
         y => ValYearMonthDuration(x.multipliedBy(y.intValue).normalized))
     case ValDayTimeDuration(x) =>
       withNumber(y, y => ValDayTimeDuration(x.multipliedBy(y.intValue)))
-    case _ => error(s"expected Number, or Duration but found '$x'")
+    case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't multiply '$x' by '$y'")
   }
 
   private def divOp(x: Val, y: Val)(implicit context: EvalContext): Val = y match {
@@ -665,7 +649,7 @@ class FeelInterpreter {
             Period.ofMonths((x.toTotalMonths() / y).intValue).normalized)
         case ValDayTimeDuration(x) =>
           ValDayTimeDuration(Duration.ofMillis((x.toMillis() / y).intValue))
-        case _ => error(s"expected Number, or Duration but found '$x'")
+        case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't divide '$x' by '$y'")
       }
 
     case ValYearMonthDuration(y) if (!y.isZero) =>
@@ -674,7 +658,7 @@ class FeelInterpreter {
     case ValDayTimeDuration(y) if (!y.isZero) =>
       withDayTimeDuration(x, x => ValNumber(x.toMillis / y.toMillis))
 
-    case _ => error(s"'$x / $y' is not allowed")
+    case _ => error(EvaluationFailureType.INVALID_TYPE, s"Can't divide '$x' by '$y'")
   }
 
   private def unaryTestExpression(x: Val)(implicit context: EvalContext): Val =
@@ -762,12 +746,12 @@ class FeelInterpreter {
     case ValList(_)              => f("list")
     case ValContext(_)           => f("context")
     case ValFunction(_, _, _)    => f("function")
-    case _                       => error(s"unexpected type '${x.getClass.getName}'")
+    case _                       => error(EvaluationFailureType.INVALID_TYPE ,s"Unknown type '${x.getClass.getName}' of '$x'")
   }
 
   private def withList(x: Val, f: ValList => Val)(implicit context: EvalContext): Val = x match {
     case x: ValList => f(x)
-    case _          => error(s"expect List but found '$x'")
+    case _          => error(EvaluationFailureType.INVALID_TYPE, s"Expected list but found '$x'")
   }
 
   private def withLists(
@@ -855,7 +839,7 @@ class FeelInterpreter {
 
   private def withContext(x: Val, f: ValContext => Val)(implicit context: EvalContext): Val = x match {
     case x: ValContext => f(x)
-    case _             => error(s"expect Context but found '$x'")
+    case _             => error(EvaluationFailureType.INVALID_TYPE, s"Expect context but found '$x'")
   }
 
   private def filterContext(x: Val)(
@@ -937,13 +921,13 @@ class FeelInterpreter {
 
     } catch {
       case e: ClassNotFoundException =>
-        error(s"fail to load class '$className'")
+        error(EvaluationFailureType.FUNCTION_INVOCATION_FAILURE, s"Failed to load class '$className'")
       case e: NoSuchMethodException =>
-        error(
-          s"fail to get method with name '$methodName' and arguments '$arguments' from class '$className'")
+        error(EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
+          s"Failed to get method with name '$methodName' and arguments '$arguments' from class '$className'")
       case _: Throwable =>
-        error(
-          s"fail to invoke method with name '$methodName' and arguments '$arguments' from class '$className'")
+        error(EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
+          s"Failed to invoke method with name '$methodName' and arguments '$arguments' from class '$className'")
     }
   }
 
@@ -960,7 +944,7 @@ class FeelInterpreter {
                 end = toRangeBoundary(range.end, endValue)
               )
             } else {
-              error(s"invalid range definition '$range'")
+              error(EvaluationFailureType.INVALID_TYPE, s"Invalid range definition '$range'")
           }
       )
     )

--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -17,10 +17,10 @@
 package org.camunda.feel.syntaxtree
 
 import org.camunda.feel.context.Context
-import org.camunda.feel.{Date, DateTime, DayTimeDuration, LocalDateTime, LocalTime, Number, Time, YearMonthDuration}
+import org.camunda.feel.{Date, DateTime, DayTimeDuration, LocalDateTime, LocalTime, Number, Time, YearMonthDuration, dateTimeFormatter, localDateTimeFormatter, localTimeFormatter}
 
-import java.math.BigInteger
 import java.time.Duration
+import java.util.regex.Pattern
 
 /**
   * FEEL supports the following datatypes:
@@ -100,11 +100,17 @@ sealed trait Val extends Ordered[Val] {
 
 }
 
-case class ValNumber(value: Number) extends Val
+case class ValNumber(value: Number) extends Val {
+  override def toString: String = value.toString()
+}
 
-case class ValBoolean(value: Boolean) extends Val
+case class ValBoolean(value: Boolean) extends Val {
+  override def toString: String = value.toString
+}
 
-case class ValString(value: String) extends Val
+case class ValString(value: String) extends Val {
+  override def toString: String = s"\"$value\""
+}
 
 case class ValDate(value: Date) extends Val {
   override protected val properties: Map[String, Val] = Map(
@@ -113,6 +119,8 @@ case class ValDate(value: Date) extends Val {
     "day" -> ValNumber(value.getDayOfMonth),
     "weekday" -> ValNumber(value.getDayOfWeek.getValue)
   )
+
+  override def toString: String = value.toString
 }
 
 case class ValLocalTime(value: LocalTime) extends Val {
@@ -123,6 +131,8 @@ case class ValLocalTime(value: LocalTime) extends Val {
     "time offset" -> ValNull,
     "timezone" -> ValNull
   )
+
+  override def toString: String = value.format(localTimeFormatter)
 }
 
 case class ValTime(value: Time) extends Val {
@@ -134,6 +144,8 @@ case class ValTime(value: Time) extends Val {
       ValDayTimeDuration(Duration.ofSeconds(value.getOffsetInTotalSeconds)),
     "timezone" -> value.getZoneId.map(ValString).getOrElse(ValNull)
   )
+
+  override def toString: String = value.format
 }
 
 case class ValLocalDateTime(value: LocalDateTime) extends Val {
@@ -148,6 +160,8 @@ case class ValLocalDateTime(value: LocalDateTime) extends Val {
     "time offset" -> ValNull,
     "timezone" -> ValNull
   )
+
+  override def toString: String = value.format(localDateTimeFormatter)
 }
 
 case class ValDateTime(value: DateTime) extends Val {
@@ -168,30 +182,27 @@ case class ValDateTime(value: DateTime) extends Val {
   )
 
   private def hasTimeZone = !value.getOffset.equals(value.getZone)
+
+  override def toString: String = ValDateTime.format(value)
+}
+
+object ValDateTime {
+
+  private val dateTimeOffsetZoneIdPattern = Pattern.compile("(.*)([+-]\\d{2}:\\d{2}|Z)(@.*)")
+
+  def format(value: DateTime): String = {
+    val formattedDateTime = value.format(dateTimeFormatter)
+    // remove offset-id if zone-id is present
+    dateTimeOffsetZoneIdPattern
+      .matcher(formattedDateTime)
+      .replaceAll("$1$3")
+  }
+
 }
 
 case class ValYearMonthDuration(value: YearMonthDuration) extends Val {
 
-  override def toString: String = {
-    def makeString(sign: String, year: Long, month: Long): String = {
-      val y = Option(year).filterNot(_ == 0).map(_ + "Y").getOrElse("")
-      val m = Option(month).filterNot(_ == 0).map(_ + "M").getOrElse("")
-
-      val stringBuilder = new StringBuilder("")
-      stringBuilder.append(sign).append("P").append(y).append(m)
-      stringBuilder.toString()
-    }
-
-    val year = value.getYears
-    val month = value.getMonths % 12
-
-    if (year == 0 && month == 0)
-      "P0Y"
-    else if (year <= 0 && month <= 0)
-      makeString("-", -year, -month)
-    else
-      makeString("", year, month)
-  }
+  override def toString: String = ValYearMonthDuration.format(value)
 
   override val properties: Map[String, Val] = Map(
     "years" -> ValNumber(value.getYears),
@@ -199,35 +210,34 @@ case class ValYearMonthDuration(value: YearMonthDuration) extends Val {
   )
 }
 
-case class ValDayTimeDuration(value: DayTimeDuration) extends Val {
-  override def toString: String = {
-    def makeString(sign: String, day: Long, hour: Long, minute: Long, second: Long): String = {
-      val d = Option(day).filterNot(_ == 0).map(_ + "D").getOrElse("")
-      val h = Option(hour).filterNot(_ == 0).map(_ + "H").getOrElse("")
-      val m = Option(minute).filterNot(_ == 0).map(_ + "M").getOrElse("")
-      val s = Option(second).filterNot(_ == 0).map(_ + "S").getOrElse("")
+object ValYearMonthDuration {
 
-      val stringBuilder = new StringBuilder("")
-      stringBuilder.append(sign).append("P").append(d)
-      if (h.nonEmpty || m.nonEmpty || s.nonEmpty) {
-        stringBuilder.append("T")
-        stringBuilder.append(h).append(m).append(s)
-      }
-      stringBuilder.toString()
-    }
+  def format(value: YearMonthDuration): String = {
+    val year = value.getYears
+    val month = value.getMonths % 12
 
-    val day = value.toDays
-    val hour = value.toHours % 24
-    val minute = value.toMinutes % 60
-    val second = value.getSeconds % 60
-
-    if (day == 0 && hour == 0 && minute == 0 && second == 0)
-      "P0D"
-    else if (day <= 0 && hour <= 0 && minute <= 0 && second <= 0)
-      makeString("-", -day, -hour, -minute, -second)
+    if (year == 0 && month == 0)
+      "P0Y"
+    else if (year <= 0 && month <= 0)
+      "-" + mkString(-year, -month)
     else
-      makeString("", day, hour, minute, second)
+      mkString(year, month)
   }
+
+  private def mkString(year: Long, month: Long): String = {
+    val y = Option(year).filterNot(_ == 0).map(_ + "Y").getOrElse("")
+    val m = Option(month).filterNot(_ == 0).map(_ + "M").getOrElse("")
+
+    val stringValue = new StringBuilder("P")
+    stringValue.append(y).append(m)
+    stringValue.toString()
+  }
+
+}
+
+case class ValDayTimeDuration(value: DayTimeDuration) extends Val {
+  override def toString: String =  ValDayTimeDuration.format(value)
+
   override val properties: Map[String, Val] = Map(
     "days" -> ValNumber(value.toDays),
     "hours" -> ValNumber(value.toHours % 24),
@@ -236,9 +246,46 @@ case class ValDayTimeDuration(value: DayTimeDuration) extends Val {
   )
 }
 
-case class ValError(error: String) extends Val
+object ValDayTimeDuration {
 
-case object ValNull extends Val
+  def format(value: DayTimeDuration): String = {
+    val day = value.toDays
+    val hour = value.toHours % 24
+    val minute = value.toMinutes % 60
+    val second = value.getSeconds % 60
+
+    if (day == 0 && hour == 0 && minute == 0 && second == 0)
+      "P0D"
+    else if (day <= 0 && hour <= 0 && minute <= 0 && second <= 0)
+      "-" + mkString(-day, -hour, -minute, -second)
+    else
+      mkString(day, hour, minute, second)
+  }
+
+  private def mkString(day: Long, hour: Long, minute: Long, second: Long): String = {
+    val d = Option(day).filterNot(_ == 0).map(_ + "D").getOrElse("")
+    val h = Option(hour).filterNot(_ == 0).map(_ + "H").getOrElse("")
+    val m = Option(minute).filterNot(_ == 0).map(_ + "M").getOrElse("")
+    val s = Option(second).filterNot(_ == 0).map(_ + "S").getOrElse("")
+
+    val stringValue = new StringBuilder("P")
+    stringValue.append(d)
+    if (h.nonEmpty || m.nonEmpty || s.nonEmpty) {
+      stringValue.append("T")
+      stringValue.append(h).append(m).append(s)
+    }
+    stringValue.toString()
+  }
+
+}
+
+case class ValError(error: String) extends Val {
+  override def toString: String = s"error(\"$error\")"
+}
+
+case object ValNull extends Val {
+  override def toString: String = "null"
+}
 
 case class ValFunction(params: List[String],
                        invoke: List[Val] => Any,
@@ -246,10 +293,25 @@ case class ValFunction(params: List[String],
     extends Val {
 
   val paramSet: Set[String] = params.toSet
+
+  override def toString: String = s"function(${params.mkString(", ")})"
 }
 
-case class ValContext(context: Context) extends Val
+case class ValContext(context: Context) extends Val {
+  override def toString: String = context.variableProvider.getVariables
+    .map { case (key, value) => s"$key:$value" }
+    .mkString(start = "{", sep = ", ", end = "}")
+}
 
-case class ValList(items: List[Val]) extends Val
+case class ValList(items: List[Val]) extends Val {
+  override def toString: String = items.mkString(start = "[", sep = ", ", end = "]")
+}
 
-case class ValRange(start: RangeBoundary, end: RangeBoundary) extends Val
+case class ValRange(start: RangeBoundary, end: RangeBoundary) extends Val {
+  override def toString: String = {
+    val startSymbol = if (start.isClosed) "[" else "("
+    val endSymbol = if (end.isClosed) "]" else ")"
+
+    s"$startSymbol${start.value}..${end.value}$endSymbol"
+  }
+}

--- a/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
+++ b/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.api
+
+import org.camunda.feel.context.Context.{EmptyContext, StaticContext}
+import org.camunda.feel.syntaxtree.{ClosedRangeBoundary, OpenRangeBoundary, ValContext, ValDate, ValDateTime, ValDayTimeDuration, ValError, ValFunction, ValList, ValLocalDateTime, ValLocalTime, ValNull, ValNumber, ValRange, ValString, ValTime, ValYearMonthDuration, ZonedTime}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.{Duration, LocalDate, LocalDateTime, LocalTime, Period, ZonedDateTime}
+
+class StringRepresentationTypeTest
+  extends AnyFlatSpec
+    with Matchers {
+
+  "Null" should "return 'null'" in {
+    ValNull.toString should be("null")
+  }
+
+  "A number" should "return '1'" in {
+    ValNumber(1).toString should be("1")
+  }
+
+  it should "return '1.2'" in {
+    ValNumber(1.2).toString should be("1.2")
+  }
+
+  "A string" should """return '"a"' """ in {
+    ValString("a").toString should be("\"a\"")
+  }
+
+  "A date" should "return '2023-09-15' " in {
+    val date = ValDate(LocalDate.parse("2023-09-15"))
+
+    date.toString should be("2023-09-15")
+  }
+
+  "A time" should "return '06:41:30' " in {
+    val time = ValLocalTime(LocalTime.parse("06:41:30"))
+
+    time.toString should be("06:41:30")
+  }
+
+  it should "return '06:41:30+02:00' " in {
+    val time = ValTime(ZonedTime.parse("06:41:30+02:00"))
+
+    time.toString should be("06:41:30+02:00")
+  }
+
+  it should "return '06:41:30@Europe/Berlin' " in {
+    val time = ValTime(ZonedTime.parse("06:41:30@Europe/Berlin"))
+
+    time.toString should be("06:41:30@Europe/Berlin")
+  }
+
+  "A date and time" should "return '2023-09-15T06:41:30'" in {
+    val dateTime = ValLocalDateTime(LocalDateTime.parse("2023-09-15T06:41:30"))
+
+    dateTime.toString should be("2023-09-15T06:41:30")
+  }
+
+  it should "return '2023-09-15T06:41:30+02:00'" in {
+    val dateTime = ValDateTime(ZonedDateTime.parse("2023-09-15T06:41:30+02:00"))
+
+    dateTime.toString should be("2023-09-15T06:41:30+02:00")
+  }
+
+  it should "return '2023-09-15T06:41:30@Europe/Berlin'" in {
+    val dateTime = ValDateTime(ZonedDateTime.parse("2023-09-15T06:41:30+02:00[Europe/Berlin]"))
+
+    dateTime.toString should be("2023-09-15T06:41:30@Europe/Berlin")
+  }
+
+  "A years-months-duration" should "return 'P1Y2M' " in {
+    val duration = ValYearMonthDuration(Period.parse("P1Y2M"))
+
+    duration.toString should be("P1Y2M")
+  }
+
+  it should "return 'P1Y' " in {
+    val duration = ValYearMonthDuration(Period.parse("P1Y"))
+
+    duration.toString should be("P1Y")
+  }
+
+  it should "return 'P2M' " in {
+    val duration = ValYearMonthDuration(Period.parse("P2M"))
+
+    duration.toString should be("P2M")
+  }
+
+  "A days-time-duration" should "return 'P1DT2H3M4S' " in {
+    val duration = ValDayTimeDuration(Duration.parse("P1DT2H3M4S"))
+
+    duration.toString should be("P1DT2H3M4S")
+  }
+
+  it should "return 'P1D' " in {
+    val duration = ValDayTimeDuration(Duration.parse("P1D"))
+
+    duration.toString should be("P1D")
+  }
+
+  it should "return 'PT2H' " in {
+    val duration = ValDayTimeDuration(Duration.parse("PT2H"))
+
+    duration.toString should be("PT2H")
+  }
+
+  it should "return 'PT3M' " in {
+    val duration = ValDayTimeDuration(Duration.parse("PT3M"))
+
+    duration.toString should be("PT3M")
+  }
+
+  it should "return 'PT4S' " in {
+    val duration = ValDayTimeDuration(Duration.parse("PT4S"))
+
+    duration.toString should be("PT4S")
+  }
+
+  "A list" should "return '[1, 2]' " in {
+    ValList(List(ValNumber(1), ValNumber(2))).toString should be("[1, 2]")
+  }
+
+  it should "return '[]' " in {
+    ValList(List()).toString should be("[]")
+  }
+
+  "A context" should "return '{x:1, y:2}' " in {
+    val context = StaticContext(variables = Map("x" -> ValNumber(1), "y" -> ValNumber(2)))
+
+    ValContext(context).toString should be("{x:1, y:2}")
+  }
+
+  it should "return '{}' " in {
+    ValContext(EmptyContext).toString should be("{}")
+  }
+
+  "A range" should "return '(1..3)' " in {
+    val range = ValRange(
+      start = OpenRangeBoundary(ValNumber(1)),
+      end = OpenRangeBoundary(ValNumber(3))
+    )
+
+    range.toString should be("(1..3)")
+  }
+
+  it should "return '[1..3]' " in {
+    val range = ValRange(
+      start = ClosedRangeBoundary(ValNumber(1)),
+      end = ClosedRangeBoundary(ValNumber(3))
+    )
+
+    range.toString should be("[1..3]")
+  }
+
+  "A function" should "return 'function(a, b)' " in {
+    val function = ValFunction(
+      params = List("a", "b"),
+      invoke = _ => ValNull
+    )
+
+    function.toString should be("function(a, b)")
+  }
+
+  "An error" should """return 'error("something wrong")' """ in {
+    val error = ValError("something wrong")
+
+    error.toString should be("error(\"something wrong\")")
+  }
+
+}

--- a/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/SuppressedFailuresTest.scala
@@ -49,48 +49,48 @@ class SuppressedFailuresTest extends AnyFlatSpec
   it should "report a suppressed failure if input is not comparable with interval" in {
     evaluateUnaryTests("[2..5]", "NaN") should reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValString(NaN) with ValNumber(2) and ValNumber(5)"
+      failureMessage = """Can't compare '"NaN"' with '2' and '5'"""
     )
   }
 
   it should "report a suppressed failure if values are not comparable" in {
     evaluateExpression("true < 2") should reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValBoolean(true) with ValNumber(2)"
+      failureMessage = "Can't compare 'true' with '2'"
     )
   }
 
   it should "report a suppressed failure if an addition has incompatible values" in {
     evaluateExpression("2 + true") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Number but found 'ValBoolean(true)'"
+      failureMessage = "Expected number but found 'true'"
     )
   }
 
   it should "report a suppressed failure if a condition is not a boolean" in {
     evaluateExpression("if 5 then 1 else 2") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Boolean but found 'ValNumber(5)'"
+      failureMessage = "Expected boolean but found '5'"
     )
 
     evaluateExpression("true and 2") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Boolean but found 'ValNumber(2)'"
+      failureMessage = "Expected boolean but found '2'"
     )
 
     evaluateExpression("false or 3") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Boolean but found 'ValNumber(3)'"
+      failureMessage = "Expected boolean but found '3'"
     )
 
     evaluateExpression("some x in [false, 2] satisfies x") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Boolean but found 'ValNumber(2)'"
+      failureMessage = "Expected boolean but found '2'"
     )
 
     evaluateExpression("every x in [true, 3] satisfies x") should reportFailure(
       failureType = EvaluationFailureType.INVALID_TYPE,
-      failureMessage = "Expected Boolean but found 'ValNumber(3)'"
+      failureMessage = "Expected boolean but found '3'"
     )
   }
 
@@ -107,7 +107,7 @@ class SuppressedFailuresTest extends AnyFlatSpec
       ),
       EvaluationFailure(
         failureType = EvaluationFailureType.INVALID_TYPE,
-        failureMessage = "Expected Number but found 'ValNull'"
+        failureMessage = "Expected number but found 'null'"
       )
     )
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/ComparisonTypeTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/ComparisonTypeTest.scala
@@ -50,17 +50,17 @@ class ComparisonTypeTest extends AnyFlatSpec
   it should "return null if the values have a different type" in {
     evaluateExpression("1 = true") should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValNumber(1) with ValBoolean(true)"
+      failureMessage = "Can't compare '1' with 'true'"
     ))
 
     evaluateExpression(""" 1 = "a" """) should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValNumber(1) with ValString(a)"
+      failureMessage = """Can't compare '1' with '"a"'"""
     ))
 
     evaluateExpression(""" 1 = @"P1D" """) should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValNumber(1) with P1D"
+      failureMessage = "Can't compare '1' with 'P1D'"
     ))
   }
 
@@ -84,12 +84,12 @@ class ComparisonTypeTest extends AnyFlatSpec
   it should "return null if the values have a different type" in {
     evaluateExpression("1 < true") should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValNumber(1) with ValBoolean(true)"
+      failureMessage = "Can't compare '1' with 'true'"
     ))
 
     evaluateExpression(""" 1 > @"P1D" """) should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValNumber(1) with P1D"
+      failureMessage = "Can't compare '1' with 'P1D'"
     ))
   }
 
@@ -113,12 +113,12 @@ class ComparisonTypeTest extends AnyFlatSpec
   it should "return null if the values have a different type" in {
     evaluateUnaryTests(expression = "1", inputValue = true) should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValBoolean(true) with ValNumber(1)"
+      failureMessage = "Can't compare 'true' with '1'"
     ))
 
     evaluateUnaryTests(expression = "1", inputValue = "a") should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValString(a) with ValNumber(1)"
+      failureMessage = """Can't compare '"a"' with '1'"""
     ))
   }
 
@@ -134,12 +134,12 @@ class ComparisonTypeTest extends AnyFlatSpec
   it should "return null if the values have a different type" in {
     evaluateUnaryTests(expression = "< 1", inputValue = true) should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValBoolean(true) with ValNumber(1)"
+      failureMessage = "Can't compare 'true' with '1'"
     ))
 
     evaluateUnaryTests(expression = "> 1", inputValue = "a") should (returnNull() and reportFailure(
       failureType = EvaluationFailureType.NOT_COMPARABLE,
-      failureMessage = "Can't compare ValString(a) with ValNumber(1)"
+      failureMessage = """Can't compare '"a"' with '1'"""
     ))
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/DateTimeDurationPropertiesTest.scala
@@ -56,7 +56,7 @@ class DateTimeDurationPropertiesTest
     evaluateExpression(""" date("2020-09-30").seconds """) should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-        failureMessage = "No property found with name 'seconds' of value 'ValDate(2020-09-30)'. Available properties: 'year', 'month', 'day', 'weekday'"
+        failureMessage = "No property found with name 'seconds' of value '2020-09-30'. Available properties: 'year', 'month', 'day', 'weekday'"
       )
     )
   }
@@ -104,7 +104,7 @@ class DateTimeDurationPropertiesTest
     evaluateExpression(""" time("11:45:30+02:00").day """) should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-        failureMessage = "No property found with name 'day' of value 'ValTime(ZonedTime(11:45:30,+02:00,None))'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
+        failureMessage = "No property found with name 'day' of value '11:45:30+02:00'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
       )
     )
   }
@@ -146,7 +146,7 @@ class DateTimeDurationPropertiesTest
     evaluateExpression(""" time("11:45:30").day """) should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-        failureMessage = "No property found with name 'day' of value 'ValLocalTime(11:45:30)'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
+        failureMessage = "No property found with name 'day' of value '11:45:30'. Available properties: 'timezone', 'second', 'time offset', 'minute', 'hour'"
       )
     )
   }
@@ -214,7 +214,7 @@ class DateTimeDurationPropertiesTest
     evaluateExpression(""" date and time("2020-09-30T22:50:30+02:00").days """) should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-        failureMessage = "No property found with name 'days' of value 'ValDateTime(2020-09-30T22:50:30+02:00)'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
+        failureMessage = "No property found with name 'days' of value '2020-09-30T22:50:30+02:00'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
       )
     )
   }
@@ -275,7 +275,7 @@ class DateTimeDurationPropertiesTest
     evaluateExpression(""" date and time("2020-09-30T22:50:30").days """) should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NO_PROPERTY_FOUND,
-        failureMessage = "No property found with name 'days' of value 'ValLocalDateTime(2020-09-30T22:50:30)'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
+        failureMessage = "No property found with name 'days' of value '2020-09-30T22:50:30'. Available properties: 'timezone', 'year', 'second', 'month', 'day', 'time offset', 'weekday', 'minute', 'hour'"
       )
     )
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -82,7 +82,7 @@ class InterpreterContextExpressionTest
     evaluateExpression("{} = 1") should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NOT_COMPARABLE,
-        failureMessage = "Can't compare ValContext() with ValNumber(1)"
+        failureMessage = "Can't compare '{}' with '1'"
       )
     )
   }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterFunctionTest.scala
@@ -163,7 +163,7 @@ class InterpreterFunctionTest
       returnNull() and
         reportFailure(
           failureType = EvaluationFailureType.FUNCTION_INVOCATION_FAILURE,
-          failureMessage = "Failed to invoke function 'number': Illegal arguments: List(ValNull)")
+          failureMessage = "Failed to invoke function 'number': Illegal arguments: 'null'")
       )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -309,7 +309,7 @@ class InterpreterListExpressionTest
     evaluateExpression("[] = 1") should (
       returnNull() and reportFailure(
         failureType = EvaluationFailureType.NOT_COMPARABLE,
-        failureMessage = "Can't compare ValList(List()) with ValNumber(1)"
+        failureMessage = "Can't compare '[]' with '1'"
       ))
   }
 


### PR DESCRIPTION
## Description

* Uniform the failure messages and add missing failure types.
* Copy the existing string representation logic of the `string()` function into the value types.

## Related issues

closes #713
