### PR TITLE
refactor: lower log level to debug

### DIFF
--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -125,7 +125,7 @@ class FeelEngine(
     externalFunctionsEnabled = configuration.externalFunctionsEnabled
   )
 
-  logger.info(
+  logger.debug(
     s"Engine created. [" +
       s"value-mapper: $valueMapper, " +
       s"function-provider: $functionProvider, " +


### PR DESCRIPTION
## Description

This PR lowers the log level of the initial engine creation log statement. The reasoning here is that almost all of the information provided here is only really useful for debugging, and generally not useful for the common user.

As this is mostly to reduce the noise-to-signal ratio in Zeebe, the alternative would be only showing WARN messages from this library (as we do with other libraries). That would also be acceptable to me, so feel free to reject this if you disagree, and we can go with the alternative :)

## Related issues

closes camunda/camunda#26395
