### PR TITLE
doc(playground): Evaluate expression with empty context

### DIFF
--- a/docs/src/components/LiveFeel.js
+++ b/docs/src/components/LiveFeel.js
@@ -30,7 +30,7 @@ const LiveFeel = ({
   const contextErrorPattern = /^.+at position (?<position>\d+)$/gm;
 
   const parseContext = () => {
-    if (!feelContext) {
+    if (!feelContext  || context.trim().length === 0) {
       return {};
     }
     return JSON.parse(context);

--- a/docs/src/components/LiveFeelUnaryTests.js
+++ b/docs/src/components/LiveFeelUnaryTests.js
@@ -33,14 +33,14 @@ const LiveFeelUnaryTests = ({
   const contextErrorPattern = /^.+at position (?<position>\d+)$/gm;
 
   const parseContext = () => {
-    if (!feelContext) {
+    if (!feelContext  || context.trim().length === 0) {
       return {};
     }
     return JSON.parse(context);
   };
 
   const parseInputValue = () => {
-    if (!feelInputValue) {
+    if (!feelInputValue || inputValue.trim().length === 0) {
       return null;
     }
     return JSON.parse(inputValue);


### PR DESCRIPTION
## Description

Modify the FEEL Playground to evaluate an expression if no/empty context is entered. 

## Related issues

closes https://github.com/camunda-community-hub/feel-scala-playground/issues/47
