### PR TITLE
feat: add trim() function for whitespace stripping

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
@@ -37,7 +37,8 @@ object StringBuiltinFunctions {
     "ends with"        -> List(endsWithFunction),
     "matches"          -> List(matchesFunction, matchesFunction3),
     "split"            -> List(splitFunction),
-    "extract"          -> List(extractFunction)
+    "extract"          -> List(extractFunction),
+    "trim"             -> List(trimFunction)
   )
 
   private def substringFunction = builtinFunction(
@@ -254,4 +255,11 @@ object StringBuiltinFunctions {
     }
   )
 
+  private def trimFunction =
+    builtinFunction(
+      params = List("string"),
+      invoke = { case List(ValString(string)) =>
+        ValString(string.trim)
+      }
+    )
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -150,4 +150,17 @@ class BuiltinStringFunctionsTest extends AnyFlatSpec with Matchers with FeelInte
   it should "return null if the pattern is invalid" in {
     eval(""" extract("abc", "[a-z") """) should be(ValNull)
   }
+
+  "A trim() function" should "return the eliminates leading and trailing spaces of a String" in {
+
+    eval(""" trim("hello world") """) should be(ValString("hello world"))
+
+    eval(""" trim("hello world  ") """) should be(ValString("hello world"))
+
+    eval(""" trim("  hello world") """) should be(ValString("hello world"))
+
+    eval(""" trim("  hello world  ") """) should be(ValString("hello world"))
+
+    eval(""" trim(" hello   world ") """) should be(ValString("hello   world"))
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Add the following built-in function `trim()`

```
// examples
trim("hello world")    // --> "hello world"
trim("hello world  ")    // --> "hello world"
trim("  hello world")    // --> "hello world"
trim("  hello world  ")    // --> "hello world"
trim(" hello   world ")    // --> "hello   world"
```

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #815 
