### PR TITLE
[Backport 1.17] fix: Variable name starting with "in"

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -157,12 +157,17 @@ object FeelParser {
   // an identifier which is not a reserved word. but, it can contain a reserved word.
   private def identifier[_: P]: P[String] =
     P(
-      reservedWord.? ~~ javaLikeIdentifier
+      (reservedWord ~~ namePart) | (reservedWord.? ~~ nameStart ~~ namePart.?)
     ).!
 
-  private def javaLikeIdentifier[_: P]: P[String] =
+  private def nameStart[_: P]: P[String] =
     P(
-      CharPred(Character.isJavaIdentifierStart) ~~ CharsWhile(Character.isJavaIdentifierPart, 0)
+      CharPred(Character.isJavaIdentifierStart)
+    ).!
+
+  private def namePart[_: P]: P[String] =
+    P(
+      CharsWhile(Character.isJavaIdentifierPart, 1)
     ).!
 
   // an identifier wrapped in backticks. it can contain any char (e.g. `a b`, `a+b`).

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterExpressionTest.scala
@@ -317,7 +317,9 @@ class InterpreterExpressionTest
     "inside",
     "durationX",
     "dateX",
-    "timeX"
+    "timeX",
+    "inX",
+    "in1"
   ).foreach { variableName =>
     it should s"contain a key-word ($variableName)" in {
 


### PR DESCRIPTION
# Description
Backport of #909 to `1.17`.

relates to #873
original author: @saig0