### PR TITLE
fix: Return `null` if a date is invalid

### DIFF
--- a/src/main/scala/org/camunda/package.scala
+++ b/src/main/scala/org/camunda/package.scala
@@ -18,20 +18,20 @@ package org.camunda
 
 import scala.math.BigDecimal
 import org.slf4j.LoggerFactory
+
 import java.time.temporal.ChronoField.{
+  DAY_OF_MONTH,
   HOUR_OF_DAY,
   MINUTE_OF_HOUR,
-  SECOND_OF_MINUTE,
-  NANO_OF_SECOND,
-  YEAR,
   MONTH_OF_YEAR,
-  DAY_OF_MONTH
+  NANO_OF_SECOND,
+  SECOND_OF_MINUTE,
+  YEAR
 }
-
 import java.util.regex.Pattern
 import org.camunda.feel.syntaxtree.ZonedTime
 
-import java.time.format.{DateTimeFormatterBuilder, SignStyle}
+import java.time.format.{DateTimeFormatterBuilder, ResolverStyle, SignStyle}
 import java.time.{Duration, LocalDate, LocalDateTime, LocalTime, Period, ZonedDateTime}
 
 /** @author
@@ -189,17 +189,20 @@ package object feel {
     .appendValue(MONTH_OF_YEAR, 2)
     .appendLiteral("-")
     .appendValue(DAY_OF_MONTH, 2)
-    .toFormatter();
+    .toFormatter()
+    .withResolverStyle(ResolverStyle.STRICT)
 
   val localDateTimeFormatter = new DateTimeFormatterBuilder()
     .append(dateFormatter)
     .append(timeFormatterWithPrefix)
-    .toFormatter();
+    .toFormatter()
+    .withResolverStyle(ResolverStyle.STRICT)
 
   val dateTimeFormatter = new DateTimeFormatterBuilder()
     .append(dateFormatter)
     .append(timeFormatterWithPrefix)
     .append(offsetFormatter)
-    .toFormatter();
+    .toFormatter()
+    .withResolverStyle(ResolverStyle.STRICT)
 
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -63,13 +63,13 @@ class BuiltinConversionFunctionsTest
     )
   }
 
-  it should "return null if the date is not valid (leap year)" in {
+  it should "return null if the date is not valid (not a leap year)" in {
 
     evaluateExpression(""" date(x) """, Map("x" -> "2023-02-29")) should returnNull()
     evaluateExpression(""" date(2023, 2, 29) """) should returnNull()
   }
 
-  it should "return null if the date is not valid (month with 31 days)" in {
+  it should "return null if the date is not valid (month without 31 days)" in {
 
     evaluateExpression(""" date(x) """, Map("x" -> "2023-06-31")) should returnNull()
     evaluateExpression(""" date(2023, 6, 31) """) should returnNull()

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -141,7 +141,7 @@ class BuiltinConversionFunctionsTest
     ) should returnResult(ZonedDateTime.parse("2012-12-24T23:59:00+01:00"))
   }
 
-  it should "return null if the date is not valid (leap year)" in {
+  it should "return null if the date is not valid (not a leap year)" in {
 
     evaluateExpression(
       """ date and time(x) """,
@@ -154,7 +154,7 @@ class BuiltinConversionFunctionsTest
     ) should returnNull()
   }
 
-  it should "return null if the date is not valid (month with 31 days)" in {
+  it should "return null if the date is not valid (month without 31 days)" in {
 
     evaluateExpression(
       """ date and time(x) """,

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -63,6 +63,18 @@ class BuiltinConversionFunctionsTest
     )
   }
 
+  it should "return null if the date is not valid (leap year)" in {
+
+    evaluateExpression(""" date(x) """, Map("x" -> "2023-02-29")) should returnNull()
+    evaluateExpression(""" date(2023, 2, 29) """) should returnNull()
+  }
+
+  it should "return null if the date is not valid (month with 31 days)" in {
+
+    evaluateExpression(""" date(x) """, Map("x" -> "2023-06-31")) should returnNull()
+    evaluateExpression(""" date(2023, 6, 31) """) should returnNull()
+  }
+
   "A date and time() function" should "convert String" in {
 
     evaluateExpression(
@@ -127,6 +139,32 @@ class BuiltinConversionFunctionsTest
     evaluateExpression(
       """ date and time(date and time("2012-12-24T10:24:00+01:00"),time("T23:59:00+01:00")) """
     ) should returnResult(ZonedDateTime.parse("2012-12-24T23:59:00+01:00"))
+  }
+
+  it should "return null if the date is not valid (leap year)" in {
+
+    evaluateExpression(
+      """ date and time(x) """,
+      Map("x" -> "2023-02-29T10:00:00")
+    ) should returnNull()
+
+    evaluateExpression(
+      """ date and time(x) """,
+      Map("x" -> "2023-02-29T10:00:00+02:00")
+    ) should returnNull()
+  }
+
+  it should "return null if the date is not valid (month with 31 days)" in {
+
+    evaluateExpression(
+      """ date and time(x) """,
+      Map("x" -> "2023-06-31T10:00:00")
+    ) should returnNull()
+
+    evaluateExpression(
+      """ date and time(x) """,
+      Map("x" -> "2023-06-31T10:00:00+02:00")
+    ) should returnNull()
   }
 
   "A time() function" should "convert String" in {

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
@@ -16,285 +16,216 @@
  */
 package org.camunda.feel.impl.interpreter
 
-import org.camunda.feel.impl.FeelIntegrationTest
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
 import org.camunda.feel.syntaxtree._
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import java.time.{
-  Duration,
-  LocalDate,
-  LocalDateTime,
-  LocalTime,
-  Period,
-  ZoneId,
-  ZoneOffset,
-  ZonedDateTime
-}
+import java.time._
 
 /** @author
   *   Philipp Ossler
   */
-class InterpreterLiteralExpressionTest extends AnyFlatSpec with Matchers with FeelIntegrationTest {
+class InterpreterLiteralExpressionTest
+    extends AnyFlatSpec
+    with Matchers
+    with FeelEngineTest
+    with EvaluationResultMatchers {
 
   "A literal" should "be a number" in {
 
-    eval("2") should be(ValNumber(2))
-    eval("2.4") should be(ValNumber(2.4))
-    eval("-3") should be(ValNumber(-3))
-    eval("02") should be(ValNumber(2))
-    eval("02.4") should be(ValNumber(2.4))
-    eval("-03") should be(ValNumber(-3))
-    eval("0000002") should be(ValNumber(2))
+    evaluateExpression("2") should returnResult(2)
+    evaluateExpression("2.4") should returnResult(2.4)
+    evaluateExpression("-3") should returnResult(-3)
+    evaluateExpression("02") should returnResult(2)
+    evaluateExpression("02.4") should returnResult(2.4)
+    evaluateExpression("-03") should returnResult(-3)
+    evaluateExpression("0000002") should returnResult(2)
 
   }
 
   it should "be a string" in {
 
-    eval(""" "a" """) should be(ValString("a"))
+    evaluateExpression(""" "a" """) should returnResult("a")
   }
 
   it should "be a boolean" in {
 
-    eval("true") should be(ValBoolean(true))
+    evaluateExpression("true") should returnResult(true)
   }
 
   it should "be null" in {
 
-    eval("null") should be(ValNull)
+    evaluateExpression("null") should returnNull()
   }
 
   it should "be a context (identifier as key)" in {
 
-    eval("{ a : 1 }")
-      .asInstanceOf[ValContext]
-      .context
-      .variableProvider
-      .getVariables should be(Map("a" -> ValNumber(1)))
+    evaluateExpression("{ a : 1 }") should returnResult(Map("a" -> 1))
 
-    eval("""{ a:1, b:"foo" }""")
-      .asInstanceOf[ValContext]
-      .context
-      .variableProvider
-      .getVariables should be(Map("a" -> ValNumber(1), "b" -> ValString("foo")))
+    evaluateExpression("""{ a:1, b:"foo" }""") should returnResult(
+      Map("a" -> 1, "b" -> "foo")
+    )
 
     // nested
-    val nestedContext = eval("{ a : { b : 1 } }")
-      .asInstanceOf[ValContext]
-      .context
-      .variableProvider
-      .getVariable("a")
-      .get
-
-    nestedContext shouldBe a[ValContext]
-    nestedContext
-      .asInstanceOf[ValContext]
-      .context
-      .variableProvider
-      .getVariables should be(Map("b" -> ValNumber(1)))
+    evaluateExpression("{ a : { b : 1 } }") should returnResult(
+      Map("a" -> Map("b" -> 1))
+    )
   }
 
   it should "be a context (string as key)" in {
-    val result = eval(""" {"a":1} """)
-
-    result shouldBe a[ValContext]
-    result match {
-      case ValContext(context) =>
-        context.variableProvider.getVariables should be(Map("a" -> ValNumber(1)))
-    }
+    evaluateExpression(""" {"a":1} """) should returnResult(Map("a" -> 1))
   }
 
   it should "be a list" in {
 
-    eval("[1]") should be(ValList(List(ValNumber(1))))
+    evaluateExpression("[1]") should returnResult(List(1))
 
-    eval("[1,2]") should be(ValList(List(ValNumber(1), ValNumber(2))))
+    evaluateExpression("[1,2]") should returnResult(List(1, 2))
 
     // nested
-    eval("[ [1], [2] ]") should be(
-      ValList(List(ValList(List(ValNumber(1))), ValList(List(ValNumber(2)))))
-    )
+    evaluateExpression("[ [1], [2] ]") should returnResult(List(List(1), List(2)))
   }
 
   "A date literal" should "be defined" in {
-    eval(""" date("2021-09-08") """) should be(
-      ValDate(
-        LocalDate.parse("2021-09-08")
-      )
+    evaluateExpression(""" date("2021-09-08") """) should returnResult(
+      LocalDate.parse("2021-09-08")
     )
   }
 
   it should "be defined with '@'" in {
-    eval(""" @"2021-09-08" """) should be(
-      ValDate(
-        LocalDate.parse("2021-09-08")
-      )
+    evaluateExpression(""" @"2021-09-08" """) should returnResult(
+      LocalDate.parse("2021-09-08")
     )
   }
 
   it should "be null if the date is not valid (leap year)" in {
-    eval(""" date("2023-02-29") """) should be(ValNull)
-    eval(""" @"2023-02-29" """) should be(ValNull)
+    evaluateExpression(""" date("2023-02-29") """) should returnNull()
+    evaluateExpression(""" @"2023-02-29" """) should returnNull()
   }
 
   it should "be null if the date is not valid (month with 31 days)" in {
-    eval(""" date("2023-06-31") """) should be(ValNull)
-    eval(""" @"2023-06-31" """) should be(ValNull)
+    evaluateExpression(""" date("2023-06-31") """) should returnNull()
+    evaluateExpression(""" @"2023-06-31" """) should returnNull()
   }
 
   "A time literal" should "be defined without offset" in {
-    eval(""" time("10:30:00") """) should be(
-      ValLocalTime(
-        LocalTime.parse("10:30:00")
-      )
+    evaluateExpression(""" time("10:30:00") """) should returnResult(
+      LocalTime.parse("10:30:00")
     )
   }
 
   it should "be defined with offset" in {
-    eval(""" time("10:30:00+02:00") """) should be(
-      ValTime(
-        ZonedTime.of(time = LocalTime.parse("10:30:00"), offset = ZoneOffset.ofHours(2))
-      )
+    evaluateExpression(""" time("10:30:00+02:00") """) should returnResult(
+      OffsetTime.parse("10:30:00+02:00")
     )
   }
 
   it should "be defined with timezone" in {
-    eval(""" time("10:30:00@Europe/Berlin") """) should be(
-      ValTime(
-        ZonedTime.of(
-          time = LocalTime.parse("10:30:00"),
-          zoneId = ZoneId.of("Europe/Berlin")
-        )
-      )
+    evaluateExpression(""" time("10:30:00@Europe/Berlin") """) should returnResult(
+      OffsetTime.parse("10:30:00+01:00")
     )
   }
 
   it should "be defined with '@' and no offset" in {
-    eval(""" @"10:30:00" """) should be(
-      ValLocalTime(
-        LocalTime.parse("10:30:00")
-      )
+    evaluateExpression(""" @"10:30:00" """) should returnResult(
+      LocalTime.parse("10:30:00")
     )
   }
 
   it should "be defined with '@' and offset" in {
-    eval(""" @"10:30:00+02:00" """) should be(
-      ValTime(
-        ZonedTime.of(time = LocalTime.parse("10:30:00"), offset = ZoneOffset.ofHours(2))
-      )
+    evaluateExpression(""" @"10:30:00+02:00" """) should returnResult(
+      OffsetTime.parse("10:30:00+02:00")
     )
   }
 
   it should "be defined with '@' and timezone" in {
-    eval(""" @"10:30:00@Europe/Berlin" """) should be(
-      ValTime(
-        ZonedTime.of(
-          time = LocalTime.parse("10:30:00"),
-          zoneId = ZoneId.of("Europe/Berlin")
-        )
-      )
+    evaluateExpression(""" @"10:30:00@Europe/Berlin" """) should returnResult(
+      OffsetTime.parse("10:30:00+01:00")
     )
   }
 
   "A date-time literal" should "be defined without offset" in {
-    eval(""" date and time("2021-09-08T10:30:00") """) should be(
-      ValLocalDateTime(
-        LocalDateTime.parse("2021-09-08T10:30:00")
-      )
+    evaluateExpression(""" date and time("2021-09-08T10:30:00") """) should returnResult(
+      LocalDateTime.parse("2021-09-08T10:30:00")
     )
   }
 
   it should "be defined with offset" in {
-    eval(""" date and time("2021-09-08T10:30:00+02:00") """) should be(
-      ValDateTime(
-        ZonedDateTime.of(LocalDateTime.parse("2021-09-08T10:30:00"), ZoneOffset.ofHours(2))
-      )
+    evaluateExpression(""" date and time("2021-09-08T10:30:00+02:00") """) should returnResult(
+      ZonedDateTime.of(LocalDateTime.parse("2021-09-08T10:30:00"), ZoneOffset.ofHours(2))
     )
   }
 
   it should "be defined with timezone" in {
-    eval(""" date and time("2021-09-08T10:30:00@Europe/Berlin") """) should be(
-      ValDateTime(
-        ZonedDateTime.of(
-          LocalDateTime.parse("2021-09-08T10:30:00"),
-          ZoneId.of("Europe/Berlin")
-        )
+    evaluateExpression(
+      """ date and time("2021-09-08T10:30:00@Europe/Berlin") """
+    ) should returnResult(
+      ZonedDateTime.of(
+        LocalDateTime.parse("2021-09-08T10:30:00"),
+        ZoneId.of("Europe/Berlin")
       )
     )
   }
 
   it should "be defined with '@' and no offset" in {
-    eval(""" @"2021-09-08T10:30:00" """) should be(
-      ValLocalDateTime(
-        LocalDateTime.parse("2021-09-08T10:30:00")
-      )
+    evaluateExpression(""" @"2021-09-08T10:30:00" """) should returnResult(
+      LocalDateTime.parse("2021-09-08T10:30:00")
     )
   }
 
   it should "be defined with '@' and offset" in {
-    eval(""" @"2021-09-08T10:30:00+02:00" """) should be(
-      ValDateTime(
-        ZonedDateTime.of(LocalDateTime.parse("2021-09-08T10:30:00"), ZoneOffset.ofHours(2))
-      )
+    evaluateExpression(""" @"2021-09-08T10:30:00+02:00" """) should returnResult(
+      ZonedDateTime.of(LocalDateTime.parse("2021-09-08T10:30:00"), ZoneOffset.ofHours(2))
     )
   }
 
   it should "be defined with '@' and timezone" in {
-    eval(""" @"2021-09-08T10:30:00@Europe/Berlin" """) should be(
-      ValDateTime(
-        ZonedDateTime.of(
-          LocalDateTime.parse("2021-09-08T10:30:00"),
-          ZoneId.of("Europe/Berlin")
-        )
+    evaluateExpression(""" @"2021-09-08T10:30:00@Europe/Berlin" """) should returnResult(
+      ZonedDateTime.of(
+        LocalDateTime.parse("2021-09-08T10:30:00"),
+        ZoneId.of("Europe/Berlin")
       )
     )
   }
 
   it should "be null if the date is not valid (leap year)" in {
-    eval(""" date and time("2023-02-29T10:00:00") """) should be(ValNull)
-    eval(""" @"2023-02-29T10:00:00" """) should be(ValNull)
+    evaluateExpression(""" date and time("2023-02-29T10:00:00") """) should returnNull()
+    evaluateExpression(""" @"2023-02-29T10:00:00" """) should returnNull()
 
-    eval(""" date and time("2023-02-29T10:00:00+02:00") """) should be(ValNull)
-    eval(""" @"2023-02-29T10:00:00+02:00" """) should be(ValNull)
+    evaluateExpression(""" date and time("2023-02-29T10:00:00+02:00") """) should returnNull()
+    evaluateExpression(""" @"2023-02-29T10:00:00+02:00" """) should returnNull()
   }
 
   it should "be null if the date is not valid (month with 31 days)" in {
-    eval(""" date and time("2023-06-31T10:00:00") """) should be(ValNull)
-    eval(""" @"2023-06-31T10:00:00" """) should be(ValNull)
+    evaluateExpression(""" date and time("2023-06-31T10:00:00") """) should returnNull()
+    evaluateExpression(""" @"2023-06-31T10:00:00" """) should returnNull()
 
-    eval(""" date and time("2023-06-31T10:00:00+02:00") """) should be(ValNull)
-    eval(""" @"2023-06-31T10:00:00+02:00" """) should be(ValNull)
+    evaluateExpression(""" date and time("2023-06-31T10:00:00+02:00") """) should returnNull()
+    evaluateExpression(""" @"2023-06-31T10:00:00+02:00" """) should returnNull()
   }
 
   "A years-months duration" should "be defined" in {
-    eval(""" duration("P1Y6M") """) should be(
-      ValYearMonthDuration(
-        Period.ofYears(1).withMonths(6)
-      )
+    evaluateExpression(""" duration("P1Y6M") """) should returnResult(
+      Period.ofYears(1).withMonths(6)
     )
   }
 
   it should "be defined with '@'" in {
-    eval(""" @"P1Y6M" """) should be(
-      ValYearMonthDuration(
-        Period.ofYears(1).withMonths(6)
-      )
+    evaluateExpression(""" @"P1Y6M" """) should returnResult(
+      Period.ofYears(1).withMonths(6)
     )
   }
 
   "A days-time duration" should "be defined" in {
-    eval(""" duration("P1DT12H30M") """) should be(
-      ValDayTimeDuration(
-        Duration.parse("P1DT12H30M")
-      )
+    evaluateExpression(""" duration("P1DT12H30M") """) should returnResult(
+      Duration.parse("P1DT12H30M")
     )
   }
 
   it should "be defined with '@'" in {
-    eval(""" @"P1DT12H30M" """) should be(
-      ValDayTimeDuration(
-        Duration.parse("P1DT12H30M")
-      )
+    evaluateExpression(""" @"P1DT12H30M" """) should returnResult(
+      Duration.parse("P1DT12H30M")
     )
   }
 

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterLiteralExpressionTest.scala
@@ -132,6 +132,16 @@ class InterpreterLiteralExpressionTest extends AnyFlatSpec with Matchers with Fe
     )
   }
 
+  it should "be null if the date is not valid (leap year)" in {
+    eval(""" date("2023-02-29") """) should be(ValNull)
+    eval(""" @"2023-02-29" """) should be(ValNull)
+  }
+
+  it should "be null if the date is not valid (month with 31 days)" in {
+    eval(""" date("2023-06-31") """) should be(ValNull)
+    eval(""" @"2023-06-31" """) should be(ValNull)
+  }
+
   "A time literal" should "be defined without offset" in {
     eval(""" time("10:30:00") """) should be(
       ValLocalTime(
@@ -238,6 +248,22 @@ class InterpreterLiteralExpressionTest extends AnyFlatSpec with Matchers with Fe
         )
       )
     )
+  }
+
+  it should "be null if the date is not valid (leap year)" in {
+    eval(""" date and time("2023-02-29T10:00:00") """) should be(ValNull)
+    eval(""" @"2023-02-29T10:00:00" """) should be(ValNull)
+
+    eval(""" date and time("2023-02-29T10:00:00+02:00") """) should be(ValNull)
+    eval(""" @"2023-02-29T10:00:00+02:00" """) should be(ValNull)
+  }
+
+  it should "be null if the date is not valid (month with 31 days)" in {
+    eval(""" date and time("2023-06-31T10:00:00") """) should be(ValNull)
+    eval(""" @"2023-06-31T10:00:00" """) should be(ValNull)
+
+    eval(""" date and time("2023-06-31T10:00:00+02:00") """) should be(ValNull)
+    eval(""" @"2023-06-31T10:00:00+02:00" """) should be(ValNull)
   }
 
   "A years-months duration" should "be defined" in {


### PR DESCRIPTION
## Description

Adjust the behavior of date and date-time literals and conversion functions to return `null` if the date is invalid. Previously, it returned the last day of the month. 

For example:
- `2023-02-29` is invalid because 2023 is not a leap year
- `2023-06-31` is invalid because June has only 30 days

## Related issues

closes #867 
