### PR TITLE
fix: Double quotes in string literal are escaped

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -123,10 +123,10 @@ import scala.util.Try
 object FeelParser {
 
   def parseExpression(expression: String): Parsed[Exp] =
-    parse(translateEscapes(expression), fullExpression(_))
+    parse(expression, fullExpression(_))
 
   def parseUnaryTests(expression: String): Parsed[Exp] =
-    parse(translateEscapes(expression), fullUnaryExpression(_))
+    parse(expression, fullUnaryExpression(_))
 
   // --------------- entry parsers ---------------
 
@@ -391,7 +391,7 @@ object FeelParser {
   private def string[_: P]: P[Exp] =
     P(
       stringWithQuotes
-    ).map(ConstString)
+    ).map(translateEscapes).map(ConstString)
 
   private def number[_: P]: P[Exp] =
     P(
@@ -697,7 +697,7 @@ object FeelParser {
       "\\n" -> "\n",
       "\\f" -> "\f",
       "\\r" -> "\r",
-      "\""  -> "\"",
+      "\\\""  -> "\"",
       "\\'" -> "'",
       "\\s" -> " "
       // Add more escape sequences as needed

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -93,11 +93,13 @@ class InterpreterStringExpressionTest
 
     evaluateExpression(""" "Hello\tWorld" """) should returnResult("Hello\tWorld")
     evaluateExpression(" x ", Map("x" -> "Hello\tWorld")) should returnResult("Hello\tWorld")
+
+    evaluateExpression(""" "Hello\"World" """) should returnResult("Hello\"World")
+    evaluateExpression(" x ", Map("x" -> "Hello\"World")) should returnResult("Hello\"World")
   }
 
   List(
     " \' ",
-    " \\\" ",
     " \\ ",
     " \n ",
     " \r ",


### PR DESCRIPTION
## Description

Handle double quotes in string literals properly. Currently, the quotes are escaped but should not.

```
// expression:
"hello \"FEEL\"!"

// result in current version: 
"hello \\\"FEEL\\\"!"

// result with the change:
"hello \"FEEL\"!"
```

## Related issues

closes #778 
