### PR TITLE
fix: Variable resolution for custom context

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/EvalContext.scala
@@ -175,7 +175,7 @@ object EvalContext {
       case (StaticVariableProvider(thisVariables), StaticVariableProvider(otherVariables)) =>
         StaticVariableProvider(thisVariables ++ otherVariables)
       case (thisProvider, otherProvider)                                                   =>
-        CompositeVariableProvider(List(thisProvider, otherProvider))
+        CompositeVariableProvider(List(otherProvider, thisProvider))
     }
   }
 
@@ -195,7 +195,7 @@ object EvalContext {
         StaticFunctionProvider(allFunctions)
       }
       case (thisProvider, otherProvider)                                                   =>
-        CompositeFunctionProvider(List(thisProvider, otherProvider))
+        CompositeFunctionProvider(List(otherProvider, thisProvider))
     }
   }
 

--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -692,14 +692,14 @@ object FeelParser {
   // replace escaped character with the provided replacement
   private def translateEscapes(input: String): String = {
     val escapeMap = Map(
-      "\\b" -> "\b",
-      "\\t" -> "\t",
-      "\\n" -> "\n",
-      "\\f" -> "\f",
-      "\\r" -> "\r",
-      "\\\""  -> "\"",
-      "\\'" -> "'",
-      "\\s" -> " "
+      "\\b"  -> "\b",
+      "\\t"  -> "\t",
+      "\\n"  -> "\n",
+      "\\f"  -> "\f",
+      "\\r"  -> "\r",
+      "\\\"" -> "\"",
+      "\\'"  -> "'",
+      "\\s"  -> " "
       // Add more escape sequences as needed
     )
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterContextExpressionTest.scala
@@ -61,18 +61,10 @@ class InterpreterContextExpressionTest
   it should "access a previous entry if there is a variable with the same name (custom context)" in {
     evaluateExpression(
       expression = "{a:1, b:a+1}",
-      context = new MyContext(Map("a" -> 0))
+      context = new MyCustomContext(Map("a" -> 0))
     ) should returnResult(
       Map("a" -> 1, "b" -> 2)
     )
-  }
-
-  class MyContext(val vars: Map[String, Any]) extends CustomContext {
-    override def variableProvider: VariableProvider = new VariableProvider {
-      override def getVariable(name: String): Option[Any] = vars.get(name)
-
-      override def keys: Iterable[String] = vars.keys
-    }
   }
 
   it should "be compared with '='" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -112,174 +112,6 @@ class InterpreterListExpressionTest
     )
   }
 
-  it should "be filtered via comparison" in {
-    evaluateExpression("[1,2,3,4][item > 2]") should returnResult(
-      List(3, 4)
-    )
-
-    evaluateExpression(
-      expression = "xs [item > 2]",
-      variables = Map("xs" -> List(1, 2, 3, 4))
-    ) should returnResult(List(3, 4))
-  }
-
-  it should "be filtered via comparison with null" in {
-    // items that are not comparable to null are ignored
-    evaluateExpression("[1,2,3,4][item > null]") should returnResult(List.empty)
-
-    // items that are not comparable to null are ignored
-    evaluateExpression("[1,2,3,4][item < null]") should returnResult(List.empty)
-  }
-
-  it should "be filtered via comparison with null elements" in {
-    // null is not comparable to 2, so it's ignored
-    evaluateExpression("[1,2,null,4][item > 2]") should returnResult(List(4))
-
-    // null is the only item for which the comparison returns true
-    evaluateExpression("[1,2,null,4][item = null]") should returnResult(List(null))
-  }
-
-  it should "be filtered via comparison with missing variable" in {
-    // null is the only item for which the comparison returns true
-    evaluateExpression("[1,2,x,4][item = null]") should returnResult(List(null))
-
-    // missing variable becomes null, so same as direct null item
-    evaluateExpression("[1,2,x,4][item > 2]") should returnResult(List(4))
-  }
-
-  it should "be filtered via index" in {
-    evaluateExpression("[1,2,3,4][1]") should returnResult(1)
-    evaluateExpression("[1,2,3,4][2]") should returnResult(2)
-
-    evaluateExpression("[1,2,3,4][-1]") should returnResult(4)
-    evaluateExpression("[1,2,3,4][-2]") should returnResult(3)
-
-    evaluateExpression("[1,2,3,4][5]") should returnNull()
-    evaluateExpression("[1,2,3,4][-5]") should returnNull()
-
-    evaluateExpression("[1,2,3,4][i]", Map("i" -> 2)) should returnResult(2)
-    evaluateExpression("[1,2,3,4][i]", Map("i" -> -2)) should returnResult(3)
-  }
-
-  it should "be filtered via boolean expression" in {
-    evaluateExpression("[1,2,3,4][odd(item)]") should returnResult(List(1, 3))
-
-    evaluateExpression("[1,2,3,4][even(item)]") should returnResult(List(2, 4))
-  }
-
-  it should "be filtered via numeric function" in {
-    evaluateExpression("[1,2,3,4][abs(1)]") should returnResult(1)
-
-    evaluateExpression("[1,2,3,4][modulo(2,4)]") should returnResult(2)
-  }
-
-  it should "be filtered via custom boolean function" in {
-    val functionInvocations: ListBuffer[Val] = ListBuffer.empty
-
-    val result = evaluateExpression(
-      expression = "[1,2,3,4][f(item)]",
-      variables = Map(),
-      functions = Map(
-        "f" -> ValFunction(
-          params = List("x"),
-          invoke = { case List(x) =>
-            functionInvocations += x
-            ValBoolean(x == ValNumber(3))
-          }
-        )
-      )
-    )
-
-    result should returnResult(List(3))
-
-    functionInvocations should be(List(ValNumber(1), ValNumber(2), ValNumber(3), ValNumber(4)))
-  }
-
-  it should "be filtered via custom numeric function" in {
-    val functionInvocations: ListBuffer[Val] = ListBuffer.empty
-
-    val result = evaluateExpression(
-      expression = "[1,2,3,4][f(item)]",
-      variables = Map(),
-      functions = Map(
-        "f" -> ValFunction(
-          params = List("x"),
-          invoke = { case List(x) =>
-            functionInvocations += x
-            ValNumber(3)
-          }
-        )
-      )
-    )
-
-    result should returnResult(3)
-
-    functionInvocations should be(List(ValNumber(1)))
-  }
-
-  it should "be filtered multiple times (from literal)" in {
-    evaluateExpression("[[1]][1][1]") should returnResult(1)
-    evaluateExpression("[[[1]]][1][1][1]") should returnResult(1)
-    evaluateExpression("[[[[1]]]][1][1][1][1]") should returnResult(1)
-  }
-
-  it should "be filtered multiple times (from variable)" in {
-    val listOfLists = List(List(1))
-
-    evaluateExpression("xs[1][1]", Map("xs" -> listOfLists)) should returnResult(1)
-    evaluateExpression("xs[1][1][1]", Map("xs" -> List(listOfLists))) should returnResult(1)
-    evaluateExpression("xs[1][1][1][1]", Map("xs" -> List(List(listOfLists)))) should returnResult(
-      1
-    )
-  }
-
-  it should "be filtered multiple times (from function invocation)" in {
-    evaluateExpression("append([], [1])[1][1]") should returnResult(1)
-    evaluateExpression("append([], [[1]])[1][1][1]") should returnResult(1)
-    evaluateExpression("append([], [[[1]]])[1][1][1][1]") should returnResult(1)
-  }
-
-  it should "be filtered multiple times (from path)" in {
-    val listOfLists = List(List(1))
-
-    evaluateExpression("x.y[1][1]", Map("x" -> Map("y" -> listOfLists))) should returnResult(1)
-    evaluateExpression(
-      "x.y[1][1][1]",
-      Map("x" -> Map("y" -> List(listOfLists)))
-    ) should returnResult(1)
-    evaluateExpression(
-      "x.y[1][1][1][1]",
-      Map("x" -> Map("y" -> List(List(listOfLists))))
-    ) should returnResult(1)
-  }
-
-  it should "be filtered multiple times (from context projection)" in {
-    evaluateExpression("{x:[[1]]}.x[1][1]") should returnResult(1)
-    evaluateExpression("{x:[[[1]]]}.x[1][1][1]") should returnResult(1)
-    evaluateExpression("{x:[[[[1]]]]}.x[1][1][1][1]") should returnResult(1)
-  }
-
-  it should "be filtered multiple times (in a context)" in {
-    val listOfLists = List(List(1))
-
-    evaluateExpression("{z: x.y[1][1]}.z", Map("x" -> Map("y" -> listOfLists))) should returnResult(
-      1
-    )
-    evaluateExpression(
-      "{z: x.y[1][1][1]}.z",
-      Map("x" -> Map("y" -> List(listOfLists)))
-    ) should returnResult(1)
-    evaluateExpression(
-      "{z: x.y[1][1][1][1]}.z",
-      Map("x" -> Map("y" -> List(List(listOfLists))))
-    ) should returnResult(1)
-  }
-
-  it should "be filtered if the filter doesn't always return a boolean or a number" in {
-    evaluateExpression(""" [1,2,3,4]["not a valid filter"] """) should returnResult(List.empty)
-    evaluateExpression("[1,2,3,4][if item < 3 then true else null]") should returnResult(List(1, 2))
-  }
-
   it should "contain null if a variable doesn't exist" in {
     evaluateExpression("[1, x]") should returnResult(List(1, null))
   }
@@ -401,7 +233,175 @@ class InterpreterListExpressionTest
     )
   }
 
-  "A filter expression" should "access an item property if the context contains a variable with the same name" in {
+  "A filter expression" should "access the item" in {
+    evaluateExpression("[1,2,3,4][item > 2]") should returnResult(
+      List(3, 4)
+    )
+
+    evaluateExpression(
+      expression = "xs [item > 2]",
+      variables = Map("xs" -> List(1, 2, 3, 4))
+    ) should returnResult(List(3, 4))
+  }
+
+  it should "compare the item with null" in {
+    // items that are not comparable to null are ignored
+    evaluateExpression("[1,2,3,4][item > null]") should returnResult(List.empty)
+
+    // items that are not comparable to null are ignored
+    evaluateExpression("[1,2,3,4][item < null]") should returnResult(List.empty)
+  }
+
+  it should "compare the item if the item is null" in {
+    // null is not comparable to 2, so it's ignored
+    evaluateExpression("[1,2,null,4][item > 2]") should returnResult(List(4))
+
+    // null is the only item for which the comparison returns true
+    evaluateExpression("[1,2,null,4][item = null]") should returnResult(List(null))
+  }
+
+  it should "compare the item if the item is a missing variable" in {
+    // null is the only item for which the comparison returns true
+    evaluateExpression("[1,2,x,4][item = null]") should returnResult(List(null))
+
+    // missing variable becomes null, so same as direct null item
+    evaluateExpression("[1,2,x,4][item > 2]") should returnResult(List(4))
+  }
+
+  it should "access an item by index" in {
+    evaluateExpression("[1,2,3,4][1]") should returnResult(1)
+    evaluateExpression("[1,2,3,4][2]") should returnResult(2)
+
+    evaluateExpression("[1,2,3,4][-1]") should returnResult(4)
+    evaluateExpression("[1,2,3,4][-2]") should returnResult(3)
+
+    evaluateExpression("[1,2,3,4][5]") should returnNull()
+    evaluateExpression("[1,2,3,4][-5]") should returnNull()
+
+    evaluateExpression("[1,2,3,4][i]", Map("i" -> 2)) should returnResult(2)
+    evaluateExpression("[1,2,3,4][i]", Map("i" -> -2)) should returnResult(3)
+  }
+
+  it should "compare the item with a boolean expression" in {
+    evaluateExpression("[1,2,3,4][odd(item)]") should returnResult(List(1, 3))
+
+    evaluateExpression("[1,2,3,4][even(item)]") should returnResult(List(2, 4))
+  }
+
+  it should "access an item by a numeric function" in {
+    evaluateExpression("[1,2,3,4][abs(1)]") should returnResult(1)
+
+    evaluateExpression("[1,2,3,4][modulo(2,4)]") should returnResult(2)
+  }
+
+  it should "compare the item with a custom boolean function" in {
+    val functionInvocations: ListBuffer[Val] = ListBuffer.empty
+
+    val result = evaluateExpression(
+      expression = "[1,2,3,4][f(item)]",
+      variables = Map(),
+      functions = Map(
+        "f" -> ValFunction(
+          params = List("x"),
+          invoke = { case List(x) =>
+            functionInvocations += x
+            ValBoolean(x == ValNumber(3))
+          }
+        )
+      )
+    )
+
+    result should returnResult(List(3))
+
+    functionInvocations should be(List(ValNumber(1), ValNumber(2), ValNumber(3), ValNumber(4)))
+  }
+
+  it should "access the item with a custom numeric function" in {
+    val functionInvocations: ListBuffer[Val] = ListBuffer.empty
+
+    val result = evaluateExpression(
+      expression = "[1,2,3,4][f(item)]",
+      variables = Map(),
+      functions = Map(
+        "f" -> ValFunction(
+          params = List("x"),
+          invoke = { case List(x) =>
+            functionInvocations += x
+            ValNumber(3)
+          }
+        )
+      )
+    )
+
+    result should returnResult(3)
+
+    functionInvocations should be(List(ValNumber(1)))
+  }
+
+  it should "access a nested item by index (from literal)" in {
+    evaluateExpression("[[1]][1][1]") should returnResult(1)
+    evaluateExpression("[[[1]]][1][1][1]") should returnResult(1)
+    evaluateExpression("[[[[1]]]][1][1][1][1]") should returnResult(1)
+  }
+
+  it should "access a nested item by index (from variable)" in {
+    val listOfLists = List(List(1))
+
+    evaluateExpression("xs[1][1]", Map("xs" -> listOfLists)) should returnResult(1)
+    evaluateExpression("xs[1][1][1]", Map("xs" -> List(listOfLists))) should returnResult(1)
+    evaluateExpression("xs[1][1][1][1]", Map("xs" -> List(List(listOfLists)))) should returnResult(
+      1
+    )
+  }
+
+  it should "access a nested item by index (from function invocation)" in {
+    evaluateExpression("append([], [1])[1][1]") should returnResult(1)
+    evaluateExpression("append([], [[1]])[1][1][1]") should returnResult(1)
+    evaluateExpression("append([], [[[1]]])[1][1][1][1]") should returnResult(1)
+  }
+
+  it should "access a nested item by index (from path)" in {
+    val listOfLists = List(List(1))
+
+    evaluateExpression("x.y[1][1]", Map("x" -> Map("y" -> listOfLists))) should returnResult(1)
+    evaluateExpression(
+      "x.y[1][1][1]",
+      Map("x" -> Map("y" -> List(listOfLists)))
+    ) should returnResult(1)
+    evaluateExpression(
+      "x.y[1][1][1][1]",
+      Map("x" -> Map("y" -> List(List(listOfLists))))
+    ) should returnResult(1)
+  }
+
+  it should "access a nested item by index (from context projection)" in {
+    evaluateExpression("{x:[[1]]}.x[1][1]") should returnResult(1)
+    evaluateExpression("{x:[[[1]]]}.x[1][1][1]") should returnResult(1)
+    evaluateExpression("{x:[[[[1]]]]}.x[1][1][1][1]") should returnResult(1)
+  }
+
+  it should "access a nested item by index (in a context)" in {
+    val listOfLists = List(List(1))
+
+    evaluateExpression("{z: x.y[1][1]}.z", Map("x" -> Map("y" -> listOfLists))) should returnResult(
+      1
+    )
+    evaluateExpression(
+      "{z: x.y[1][1][1]}.z",
+      Map("x" -> Map("y" -> List(listOfLists)))
+    ) should returnResult(1)
+    evaluateExpression(
+      "{z: x.y[1][1][1][1]}.z",
+      Map("x" -> Map("y" -> List(List(listOfLists))))
+    ) should returnResult(1)
+  }
+
+  it should "ignore items if the filter doesn't return a boolean or a number" in {
+    evaluateExpression(""" [1,2,3,4]["not a valid filter"] """) should returnResult(List.empty)
+    evaluateExpression("[1,2,3,4][if item < 3 then true else null]") should returnResult(List(1, 2))
+  }
+
+  it should "access an item property if the context contains a variable with the same name" in {
     evaluateExpression(
       expression =
         """sum({"loans" : [
@@ -424,6 +424,7 @@ class InterpreterListExpressionTest
       context = new MyContext(Map("id" -> "AAA002", "loanId" -> "AAA002"))
     ) should returnResult(20)
   }
+
 
   class MyContext(val vars: Map[String, Any]) extends CustomContext {
     override def variableProvider: VariableProvider = new VariableProvider {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -421,17 +421,8 @@ class InterpreterListExpressionTest
                            {"loanId" : "AAA002", "amount" : 20},
                            {"loanId" : "AAA001", "amount" : 50}
                          ]}.loans[loanId = id].amount)""",
-      context = new MyContext(Map("id" -> "AAA002", "loanId" -> "AAA002"))
+      context = new MyCustomContext(Map("id" -> "AAA002", "loanId" -> "AAA002"))
     ) should returnResult(20)
-  }
-
-
-  class MyContext(val vars: Map[String, Any]) extends CustomContext {
-    override def variableProvider: VariableProvider = new VariableProvider {
-      override def getVariable(name: String): Option[Any] = vars.get(name)
-
-      override def keys: Iterable[String] = vars.keys
-    }
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -403,8 +403,7 @@ class InterpreterListExpressionTest
 
   it should "access an item property if the context contains a variable with the same name" in {
     evaluateExpression(
-      expression =
-        """sum({"loans" : [
+      expression = """sum({"loans" : [
                            {"loanId" : "AAA001", "amount" : 10},
                            {"loanId" : "AAA002", "amount" : 20},
                            {"loanId" : "AAA001", "amount" : 50}
@@ -415,8 +414,7 @@ class InterpreterListExpressionTest
 
   it should "access an item property if the custom context contains a variable with the same name" in {
     evaluateExpression(
-      expression =
-        """sum({"loans" : [
+      expression = """sum({"loans" : [
                            {"loanId" : "AAA001", "amount" : 10},
                            {"loanId" : "AAA002", "amount" : 20},
                            {"loanId" : "AAA001", "amount" : 50}

--- a/src/test/scala/org/camunda/feel/impl/interpreter/MyCustomContext.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/MyCustomContext.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.impl.interpreter
+
+import org.camunda.feel.context.{CustomContext, VariableProvider}
+
+class MyCustomContext(val vars: Map[String, Any]) extends CustomContext {
+  override def variableProvider: VariableProvider = new VariableProvider {
+    override def getVariable(name: String): Option[Any] = vars.get(name)
+
+    override def keys: Iterable[String] = vars.keys
+  }
+}


### PR DESCRIPTION
## Description

Fix the variable resolution if the variables are provided by a custom context. 

Currently, the local variables within a list filter or a context literal are overridden by variables from the custom context.  

## Related issues

closes #765 
closes #774
