### PR TITLE
fix: A unary-test expression with ? returns true/false

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/BuiltinFunction.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/BuiltinFunction.scala
@@ -16,7 +16,7 @@
  */
 package org.camunda.feel.impl.builtin
 
-import org.camunda.feel.syntaxtree.{Val, ValError, ValFatalError, ValFunction}
+import org.camunda.feel.syntaxtree.{Val, ValError, ValFunction}
 
 object BuiltinFunction {
 
@@ -27,20 +27,14 @@ object BuiltinFunction {
   ): ValFunction = {
     ValFunction(
       params = params,
-      invoke = validateArgs.orElse(invoke).orElse(error),
+      invoke = invoke.orElse(error),
       hasVarArgs = hasVarArgs
     )
   }
 
-  private def validateArgs: PartialFunction[List[Val], Any] = {
-    case args if args.exists(_.isInstanceOf[ValFatalError]) => args.find(_.isInstanceOf[ValFatalError]).get
-    case args if args.exists(_.isInstanceOf[ValError]) => args.find(_.isInstanceOf[ValError]).get
-  }
-
-  private def error: PartialFunction[List[Val], Any] = {
-    case args =>
-      val argumentList = args.map("'" + _ + "'").mkString(", ")
-      ValError(s"Illegal arguments: $argumentList")
+  private def error: PartialFunction[List[Val], Any] = { case args =>
+    val argumentList = args.map("'" + _ + "'").mkString(", ")
+    ValError(s"Illegal arguments: $argumentList")
   }
 
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterUnaryTest.scala
@@ -529,7 +529,7 @@ class InterpreterUnaryTest
     evaluateUnaryTests("null", inputValue = null) should returnResult(true)
   }
 
-  "A function" should "be invoked with ? (input value)" in {
+  "A function" should "be invoked with the special variable '?'" in {
 
     evaluateUnaryTests(""" starts with(?, "f") """, "foo") should returnResult(true)
     evaluateUnaryTests(""" starts with(?, "b") """, "foo") should returnResult(false)
@@ -539,6 +539,12 @@ class InterpreterUnaryTest
 
     evaluateUnaryTests("< max(1,2,3)", 2) should returnResult(true)
     evaluateUnaryTests("< min(1,2,3)", 2) should returnResult(false)
+  }
+
+  it should "be invoked with the special variable '?' for a parameter with ANY type" in {
+
+    evaluateUnaryTests("list contains([481, 485, 551, 483], ?)", 481) should returnResult(true)
+    evaluateUnaryTests("list contains([481, 485, 551, 483], ?)", 999) should returnResult(false)
   }
 
   "A unary-tests expression" should "return true if it evaluates to a value that is equal to the implicit value" in {


### PR DESCRIPTION
## Description

The engine restricts the usage of `?` to an unary-test expression. It is implemented by returning a `ValFatalError` when accessing `?`. If the expression is a unary-test, it evaluates the expression again and assigns the input value to `?`.  

Previously, the engine invoked a function without checking the arguments before. As a result, a function with an `Any` parameter (e.g. `list contains(list, any)`) accepted a `ValError`/`ValFatalError` as a regular value and didn't forward the error. 

Fix the issue by adding the validation of the arguments before invoking the function. 

## Related issues

closes https://github.com/camunda/camunda/issues/26054
