### PR TITLE
[Backport 1.17] fix: Invoke context() function with a list containing a custom context

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -189,7 +189,8 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
     invoke = {
       case List(ValList(entries)) if isListOfKeyValuePairs(entries) =>
         ValContext(StaticContext(variables = entries.flatMap { case ValContext(context) =>
-          val getValue = context.variableProvider.getVariable(_)
+          val getValue: String => Option[Val] =
+            context.variableProvider.getVariable(_).map(valueMapper.toVal)
           getValue("key")
             .map { case ValString(key) => key }
             .flatMap(key => getValue("value").map(value => key -> value))
@@ -204,6 +205,7 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
         val keys = context.variableProvider.keys.toList
         keys.contains("value") && context.variableProvider
           .getVariable("key")
+          .map(valueMapper.toVal)
           .exists(_.isInstanceOf[ValString])
       case _                   => false
     }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -17,6 +17,7 @@
 package org.camunda.feel.impl.builtin
 
 import org.camunda.feel.context.{CustomContext, VariableProvider}
+import org.camunda.feel.impl.interpreter.MyCustomContext
 import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
 import org.camunda.feel.syntaxtree._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -458,6 +459,25 @@ class BuiltinContextFunctionsTest
     evaluateExpression(
       """ context([{"key":"a", "value":1}, {"key":2, "value":2}]) """
     ) should returnNull()
+  }
+
+  it should "return a context with entries from a custom context" in {
+
+    evaluateExpression(
+      expression = """context(list)""",
+      variables = Map(
+        "list" -> List(
+          ValContext(
+            new MyCustomContext(
+              Map(
+                "key"   -> "a",
+                "value" -> 1
+              )
+            )
+          )
+        )
+      )
+    ) should returnResult(Map("a" -> 1))
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -118,23 +118,17 @@ class BuiltinContextFunctionsTest
 
   it should "return a value from a custom context" in {
 
-    class MyCustomContext extends CustomContext {
-      class MyVariableProvider extends VariableProvider {
-        private val entries = Map(
-          "x" -> Map("y" -> 1)
-        )
-
-        override def getVariable(name: String): Option[Any] = entries.get(name)
-
-        override def keys: Iterable[String] = entries.keys
-      }
-
-      override def variableProvider: VariableProvider = new MyVariableProvider
-    }
-
     evaluateExpression(
       expression = """get value(context, ["x", "y"])""",
-      variables = Map("context" -> ValContext(new MyCustomContext))
+      variables = Map(
+        "context" -> ValContext(
+          new MyCustomContext(
+            Map(
+              "x" -> Map("y" -> 1)
+            )
+          )
+        )
+      )
     ) should returnResult(1)
   }
 


### PR DESCRIPTION
## Description

Backport of #858 to `1.17`.

## Related issues

relates to #856
