### PR TITLE
correct link to developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Please have a look at the [documentation](https://docs.camunda.io/docs/next/comp
 
 Want to try it out? Use the [Playground](https://camunda.github.io/feel-scala/docs/playground/) to evaluate FEEL expressions. 
 
-## Install
+## Install and Extend
 
-Please have a look at the [developer documentation](https://camunda.github.io/feel-scala/docs/reference/developer-guide/developer-guide-introduction). It describes how to integrate the engine into your application, and how to extend/customize it.
+Please have a look at the [developer documentation](https://camunda.github.io/feel-scala/docs/developer-guide). It describes how to integrate the engine into your application, and how to extend/customize it.
 
 ## Contribution
 


### PR DESCRIPTION
I got a 404 when clicking on the link before.

## Description

<!-- Please explain the changes you made here. -->

* Correct the link to the developer docs. It's the only doc about extending the FEEL engine.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #
