### PR TITLE
[Backport 1.16] fix: Handle escape and regex characters

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
+++ b/src/main/scala/org/camunda/feel/impl/parser/FeelParser.scala
@@ -688,22 +688,16 @@ object FeelParser {
     }.getOrElse(ConstNull)
   }
 
-  // replace escaped character with the provided replacement
   private def translateEscapes(input: String): String = {
-    val escapeMap = Map(
-      "\\b"  -> "\b",
-      "\\t"  -> "\t",
-      "\\n"  -> "\n",
-      "\\f"  -> "\f",
-      "\\r"  -> "\r",
-      "\\\"" -> "\"",
-      "\\'"  -> "'",
-      "\\s"  -> " "
-      // Add more escape sequences as needed
-    )
-
-    escapeMap.foldLeft(input) { case (result, (escape, replacement)) =>
-      result.replace(escape, replacement)
-    }
+    // replace all escape sequences
+    input
+      .replaceAll("(?<!\\\\)\\\\n", "\n")  // new line
+      .replaceAll("(?<!\\\\)\\\\r", "\r")  // carriage return
+      .replaceAll("(?<!\\\\)\\\\t", "\t")  // tab
+      .replaceAll("(?<!\\\\)\\\\b", "\b")  // backspace
+      .replaceAll("(?<!\\\\)\\\\f", "\f")  // form feed
+      .replaceAll("(?<!\\\\)\\\\'", "'")   // single quote
+      .replaceAll("(?<!\\\\)\\\\\"", "\"") // double quote
+      .replaceAll("\\\\\\\\", "\\\\")      // backslash (for regex characters)
   }
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -115,4 +115,26 @@ class InterpreterStringExpressionTest
     }
   }
 
+  private val regexCharacters = Table(
+    ("Character", "Display name"),
+    ("\\s", "\\s"),
+    ("\\S", "\\S"),
+    ("\\d", "\\d"),
+    ("\\w", "\\w"),
+    ("\\R", "\\R"),
+    ("\\h", "\\h"),
+    ("\\v", "\\v"),
+    ("\\\n", "\\n"),
+    ("\\\r", "\\r")
+  )
+
+  it should "contains a regex character" in {
+    forEvery(regexCharacters) { (character, _) =>
+      val expectedString = s"a $character b"
+
+      evaluateExpression(s" \"a $character b\" ") should returnResult(expectedString)
+      evaluateExpression("char", Map("char" -> expectedString)) should returnResult(expectedString)
+    }
+  }
+
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -16,80 +16,86 @@
  */
 package org.camunda.feel.impl.interpreter
 
-import org.camunda.feel.impl.FeelIntegrationTest
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest, FeelIntegrationTest}
 import org.camunda.feel.syntaxtree._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
 
+import scala.collection.immutable.Map
+
 /** @author
   *   Philipp Ossler
   */
-class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with FeelIntegrationTest {
+class InterpreterStringExpressionTest
+    extends AnyFlatSpec
+    with Matchers
+    with FeelEngineTest
+    with EvaluationResultMatchers {
 
   "A string" should "concatenates to another String" in {
 
-    eval(""" "a" + "b" """) should be(ValString("ab"))
+    evaluateExpression(""" "a" + "b" """) should returnResult("ab")
   }
 
   it should "compare with '='" in {
 
-    eval(""" "a" = "a" """) should be(ValBoolean(true))
-    eval(""" "a" = "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" = "a" """) should returnResult(true)
+    evaluateExpression(""" "a" = "b" """) should returnResult(false)
   }
 
   it should "compare with '!='" in {
 
-    eval(""" "a" != "a" """) should be(ValBoolean(false))
-    eval(""" "a" != "b" """) should be(ValBoolean(true))
+    evaluateExpression(""" "a" != "a" """) should returnResult(false)
+    evaluateExpression(""" "a" != "b" """) should returnResult(true)
   }
 
   it should "compare with '<'" in {
 
-    eval(""" "a" < "b" """) should be(ValBoolean(true))
-    eval(""" "b" < "a" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" < "b" """) should returnResult(true)
+    evaluateExpression(""" "b" < "a" """) should returnResult(false)
   }
 
   it should "compare with '<='" in {
 
-    eval(""" "a" <= "a" """) should be(ValBoolean(true))
-    eval(""" "b" <= "a" """) should be(ValBoolean(false))
+    evaluateExpression(""" "a" <= "a" """) should returnResult(true)
+    evaluateExpression(""" "b" <= "a" """) should returnResult(false)
   }
 
   it should "compare with '>'" in {
 
-    eval(""" "b" > "a" """) should be(ValBoolean(true))
-    eval(""" "a" > "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "b" > "a" """) should returnResult(true)
+    evaluateExpression(""" "a" > "b" """) should returnResult(false)
   }
 
   it should "compare with '>='" in {
 
-    eval(""" "b" >= "b" """) should be(ValBoolean(true))
-    eval(""" "a" >= "b" """) should be(ValBoolean(false))
+    evaluateExpression(""" "b" >= "b" """) should returnResult(true)
+    evaluateExpression(""" "a" >= "b" """) should returnResult(false)
   }
 
   it should "compare with null" in {
 
-    eval(""" "a" = null """) should be(ValBoolean(false))
-    eval(""" null = "a" """) should be(ValBoolean(false))
-    eval(""" "a" != null """) should be(ValBoolean(true))
+    evaluateExpression(""" "a" = null """) should returnResult(false)
+    evaluateExpression(""" null = "a" """) should returnResult(false)
+    evaluateExpression(""" "a" != null """) should returnResult(true)
   }
 
   it should "return not escaped characters" in {
 
-    eval(""" "Hello\nWorld" """) should be(ValString("Hello\nWorld"))
-    eval(" x ", Map("x" -> "Hello\nWorld")) should be(ValString("Hello\nWorld"))
+    evaluateExpression(""" "Hello\nWorld" """) should returnResult("Hello\nWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\nWorld")) should returnResult("Hello\nWorld")
 
-    eval(""" "Hello\rWorld" """) should be(ValString("Hello\rWorld"))
-    eval(" x ", Map("x" -> "Hello\rWorld")) should be(ValString("Hello\rWorld"))
+    evaluateExpression(""" "Hello\rWorld" """) should returnResult("Hello\rWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\rWorld")) should returnResult("Hello\rWorld")
 
-    eval(""" "Hello\'World" """) should be(ValString("Hello\'World"))
-    eval(" x ", Map("x" -> "Hello\'World")) should be(ValString("Hello\'World"))
+    evaluateExpression(""" "Hello\'World" """) should returnResult("Hello\'World")
+    evaluateExpression(" x ", Map("x" -> "Hello\'World")) should returnResult("Hello\'World")
 
-    eval(""" "Hello\tWorld" """) should be(ValString("Hello\tWorld"))
-    eval(" x ", Map("x" -> "Hello\tWorld")) should be(ValString("Hello\tWorld"))
+    evaluateExpression(""" "Hello\tWorld" """) should returnResult("Hello\tWorld")
+    evaluateExpression(" x ", Map("x" -> "Hello\tWorld")) should returnResult("Hello\tWorld")
 
-    eval(""" "Hello\"World" """) should be(ValString("Hello\"World"))
-    eval(" x ", Map("x" -> "Hello\"World")) should be(ValString("Hello\"World"))
+    evaluateExpression(""" "Hello\"World" """) should returnResult("Hello\"World")
+    evaluateExpression(" x ", Map("x" -> "Hello\"World")) should returnResult("Hello\"World")
   }
 
   List(
@@ -104,10 +110,8 @@ class InterpreterStringExpressionTest extends AnyFlatSpec with Matchers with Fee
     .foreach { notEscapeChar =>
       it should s"contains a not escape sequence ($notEscapeChar)" in {
 
-        eval(s""" "a $notEscapeChar b" """) should be(
-          ValString(
-            s"""a $notEscapeChar b"""
-          )
+        evaluateExpression(s""" "a $notEscapeChar b" """) should returnResult(
+          s"""a $notEscapeChar b"""
         )
       }
     }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterStringExpressionTest.scala
@@ -82,38 +82,24 @@ class InterpreterStringExpressionTest
     evaluateExpression(""" "a" != null """) should returnResult(true)
   }
 
-  it should "return not escaped characters" in {
-
-    evaluateExpression(""" "Hello\nWorld" """) should returnResult("Hello\nWorld")
-    evaluateExpression(" x ", Map("x" -> "Hello\nWorld")) should returnResult("Hello\nWorld")
-
-    evaluateExpression(""" "Hello\rWorld" """) should returnResult("Hello\rWorld")
-    evaluateExpression(" x ", Map("x" -> "Hello\rWorld")) should returnResult("Hello\rWorld")
-
-    evaluateExpression(""" "Hello\'World" """) should returnResult("Hello\'World")
-    evaluateExpression(" x ", Map("x" -> "Hello\'World")) should returnResult("Hello\'World")
-
-    evaluateExpression(""" "Hello\tWorld" """) should returnResult("Hello\tWorld")
-    evaluateExpression(" x ", Map("x" -> "Hello\tWorld")) should returnResult("Hello\tWorld")
-
-    evaluateExpression(""" "Hello\"World" """) should returnResult("Hello\"World")
-    evaluateExpression(" x ", Map("x" -> "Hello\"World")) should returnResult("Hello\"World")
-  }
-
   private val escapeSequences = Table(
-    ("Character", "Display name"),
-    ('\n', "\\n"),
-    ('\r', "\\r"),
-    ('\t', "\\t"),
-    ('\b', "\\b"),
-    ('\f', "\\f"),
-    ('\'', "\'"),
-    ('\\', "\\")
+    ("Character", "Expected", "Display name"),
+    ('\n', '\n', "new line"),
+    ('\r', '\r', "carriage return"),
+    ('\t', '\t', "tab"),
+    ('\b', '\b', "backspace"),
+    ('\f', '\f', "form feed"),
+    ('\'', '\'', "single quote"),
+    ("\\\"", '"', "double quote"),
+    ("\\\\", '\\', "backslash")
   )
 
   it should "contains an escape sequence" in {
-    forEvery(escapeSequences) { (character, _) =>
-      evaluateExpression(s" \"a $character b\" ") should returnResult(s"a $character b")
+    forEvery(escapeSequences) { (character, expected, _) =>
+      val expectedString = s"a $expected b"
+
+      evaluateExpression(s" \"a $character b\" ") should returnResult(expectedString)
+      evaluateExpression("char", Map("char" -> expectedString)) should returnResult(expectedString)
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #930 to `1.16`.

relates to #883 #879