### PR TITLE
refactor: FeelEngineBuilder for Java usage

### DIFF
--- a/src/main/scala/org/camunda/feel/api/FeelEngineBuilder.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineBuilder.scala
@@ -60,10 +60,6 @@ case class FeelEngineBuilder private (
   def withEnabledExternalFunctions(enabled: Boolean): FeelEngineBuilder =
     copy(configuration = configuration.copy(externalFunctionsEnabled = enabled))
 
-  /** Java-compatibility method to create a builder instance.
-   */
-  def forJava(): FeelEngineBuilder = FeelEngineBuilder().withCustomValueMapper(new JavaValueMapper)
-
   /** Creates a new engine with the given configuration.
     *
     * @return
@@ -82,5 +78,18 @@ case class FeelEngineBuilder private (
 
 object FeelEngineBuilder {
 
+  /** Creates a new builder for the FEEL engine.
+    *
+    * @return
+    *   a new builder
+    */
   def create(): FeelEngineBuilder = FeelEngineBuilder()
+
+  /** Creates a new preconfigured builder for the FEEL engine. Use it if the engine is called from
+    * Java code.
+    *
+    * @return
+    *   a new builder
+    */
+  def forJava(): FeelEngineBuilder = FeelEngineBuilder().withCustomValueMapper(new JavaValueMapper)
 }

--- a/src/test/java/org/camunda/feel/api/FeelEngineBuilderJava.java
+++ b/src/test/java/org/camunda/feel/api/FeelEngineBuilderJava.java
@@ -17,7 +17,8 @@
 package org.camunda.feel.api;
 
 public class FeelEngineBuilderJava {
-    public FeelEngineApi buildEngine() {
-        return FeelEngineBuilder.create().forJava().build();
-    }
+
+  public FeelEngineApi buildEngine() {
+    return FeelEngineBuilder.forJava().build();
+  }
 }

--- a/src/test/scala/org/camunda/feel/api/FeelEngineBuilderTest.scala
+++ b/src/test/scala/org/camunda/feel/api/FeelEngineBuilderTest.scala
@@ -21,9 +21,18 @@ import org.scalatest.matchers.should.Matchers
 
 class FeelEngineBuilderTest extends AnyFlatSpec with Matchers {
 
-  "A FeelEngineBuilder" should "successfully build a FeelEngineApi instance" in {
+  "The FeelEngineBuilder" should "be usable from Java" in {
     val javaBuilder = new FeelEngineBuilderJava()
-    val engine: FeelEngineApi = javaBuilder.buildEngine()
-    engine should not be null
+
+    javaBuilder.buildEngine() shouldBe a[FeelEngineApi]
+  }
+
+  it should "build a preconfigured Java engine" in {
+    val javaBuilder = new FeelEngineBuilderJava()
+    val engine = javaBuilder.buildEngine()
+
+    val evaluationResult = engine.evaluateExpression("[1,2]")
+
+    evaluationResult.result shouldBe a[java.util.List[Integer]]
   }
 }

--- a/src/test/scala/org/camunda/feel/api/FeelEngineBuilderTest.scala
+++ b/src/test/scala/org/camunda/feel/api/FeelEngineBuilderTest.scala
@@ -27,7 +27,7 @@ class FeelEngineBuilderTest extends AnyFlatSpec with Matchers {
     javaBuilder.buildEngine() shouldBe a[FeelEngineApi]
   }
 
-  it should "build a preconfigured Java engine" in {
+  it should "build a preconfigured Java engine and evaluate expression" in {
     val javaBuilder = new FeelEngineBuilderJava()
     val engine = javaBuilder.buildEngine()
 


### PR DESCRIPTION
## Description

Follow-up of #832.

- Move the Java builder method to the root 
- Add JavaDoc
- Extend the test cases for the Java builder

## Related issues

related to #724 
