### PR TITLE
[Backport 1.16] fix: string escape characters

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -123,10 +123,10 @@ import scala.util.Try
 object FeelParser {
 
   def parseExpression(expression: String): Parsed[Exp] =
-    parse(expression, fullExpression(_))
+    parse(translateEscapes(expression), fullExpression(_))
 
   def parseUnaryTests(expression: String): Parsed[Exp] =
-    parse(expression, fullUnaryExpression(_))
+    parse(translateEscapes(expression), fullUnaryExpression(_))
 
   // --------------- entry parsers ---------------
 
@@ -681,5 +681,24 @@ object FeelParser {
         ConstLocalTime(value)
       }
     }.getOrElse(ConstNull)
+  }
+
+  // replace escaped character with the provided replacement
+  private def translateEscapes(input: String): String = {
+    val escapeMap = Map(
+      "\\b" -> "\b",
+      "\\t" -> "\t",
+      "\\n" -> "\n",
+      "\\f" -> "\f",
+      "\\r" -> "\r",
+      "\""  -> "\"",
+      "\\'" -> "'",
+      "\\s" -> " "
+      // Add more escape sequences as needed
+    )
+
+    escapeMap.foldLeft(input) { case (result, (escape, replacement)) =>
+      result.replace(escape, replacement)
+    }
   }
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -74,20 +74,37 @@ class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with Fee
     eval(""" "a" != null """) should be(ValBoolean(true))
   }
 
+  it should "return not escaped characters" in {
+
+    eval(""" "Hello\nWorld" """) should be (ValString("Hello\nWorld"))
+    eval(" x ", Map("x" -> "Hello\nWorld")) should be (ValString("Hello\nWorld"))
+
+    eval(""" "Hello\rWorld" """) should be (ValString("Hello\rWorld"))
+    eval(" x ", Map("x" -> "Hello\rWorld")) should be (ValString("Hello\rWorld"))
+
+    eval(""" "Hello\'World" """) should be (ValString("Hello\'World"))
+    eval(" x ", Map("x" -> "Hello\'World")) should be (ValString("Hello\'World"))
+
+    eval(""" "Hello\tWorld" """) should be (ValString("Hello\tWorld"))
+    eval(" x ", Map("x" -> "Hello\tWorld")) should be (ValString("Hello\tWorld"))
+  }
+
   List(
-    """ \' """,
-    """ \" """,
-    """ \\ """,
-    """ \n """,
-    """ \r """,
-    """ \t """,
+    " \' ",
+    " \\\" ",
+    " \\ ",
+    " \n ",
+    " \r ",
+    " \t ",
     """ \u269D """,
     """ \U101EF """
   )
-    .foreach { escapeChar =>
-      it should s"contains an escape sequence ($escapeChar)" in {
+    .foreach { notEscapeChar =>
+      it should s"contains a not escape sequence ($notEscapeChar)" in {
 
-        eval(s""" "a $escapeChar b" """) should be(ValString(s"""a $escapeChar b"""))
+        eval(s""" "a $notEscapeChar b" """) should be (ValString(
+          s"""a $notEscapeChar b"""
+        ))
       }
     }
 


### PR DESCRIPTION
## Description

Backport of #750 to `1.16`.

## Related issues


relates to #701 
