### PR TITLE
fix: string escape characters

### DIFF
--- a/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
@@ -197,7 +197,7 @@ class FeelEngineApi(engine: FeelEngine) {
     *   the result of the evaluation as [[EvaluationResult]]
     */
   def evaluateExpression(expression: String, context: Context): EvaluationResult =
-    engine.parseExpression(expression = expression.translateEscapes()) match {
+    engine.parseExpression(expression = StringContext.processEscapes(expression)) match {
       case Right(parsedExpression) =>
         evaluate(
           expression = parsedExpression,

--- a/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
@@ -197,7 +197,7 @@ class FeelEngineApi(engine: FeelEngine) {
     *   the result of the evaluation as [[EvaluationResult]]
     */
   def evaluateExpression(expression: String, context: Context): EvaluationResult =
-    engine.parseExpression(expression = StringContext.processEscapes(expression)) match {
+    engine.parseExpression(expression = expression) match {
       case Right(parsedExpression) =>
         evaluate(
           expression = parsedExpression,

--- a/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
@@ -197,7 +197,7 @@ class FeelEngineApi(engine: FeelEngine) {
     *   the result of the evaluation as [[EvaluationResult]]
     */
   def evaluateExpression(expression: String, context: Context): EvaluationResult =
-    engine.parseExpression(expression = expression) match {
+    engine.parseExpression(expression = expression.translateEscapes()) match {
       case Right(parsedExpression) =>
         evaluate(
           expression = parsedExpression,

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -126,7 +126,7 @@ object FeelParser {
     parse(translateEscapes(expression), fullExpression(_))
 
   def parseUnaryTests(expression: String): Parsed[Exp] =
-    parse(expression, fullUnaryExpression(_))
+    parse(translateEscapes(expression), fullUnaryExpression(_))
 
   // --------------- entry parsers ---------------
 
@@ -703,11 +703,8 @@ object FeelParser {
       // Add more escape sequences as needed
     )
 
-    var result = input
-    escapeMap.foreach { case (escape, replacement) =>
-      result = result.replace(escape, replacement)
+    escapeMap.foldLeft(input) { case (result, (escape, replacement)) =>
+      result.replace(escape, replacement)
     }
-
-    result
   }
 }

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -123,7 +123,7 @@ import scala.util.Try
 object FeelParser {
 
   def parseExpression(expression: String): Parsed[Exp] =
-    parse(expression, fullExpression(_))
+    parse(translateEscapes(expression), fullExpression(_))
 
   def parseUnaryTests(expression: String): Parsed[Exp] =
     parse(expression, fullUnaryExpression(_))
@@ -687,5 +687,26 @@ object FeelParser {
         ConstLocalTime(value)
       }
     }.getOrElse(ConstNull)
+  }
+
+  private def translateEscapes(input: String): String = {
+    val escapeMap = Map(
+      "\\b"  -> "\b", // backspace
+      "\\t"  -> "\t", // tab
+      "\\n"  -> "\n", // newline
+      "\\f"  -> "\f", // form feed
+      "\\r"  -> "\r", // carriage return
+      "\\\"" -> "\"", // double quote
+      "\\'"  -> "'",  // single quote
+      "\\s"  -> " "   // Space character
+      // Add more escape sequences as needed
+    )
+
+    var result = input
+    escapeMap.foreach { case (escape, replacement) =>
+      result = result.replace(escape, replacement)
+    }
+
+    result
   }
 }

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -689,16 +689,17 @@ object FeelParser {
     }.getOrElse(ConstNull)
   }
 
+  // replace escaped character with the provided replacement
   private def translateEscapes(input: String): String = {
     val escapeMap = Map(
-      "\\b"  -> "\b", // backspace
-      "\\t"  -> "\t", // tab
-      "\\n"  -> "\n", // newline
-      "\\f"  -> "\f", // form feed
-      "\\r"  -> "\r", // carriage return
-      "\\\"" -> "\"", // double quote
-      "\\'"  -> "'",  // single quote
-      "\\s"  -> " "   // Space character
+      "\\b" -> "\b",
+      "\\t" -> "\t",
+      "\\n" -> "\n",
+      "\\f" -> "\f",
+      "\\r" -> "\r",
+      "\""  -> "\"",
+      "\\'" -> "'",
+      "\\s" -> " "
       // Add more escape sequences as needed
     )
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -21,6 +21,8 @@ import org.camunda.feel.syntaxtree._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
+import scala.collection.immutable.Map
+
 /** @author
   *   Philipp Ossler
   */
@@ -78,10 +80,38 @@ class InterpreterStringExpressionTest
     evaluateExpression(""" "a" != null """) should returnResult(true)
   }
 
-  it should "return escaped characters" in {
+  it should "return not escaped characters" in {
 
     evaluateExpression(""" "Hello\nWorld" """) should returnResult("Hello\nWorld")
     evaluateExpression(" x ", Map("x" -> "Hello\nWorld")) should returnResult("Hello\nWorld")
+
+    evaluateExpression(""" "Hello\rWorld" """) should returnResult("Hello\rWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\rWorld")) should returnResult("Hello\rWorld")
+
+    evaluateExpression(""" "Hello\'World" """) should returnResult("Hello\'World")
+    evaluateExpression(" x ", Map("x" -> "Hello\'World")) should returnResult("Hello\'World")
+
+    evaluateExpression(""" "Hello\tWorld" """) should returnResult("Hello\tWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\tWorld")) should returnResult("Hello\tWorld")
   }
+
+  List(
+    " \' ",
+    " \\\" ",
+    " \\ ",
+    " \n ",
+    " \r ",
+    " \t ",
+    """ \u269D """,
+    """ \U101EF """
+  )
+    .foreach { notEscapeChar =>
+      it should s"contains a not escape sequence ($notEscapeChar)" in {
+
+        evaluateExpression(s""" "a $notEscapeChar b" """) should returnResult(
+          s"""a $notEscapeChar b"""
+        )
+      }
+    }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -16,7 +16,7 @@
  */
 package org.camunda.feel.impl.interpreter
 
-import org.camunda.feel.impl.FeelIntegrationTest
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest, FeelIntegrationTest}
 import org.camunda.feel.syntaxtree._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -24,71 +24,64 @@ import org.scalatest.flatspec.AnyFlatSpec
 /** @author
   *   Philipp Ossler
   */
-class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with FeelIntegrationTest {
+class InterpreterStringExpressionTest
+    extends AnyFlatSpec
+    with Matchers
+    with FeelEngineTest
+    with EvaluationResultMatchers {
 
   "A string" should "concatenates to another String" in {
 
-    eval(""" "a" + "b" """) should be(ValString("ab"))
+    evaluateExpression(""" "a" + "b" """) should returnResult("ab")
   }
 
   it should "compare with '='" in {
 
-    eval(""" "a" = "a" """) should be(ValBoolean(true))
-    eval(""" "a" = "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" = "a" """) should returnResult(true)
+    evaluateExpression(""" "a" = "b" """) should returnResult(false)
   }
 
   it should "compare with '!='" in {
 
-    eval(""" "a" != "a" """) should be(ValBoolean(false))
-    eval(""" "a" != "b" """) should be(ValBoolean(true))
+    evaluateExpression(""" "a" != "a" """) should returnResult(false)
+    evaluateExpression(""" "a" != "b" """) should returnResult(true)
   }
 
   it should "compare with '<'" in {
 
-    eval(""" "a" < "b" """) should be(ValBoolean(true))
-    eval(""" "b" < "a" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" < "b" """) should returnResult(true)
+    evaluateExpression(""" "b" < "a" """) should returnResult(false)
   }
 
   it should "compare with '<='" in {
 
-    eval(""" "a" <= "a" """) should be(ValBoolean(true))
-    eval(""" "b" <= "a" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" <= "a" """) should returnResult(true)
+    evaluateExpression(""" "b" <= "a" """) should returnResult(false)
   }
 
   it should "compare with '>'" in {
 
-    eval(""" "b" > "a" """) should be(ValBoolean(true))
-    eval(""" "a" > "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "b" > "a" """) should returnResult(true)
+    evaluateExpression(""" "a" > "b" """) should returnResult(false)
   }
 
   it should "compare with '>='" in {
 
-    eval(""" "b" >= "b" """) should be(ValBoolean(true))
-    eval(""" "a" >= "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "b" >= "b" """) should returnResult(true)
+    evaluateExpression(""" "a" >= "b" """) should returnResult(false)
   }
 
   it should "compare with null" in {
 
-    eval(""" "a" = null """) should be(ValBoolean(false))
-    eval(""" null = "a" """) should be(ValBoolean(false))
-    eval(""" "a" != null """) should be(ValBoolean(true))
+    evaluateExpression(""" "a" = null """) should returnResult(false)
+    evaluateExpression(""" null = "a" """) should returnResult(false)
+    evaluateExpression(""" "a" != null """) should returnResult(true)
   }
 
-  List(
-    """ \' """,
-    """ \" """,
-    """ \\ """,
-    """ \n """,
-    """ \r """,
-    """ \t """,
-    """ \u269D """,
-    """ \U101EF """
-  )
-    .foreach { escapeChar =>
-      it should s"contains an escape sequence ($escapeChar)" in {
+  it should "return escaped characters" in {
 
-        eval(s""" "a $escapeChar b" """) should be(ValString(s"""a $escapeChar b"""))
-      }
-    }
+    evaluateExpression(""" "Hello\nWorld" """) should returnResult("Hello\nWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\nWorld")) should returnResult("Hello\nWorld")
+  }
 
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR changes the evaluation of escape characters within a string. Instead of escaping those characters now are translated.

## Related issues

closes #701 
