### PR TITLE
[Backport 1.17] fix: `string()` function can handle a context with custom value types

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -17,35 +17,17 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
-import org.camunda.feel.syntaxtree.{
-  Val,
-  ValBoolean,
-  ValDate,
-  ValDateTime,
-  ValDayTimeDuration,
-  ValError,
-  ValLocalDateTime,
-  ValLocalTime,
-  ValNull,
-  ValNumber,
-  ValString,
-  ValTime,
-  ValYearMonthDuration,
-  ZonedTime
-}
+import org.camunda.feel.syntaxtree._
+import org.camunda.feel.valuemapper.ValueMapper
 import org.camunda.feel.{
   Date,
   YearMonthDuration,
-  dateFormatter,
-  dateTimeFormatter,
   isDayTimeDuration,
   isLocalDateTime,
   isOffsetDateTime,
   isOffsetTime,
   isValidDate,
   isYearMonthDuration,
-  localDateTimeFormatter,
-  localTimeFormatter,
   stringToDate,
   stringToDateTime,
   stringToDayTimeDuration,
@@ -56,11 +38,10 @@ import org.camunda.feel.{
 }
 
 import java.math.BigDecimal
-import java.time.{LocalDate, LocalTime, Period, ZoneId, ZoneOffset}
-import java.util.regex.Pattern
+import java.time._
 import scala.util.Try
 
-object ConversionBuiltinFunctions {
+class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
 
   def functions = Map(
     "date"                      -> List(dateFunction, dateFunction3),
@@ -234,9 +215,24 @@ object ConversionBuiltinFunctions {
     invoke = {
       case List(ValNull)         => ValNull
       case List(from: ValString) => from
-      case List(from)            => ValString(from.toString)
+      case List(from)            => ValString(map(from))
     }
   )
+
+  private def map(from: Val): String = {
+    from match {
+      case ValNull             => ValNull.toString
+      case ValContext(context) =>
+        context.variableProvider.getVariables
+          .map { case (key, value) => s"$key:${map(valueMapper.toVal(value))}" }
+          .mkString(start = "{", sep = ", ", end = "}")
+      case ValList(items)      =>
+        items
+          .map(item => map(item))
+          .mkString(start = "[", sep = ", ", end = "]")
+      case from                => from.toString
+    }
+  }
 
   private def durationFunction =
     builtinFunction(

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -215,20 +215,23 @@ class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
     invoke = {
       case List(ValNull)         => ValNull
       case List(from: ValString) => from
-      case List(from)            => ValString(map(from))
+      case List(from)            => ValString(toString(from))
     }
   )
 
-  private def map(from: Val): String = {
+  private def toString(from: Val): String = {
     from match {
-      case ValNull             => ValNull.toString
       case ValContext(context) =>
         context.variableProvider.getVariables
-          .map { case (key, value) => s"$key:${map(valueMapper.toVal(value))}" }
+          .map { case (key, value) =>
+            val asVal    = valueMapper.toVal(value)
+            val asString = toString(asVal)
+            s"$key:$asString"
+          }
           .mkString(start = "{", sep = ", ", end = "}")
       case ValList(items)      =>
         items
-          .map(item => map(item))
+          .map(toString)
           .mkString(start = "[", sep = ", ", end = "]")
       case from                => from.toString
     }

--- a/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/BuiltinFunctions.scala
@@ -39,7 +39,7 @@ class BuiltinFunctions(clock: FeelEngineClock, valueMapper: ValueMapper) extends
   override def functionNames: Iterable[String] = functions.keys
 
   val functions: Map[String, List[ValFunction]] =
-    ConversionBuiltinFunctions.functions ++
+    new ConversionBuiltinFunctions(valueMapper).functions ++
       BooleanBuiltinFunctions.functions ++
       StringBuiltinFunctions.functions ++
       ListBuiltinFunctions.functions ++


### PR DESCRIPTION
# Description
Backport of #833 to `1.17`.

relates to #804
original author: @mustafadagher