### PR TITLE
fix: number() to return null if the given string is invalid

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -170,16 +170,25 @@ class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
     builtinFunction(
       params = List("from"),
       invoke = { case List(ValString(from)) =>
-        ValNumber(from)
+        parseNumber(from)
       }
     )
+
+  private def parseNumber(from: String): Val = {
+    Try(
+      ValNumber(from)
+    ).getOrElse(
+      ValError(s"Can't parse '$from' as a number")
+    )
+  }
 
   private def numberFunction2 = builtinFunction(
     params = List("from", "grouping separator"),
     invoke = {
       case List(ValString(from), ValString(grouping)) if (isValidGroupingSeparator(grouping)) =>
-        ValNumber(from.replace(grouping, ""))
-      case List(ValString(from), ValString(grouping))                                         =>
+        parseNumber(from.replace(grouping, ""))
+
+      case List(ValString(_), ValString(_)) =>
         ValError(s"illegal argument for grouping. Must be one of ' ', ',' or '.'")
     }
   )
@@ -191,13 +200,16 @@ class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
           if (isValidGroupingSeparator(grouping) && isValidDecimalSeparator(
             decimal
           ) && grouping != decimal) =>
-        ValNumber(from.replace(grouping, "").replace(decimal, "."))
+        parseNumber(from.replace(grouping, "").replace(decimal, "."))
+
       case List(ValString(from), ValNull, ValString(decimal)) if isValidDecimalSeparator(decimal) =>
-        ValNumber(from.replace(decimal, "."))
+        parseNumber(from.replace(decimal, "."))
+
       case List(ValString(from), ValString(grouping), ValNull)
           if isValidGroupingSeparator(grouping) =>
-        ValNumber(from.replace(grouping, ""))
-      case List(ValString(from), ValString(grouping), ValString(decimal))                         =>
+        parseNumber(from.replace(grouping, ""))
+
+      case List(ValString(_), ValString(_), ValString(_)) =>
         ValError(
           s"illegal arguments for grouping or decimal. Must be one of ' ' (grouping only), ',' or '.'"
         )

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -16,6 +16,7 @@
  */
 package org.camunda.feel.impl.builtin
 
+import org.camunda.feel.api.EvaluationFailureType.FUNCTION_INVOCATION_FAILURE
 import org.camunda.feel.api.FeelEngineBuilder
 import org.camunda.feel.impl.interpreter.MyCustomContext
 import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
@@ -215,6 +216,30 @@ class BuiltinConversionFunctionsTest
       """ number(from: "1.500", grouping separator: ".", decimal separator: null) """
     ) should returnResult(
       1500
+    )
+  }
+
+  it should "return null if the string is not a number" in {
+
+    evaluateExpression(""" number("x") """) should (
+      returnNull() and reportFailure(
+        FUNCTION_INVOCATION_FAILURE,
+        "Failed to invoke function 'number': Can't parse 'x' as a number"
+      )
+    )
+
+    evaluateExpression(""" number("x", ".") """) should (
+      returnNull() and reportFailure(
+        FUNCTION_INVOCATION_FAILURE,
+        "Failed to invoke function 'number': Can't parse 'x' as a number"
+      )
+    )
+
+    evaluateExpression(""" number("x", ".", ",") """) should (
+      returnNull() and reportFailure(
+        FUNCTION_INVOCATION_FAILURE,
+        "Failed to invoke function 'number': Can't parse 'x' as a number"
+      )
     )
   }
 


### PR DESCRIPTION
## Description

Fix the `number()` function to return `null` if the given string is invalid. Before the evaluation failed with an exception. 

## Related issues

closes #731 
