### PR TITLE
chore(ci): disbale fail on error for the javadoc 

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,8 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:11, mvn:3.5, licenseCheck:true, publishZipArtifactToCamundaOrg:true])
+buildMavenAndDeployToMavenCentral([
+  jdk:11,
+  mvn:3.5,
+  additionalMvnGoals:'javadoc:javadoc',
+  licenseCheck:true,
+  publishZipArtifactToCamundaOrg:true
+])

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${encoding}</project.build.resourceEncoding>
     <skip-third-party-bom>false</skip-third-party-bom>
-    <plugin.version.javadoc>2.9.1</plugin.version.javadoc>
+    <plugin.version.javadoc>3.0.1</plugin.version.javadoc>
   </properties>
 
   <dependencyManagement>
@@ -143,6 +143,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <failOnError>false</failOnError>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* ci: add javadoc
* disable failure on error for javadoc => the javadocs won't be built but it's only one class so we can use this as workaround until the javadoc failure is fixed

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

https://github.com/camunda/camunda-bpm-platform/issues/3690
