### PR TITLE
eppdot-fix-lazy-value-mapper

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -136,6 +136,7 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
       case key :: tail =>
         val contextOfKey = contextValue.context.variableProvider
           .getVariable(key)
+          .map(valueMapper.toVal)
           .map {
             case contextOfKey: ValContext => contextOfKey
             case _                        => ValContext(EmptyContext)

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -236,30 +236,17 @@ class BuiltinContextFunctionsTest
     )
   }
 
-  it should "handle a lazy value mapper" in {
-    val lazyEngine = FeelEngineBuilder()
-      .withCustomValueMapper(new CustomValueMapper {
-        override def toVal(x: Any, innerValueMapper: Any => Val): Option[Val] = x match {
-          case x: Map[String, Any] =>
-            Some {
-              ValContext(
-                Context.StaticContext(
-                  variables = x, // don't eagerly map inner values
-                )
-              )
-            }
-          case  _ => None // fallback to default
-        }
-
-        override def unpackVal(value: Val, innerValueMapper: Val => Any): Option[Any] = {
-          None // fallback to default
-        }
-      })
-      .build()
-
-    lazyEngine.evaluateExpression(
-      """ context put(vars, ["a", "c"], 3) """,
-      Map("vars" -> Map("a" -> Map("b" -> 1, "c" -> 2)))
+  it should "override nested context entry from a custom context" in {
+    evaluateExpression(
+      expression = """ context put(vars, ["a", "c"], 3) """,
+      variables = Map(
+        "vars" ->
+          ValContext(
+            new MyCustomContext(
+              Map("a" -> Map("b" -> 1, "c" -> 2))
+            )
+        )
+      )
     ) should returnResult(
       Map("a" -> Map("b" -> 1, "c" -> 3))
     )


### PR DESCRIPTION
## Description

Previously, the builtin context#put function was expecting to
receive a fully mapped context (including all nested variables).
But this can not always be guaranteed as some VariableProviders
can only resolve variables lazily, because of performance/memory
concerns.

For example, in camunda engine we don't want to decode all possible
variables of a process/element-scope at once as most of them might
not be needed by the expression at all.

## Related issues

Closes https://github.com/camunda/camunda/issues/29752
