### PR TITLE
[Backport 1.18] fix: Return normalized years-months-duration 

### DIFF
--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -219,8 +219,8 @@ case class ValYearMonthDuration(value: YearMonthDuration) extends Val {
 object ValYearMonthDuration {
 
   def format(value: YearMonthDuration): String = {
-    val year  = value.getYears
-    val month = value.getMonths % 12
+    val year  = value.toTotalMonths / 12
+    val month = value.toTotalMonths % 12
 
     if (year == 0 && month == 0)
       "P0Y"

--- a/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
+++ b/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
@@ -121,6 +121,14 @@ class StringRepresentationTypeTest extends AnyFlatSpec with Matchers {
     duration.toString should be("P2M")
   }
 
+  it should "return normalized format " in {
+    ValYearMonthDuration(Period.parse("P2Y")).toString should be("P2Y")
+    ValYearMonthDuration(Period.parse("P24M")).toString should be("P2Y")
+
+    ValYearMonthDuration(Period.parse("P25M")).toString should be("P2Y1M")
+    ValYearMonthDuration(Period.parse("P35M")).toString should be("P2Y11M")
+  }
+
   "A days-time-duration" should "return 'P1DT2H3M4S' " in {
     val duration = ValDayTimeDuration(Duration.parse("P1DT2H3M4S"))
 
@@ -149,6 +157,17 @@ class StringRepresentationTypeTest extends AnyFlatSpec with Matchers {
     val duration = ValDayTimeDuration(Duration.parse("PT4S"))
 
     duration.toString should be("PT4S")
+  }
+
+  it should "return normalized format " in {
+    ValDayTimeDuration(Duration.parse("P5D")).toString should be("P5D")
+    ValDayTimeDuration(Duration.parse("PT120H")).toString should be("P5D")
+    ValDayTimeDuration(Duration.parse("PT7200M")).toString should be("P5D")
+    ValDayTimeDuration(Duration.parse("PT432000S")).toString should be("P5D")
+
+    ValDayTimeDuration(Duration.parse("PT121H")).toString should be("P5DT1H")
+    ValDayTimeDuration(Duration.parse("PT7201M")).toString should be("P5DT1M")
+    ValDayTimeDuration(Duration.parse("PT7261M")).toString should be("P5DT1H1M")
   }
 
   "A list" should "return '[1, 2]' " in {

--- a/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
+++ b/src/test/scala/org/camunda/feel/api/StringRepresentationTypeTest.scala
@@ -127,6 +127,8 @@ class StringRepresentationTypeTest extends AnyFlatSpec with Matchers {
 
     ValYearMonthDuration(Period.parse("P25M")).toString should be("P2Y1M")
     ValYearMonthDuration(Period.parse("P35M")).toString should be("P2Y11M")
+
+    ValYearMonthDuration(Period.parse("P2Y13M")).toString should be("P3Y1M")
   }
 
   "A days-time-duration" should "return 'P1DT2H3M4S' " in {


### PR DESCRIPTION
# Description
Backport of #971 to `1.18`.

relates to #953
original author: @saig0