### PR TITLE
revert(project): update to Java 11 source code level

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,2 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:11, mvn:3.5, licenseCheck:true, publishZipArtifactToCamundaOrg:true])
+buildMavenAndDeployToMavenCentral([jdk:8, extraJdks: ['jdk-11-latest'], mvn:3.5, licenseCheck:true, publishZipArtifactToCamundaOrg:true])

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -7,21 +7,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '11', '17' ]
-
-    name: Java ${{ matrix.Java }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-
+      uses: actions/checkout@v3
     - name: Java setup
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-
+        java-version: 11
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -29,6 +22,5 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-
     - name: Run Maven
       run: mvn -B clean verify com.mycila:license-maven-plugin:check

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.2.4</version>
     <relativePath />
   </parent>
 
@@ -15,6 +15,7 @@
   <name>FEEL Scala Engine</name>
 
   <properties>
+    <version.java>1.8</version.java>
     <scala.version>2.13.9</scala.version>
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.17.2</version.log4j>


### PR DESCRIPTION
This reverts commit 0134bada883c742534bfc29cdbb2394288919ee3.




## Description

<!-- Please explain the changes you made here. -->

* Cammunda Platform 7.19 uses 1.15.3 therefore we want to leave the source code changed

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->



related to https://github.com/camunda/camunda-bpm-platform/issues/3690
