### PR TITLE
feat: add built-in function to generate a UUID string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <scala.version>2.13.13</scala.version>
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.23.1</version.log4j>
+    <version.uuid>5.0.0</version.uuid>
 
     <plugin.version.shade>3.5.2</plugin.version.shade>
     <plugin.version.gpg>1.6</plugin.version.gpg>
@@ -88,6 +89,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>${version.uuid}</version>
     </dependency>
 
     <dependency>

--- a/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
@@ -25,6 +25,8 @@ import scala.util.Try
 
 object StringBuiltinFunctions {
 
+  private lazy val generator = Generators.timeBasedGenerator(EthernetAddress.fromInterface())
+
   def functions = Map(
     "substring"        -> List(substringFunction, substringFunction3),
     "string length"    -> List(stringLengthFunction),
@@ -269,8 +271,7 @@ object StringBuiltinFunctions {
     builtinFunction(
       params = List(),
       invoke = { case List() =>
-        val uuid  = Generators.timeBasedGenerator.generate()
-        ValString(uuid.toString)
+        ValString(generator.generate.toString())
       }
     )
 }

--- a/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
@@ -16,6 +16,7 @@
  */
 package org.camunda.feel.impl.builtin
 
+import com.fasterxml.uuid.{EthernetAddress, Generators}
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
 import org.camunda.feel.syntaxtree.{ValBoolean, ValError, ValList, ValNumber, ValString}
 
@@ -38,7 +39,8 @@ object StringBuiltinFunctions {
     "matches"          -> List(matchesFunction, matchesFunction3),
     "split"            -> List(splitFunction),
     "extract"          -> List(extractFunction),
-    "trim"             -> List(trimFunction)
+    "trim"             -> List(trimFunction),
+    "uuid"             -> List(uuidFunction)
   )
 
   private def substringFunction = builtinFunction(
@@ -260,6 +262,15 @@ object StringBuiltinFunctions {
       params = List("string"),
       invoke = { case List(ValString(string)) =>
         ValString(string.trim)
+      }
+    )
+
+  private def uuidFunction =
+    builtinFunction(
+      params = List(),
+      invoke = { case List() =>
+        val uuid  = Generators.timeBasedGenerator.generate()
+        ValString(uuid.toString)
       }
     )
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -17,9 +17,9 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.FeelIntegrationTest
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.flatspec.AnyFlatSpec
 import org.camunda.feel.syntaxtree._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.math.BigDecimal.int2bigDecimal
 
@@ -162,5 +162,15 @@ class BuiltinStringFunctionsTest extends AnyFlatSpec with Matchers with FeelInte
     eval(""" trim("  hello world  ") """) should be(ValString("hello world"))
 
     eval(""" trim(" hello   world ") """) should be(ValString("hello   world"))
+  }
+
+  "A uuid() function" should "return a string" in {
+
+    eval(" uuid() ") shouldBe a[ValString]
+  }
+
+  it should "return a string of length 36" in {
+
+    eval(" string length(uuid()) ") should be(ValNumber(36))
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Add the following built-in function `uuid()`.

```
// function signature
uuid(): String

// usage
uuid()    // -> "7793aab1-d761-4d38-916b-b7270e309894"
uuid()    // -> "df09d5c2-e9f0-432d-9027-aaa5db56b8b5"
```
## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #796 
