### PR TITLE
fix: number() should return null instead of failing the evaluation

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -218,6 +218,22 @@ class BuiltinConversionFunctionsTest
     )
   }
 
+  it should "return null if the string is not a valid number" in {
+
+    evaluateExpression(""" number("x") """) should returnNull()
+    evaluateExpression(""" number("1 5.x") """) should returnNull()
+    evaluateExpression(""" number("1 500.5x", " ") """) should returnNull
+    evaluateExpression(""" number("1,500x", ",") """) should returnNull
+    evaluateExpression(""" number("1.50x0", ".") """) should returnNull
+    evaluateExpression(""" number("1 50x0.5", " ", ".") """) should returnNull
+    evaluateExpression(""" number("1 50x0,5", " ", ",") """) should returnNull
+    evaluateExpression(""" number("150x0,5", null, ",") """) should returnNull
+    evaluateExpression(""" number("1.5x00", ".", null) """) should returnNull
+    evaluateExpression(
+      """ number(from: "1.5x00", grouping separator: ".", decimal separator: null) """
+      ) should returnNull
+  }
+
   "A string() function" should "convert Number" in {
 
     evaluateExpression(""" string(1.1) """) should returnResult("1.1")


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The function `number()` should return `null` if the string is not a valid number.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #731 
