### PR TITLE
[Backport 1.16] update to Java 11 source code level

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,2 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:8, extraJdks: ['jdk-11-latest'], mvn:3.5, licenseCheck:true, publishZipArtifactToCamundaOrg:true])
+buildMavenAndDeployToMavenCentral([jdk:11, mvn:3.5, licenseCheck:true, publishZipArtifactToCamundaOrg:true])

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -7,14 +7,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
+
+    name: Java ${{ matrix.Java }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
     - name: Java setup
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 11
+        java-version: ${{ matrix.java }}
+
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -22,5 +29,6 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+
     - name: Run Maven
       run: mvn -B clean verify com.mycila:license-maven-plugin:check

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.2.6</version>
+    <version>2.3.0</version>
     <relativePath />
   </parent>
 
@@ -15,7 +15,6 @@
   <name>FEEL Scala Engine</name>
 
   <properties>
-    <version.java>1.8</version.java>
     <scala.version>2.13.10</scala.version>
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.20.0</version.log4j>
@@ -447,7 +446,7 @@
     <connection>scm:git:git@github.com:camunda/feel-scala.git</connection>
     <url>scm:git:git@github.com:camunda/feel-scala.git</url>
     <developerConnection>scm:git:git@github.com:camunda/feel-scala.git</developerConnection>
-    <tag>1.4.0</tag>
+    <tag>1.16.0</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/feel-scala/pull/716 for version `1.16`.

## Related issues

related to https://github.com/camunda/camunda-bpm-platform/issues/3690
