### PR TITLE
chore(deps): downport the javadoc plugin version to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${encoding}</project.build.resourceEncoding>
     <skip-third-party-bom>false</skip-third-party-bom>
+    <plugin.version.javadoc>2.9.1</plugin.version.javadoc>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* Downport javadoc plugin version to 2.9.1 to avoid errors that appear with higher version

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

https://github.com/camunda/camunda-bpm-platform/issues/3690
