### PR TITLE
[Backport 1.19] eppdot-fix-lazy-value-mapper

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ContextBuiltinFunctions.scala
@@ -136,6 +136,7 @@ class ContextBuiltinFunctions(valueMapper: ValueMapper) {
       case key :: tail =>
         val contextOfKey = contextValue.context.variableProvider
           .getVariable(key)
+          .map(valueMapper.toVal)
           .map {
             case contextOfKey: ValContext => contextOfKey
             case _                        => ValContext(EmptyContext)

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinContextFunctionsTest.scala
@@ -236,30 +236,17 @@ class BuiltinContextFunctionsTest
     )
   }
 
-  it should "handle a lazy value mapper" in {
-    val lazyEngine = FeelEngineBuilder()
-      .withCustomValueMapper(new CustomValueMapper {
-        override def toVal(x: Any, innerValueMapper: Any => Val): Option[Val] = x match {
-          case x: Map[String, Any] =>
-            Some {
-              ValContext(
-                Context.StaticContext(
-                  variables = x, // don't eagerly map inner values
-                )
-              )
-            }
-          case  _ => None // fallback to default
-        }
-
-        override def unpackVal(value: Val, innerValueMapper: Val => Any): Option[Any] = {
-          None // fallback to default
-        }
-      })
-      .build()
-
-    lazyEngine.evaluateExpression(
-      """ context put(vars, ["a", "c"], 3) """,
-      Map("vars" -> Map("a" -> Map("b" -> 1, "c" -> 2)))
+  it should "override nested context entry from a custom context" in {
+    evaluateExpression(
+      expression = """ context put(vars, ["a", "c"], 3) """,
+      variables = Map(
+        "vars" ->
+          ValContext(
+            new MyCustomContext(
+              Map("a" -> Map("b" -> 1, "c" -> 2))
+            )
+        )
+      )
     ) should returnResult(
       Map("a" -> Map("b" -> 1, "c" -> 3))
     )


### PR DESCRIPTION
# Description
Backport of #993 to `1.19`.

relates to camunda/camunda#29752
original author: @eppdot