### PR TITLE
fix: typos

### DIFF
--- a/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/docs/reference/builtin-functions/feel-built-in-functions-boolean.md
@@ -77,13 +77,13 @@ get or else(value: Any, default: Any): Any
 **Examples**
 
 ```js
-get or default("this", "default")
+get or else("this", "default")
 // "this"
 
-get or default(null, "default")
+get or else(null, "default")
 // "default"
 
-get or default(null, null)     
+get or else(null, null)     
 // null
 ```
 


### PR DESCRIPTION
## Description

Correct the example of the `get or else()` function in the doc. 