### PR TITLE
refactor: extend `is empty()` to check if a string is empty

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -513,8 +513,9 @@ class ListBuiltinFunctions(private val valueMapper: ValueMapper) {
   private def emptyFunction =
     builtinFunction(
       params = List("list"),
-      invoke = { case List(ValList(list)) =>
-        ValBoolean(list.isEmpty)
+      invoke = {
+        case List(ValString(list)) => ValBoolean(list.isEmpty)
+        case List(ValList(list)) => ValBoolean(list.isEmpty)
       }
     )
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinListFunctionsTest.scala
@@ -563,11 +563,31 @@ class BuiltinListFunctionsTest
     evaluateExpression(""" string join(["foo", 123, "bar"]) """) should returnNull()
   }
 
-  "A list is empty() function" should "return if the list is empty" in {
+  "A list or string is empty() function" should "return Boolean" in {
 
     evaluateExpression(" is empty([]) ") should returnResult(true)
     evaluateExpression(" is empty([1]) ") should returnResult(false)
     evaluateExpression(" is empty([1,2,3]) ") should returnResult(false)
     evaluateExpression(" is empty(list: [1]) ") should returnResult(false)
+
+    evaluateExpression(
+      expression = """ is empty("") """
+    ) should returnResult(true)
+
+    evaluateExpression(
+      expression = """ is empty(" ") """
+    ) should returnResult(false)
+
+    evaluateExpression(
+      expression = """ is empty("hello world") """
+    ) should returnResult(false)
+
+    evaluateExpression(
+      expression = """ is empty(" hello world ") """
+    ) should returnResult(false)
+
+    evaluateExpression(
+      expression = """ is empty("\t\n\r\f") """
+    ) should returnResult(false)
   }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Refactor: extend `is empty()` to check if a string is empty

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #
