### PR TITLE
chore(workflows): Add Java 21 to build-maven.yml

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '21' ]
 
     name: Java ${{ matrix.Java }}
     steps:


### PR DESCRIPTION
Backport `JDK 21` Support to `1.16` branch
Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4058