### PR TITLE
fix: Function `context put()` works for more than two keys

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -150,10 +150,12 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
           parentContextUpdater =
             // pass a lambda to update this context with the modified nested context
             nestedContext =>
-              contextPut(
-                contextValue = contextValue,
-                key = key,
-                value = nestedContext
+              parentContextUpdater(
+                contextPut(
+                  contextValue = contextValue,
+                  key = key,
+                  value = nestedContext
+                )
               )
         )
     }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -202,17 +202,49 @@ class BuiltinContextFunctionsTest
     evaluateExpression(""" context put({x:1, y:{a:1}}, ["y", "b"], 2) """) should returnResult(
       Map("x" -> 1, "y" -> Map("a" -> 1, "b" -> 2))
     )
+
+    evaluateExpression(
+      """ context put({x:1, a:{b:{c:1}}}, ["a", "b", "d"], 2) """
+    ) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> 1, "d" -> 2)))
+    )
+
+    evaluateExpression(
+      """ context put({x:1, a:{b:{c:{d:1}}}}, ["a", "b", "c", "e"], 2) """
+    ) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> Map("d" -> 1, "e" -> 2))))
+    )
   }
 
   it should "override nested context entry" in {
     evaluateExpression(""" context put({x:1, y:{a:1}}, ["y", "a"], 2) """) should returnResult(
       Map("x" -> 1, "y" -> Map("a" -> 2))
     )
+
+    evaluateExpression(
+      """ context put({x:1, a:{b:{c:1}}}, ["a", "b", "c"], 2) """
+    ) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> 2)))
+    )
+
+    evaluateExpression(
+      """ context put({x:1, a:{b:{c:{d:1}}}}, ["a", "b", "c", "d"], 2) """
+    ) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> Map("d" -> 2))))
+    )
   }
 
   it should "add nested context entry if key doesn't exist" in {
     evaluateExpression(""" context put({x:1}, ["y", "z"], 2) """) should returnResult(
       Map("x" -> 1, "y" -> Map("z" -> 2))
+    )
+
+    evaluateExpression(""" context put({x:1}, ["a", "b", "c"], 2) """) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> 2)))
+    )
+
+    evaluateExpression(""" context put({x:1}, ["a", "b", "c", "d"], 2) """) should returnResult(
+      Map("x" -> 1, "a" -> Map("b" -> Map("c" -> Map("d" -> 2))))
     )
   }
 


### PR DESCRIPTION
## Description

Fix the function `context put()` if more than two keys are passed as arguments.

We had an issue in the recursion and forgot to pass the context updater function with us. As a result, this worked only for one or two keys. :loop: 

## Related issues

closes #835
