### PR TITLE
[Backport 1.16] fix: Double quotes in string literal are escaped

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -123,10 +123,10 @@ import scala.util.Try
 object FeelParser {
 
   def parseExpression(expression: String): Parsed[Exp] =
-    parse(translateEscapes(expression), fullExpression(_))
+    parse(expression, fullExpression(_))
 
   def parseUnaryTests(expression: String): Parsed[Exp] =
-    parse(translateEscapes(expression), fullUnaryExpression(_))
+    parse(expression, fullUnaryExpression(_))
 
   // --------------- entry parsers ---------------
 
@@ -391,7 +391,7 @@ object FeelParser {
   private def string[_: P]: P[Exp] =
     P(
       stringWithQuotes
-    ).map(ConstString)
+    ).map(translateEscapes).map(ConstString)
 
   private def number[_: P]: P[Exp] =
     P(
@@ -686,14 +686,14 @@ object FeelParser {
   // replace escaped character with the provided replacement
   private def translateEscapes(input: String): String = {
     val escapeMap = Map(
-      "\\b" -> "\b",
-      "\\t" -> "\t",
-      "\\n" -> "\n",
-      "\\f" -> "\f",
-      "\\r" -> "\r",
-      "\""  -> "\"",
-      "\\'" -> "'",
-      "\\s" -> " "
+      "\\b"  -> "\b",
+      "\\t"  -> "\t",
+      "\\n"  -> "\n",
+      "\\f"  -> "\f",
+      "\\r"  -> "\r",
+      "\\\"" -> "\"",
+      "\\'"  -> "'",
+      "\\s"  -> " "
       // Add more escape sequences as needed
     )
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -76,22 +76,24 @@ class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with Fee
 
   it should "return not escaped characters" in {
 
-    eval(""" "Hello\nWorld" """) should be (ValString("Hello\nWorld"))
-    eval(" x ", Map("x" -> "Hello\nWorld")) should be (ValString("Hello\nWorld"))
+    eval(""" "Hello\nWorld" """) should be(ValString("Hello\nWorld"))
+    eval(" x ", Map("x" -> "Hello\nWorld")) should be(ValString("Hello\nWorld"))
 
-    eval(""" "Hello\rWorld" """) should be (ValString("Hello\rWorld"))
-    eval(" x ", Map("x" -> "Hello\rWorld")) should be (ValString("Hello\rWorld"))
+    eval(""" "Hello\rWorld" """) should be(ValString("Hello\rWorld"))
+    eval(" x ", Map("x" -> "Hello\rWorld")) should be(ValString("Hello\rWorld"))
 
-    eval(""" "Hello\'World" """) should be (ValString("Hello\'World"))
-    eval(" x ", Map("x" -> "Hello\'World")) should be (ValString("Hello\'World"))
+    eval(""" "Hello\'World" """) should be(ValString("Hello\'World"))
+    eval(" x ", Map("x" -> "Hello\'World")) should be(ValString("Hello\'World"))
 
-    eval(""" "Hello\tWorld" """) should be (ValString("Hello\tWorld"))
-    eval(" x ", Map("x" -> "Hello\tWorld")) should be (ValString("Hello\tWorld"))
+    eval(""" "Hello\tWorld" """) should be(ValString("Hello\tWorld"))
+    eval(" x ", Map("x" -> "Hello\tWorld")) should be(ValString("Hello\tWorld"))
+
+    eval(""" "Hello\"World" """) should be(ValString("Hello\"World"))
+    eval(" x ", Map("x" -> "Hello\"World")) should be(ValString("Hello\"World"))
   }
 
   List(
     " \' ",
-    " \\\" ",
     " \\ ",
     " \n ",
     " \r ",
@@ -102,9 +104,11 @@ class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with Fee
     .foreach { notEscapeChar =>
       it should s"contains a not escape sequence ($notEscapeChar)" in {
 
-        eval(s""" "a $notEscapeChar b" """) should be (ValString(
-          s"""a $notEscapeChar b"""
-        ))
+        eval(s""" "a $notEscapeChar b" """) should be(
+          ValString(
+            s"""a $notEscapeChar b"""
+          )
+        )
       }
     }
 


### PR DESCRIPTION
# Description
Backport of #780 to `1.16`.

relates to #778