### PR TITLE
chore(fasterxml): add relocation for fasterxml shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,11 @@
                   <shadedPattern>camundajar.impl.sourcecode</shadedPattern>
                 </relocation>
 
+                <relocation>
+                  <pattern>com.fasterxml.uuid</pattern>
+                  <shadedPattern>camundajar.impl.com.fasterxml.uuid</shadedPattern>
+                </relocation>
+
               </relocations>
 
             </configuration>


### PR DESCRIPTION
related to [AP7 #5072](https://github.com/camunda/camunda-bpm-platform/issues/5072#issue-2971765725)

## Description

This is to address the issue reported in https://github.com/camunda/camunda-bpm-platform/issues/5072#issue-2971765725. We have also had a support ticket relating to this issue (to be linked in the AP7 ticket)

The fasterxml dependency was not added to the relocation config for the maven-shade-plugin, leading to conflicts.

Before changes from this PR:

```
jar tvf feel-engine-1.20.0-SNAPSHOT-scala-shaded.jar  

[...]
0 Fri Feb 01 08:00:00 ICT 1980 com/fasterxml/uuid/
1096 Fri Feb 01 08:00:00 ICT 1980 com/fasterxml/uuid/EgressInterfaceFinder$1.class
1246 Fri Feb 01 08:00:00 ICT 1980 com/fasterxml/uuid/EgressInterfaceFinder$2.class
1258 Fri Feb 01 08:00:00 ICT 1980 com/fasterxml/uuid/EgressInterfaceFinder$3.class
[...]
```

After changes from this PR:

```
jar tvf feel-engine-1.20.0-SNAPSHOT-scala-shaded.jar  

[...]
0 Fri Feb 01 08:00:00 ICT 1980 camundajar/impl/com/fasterxml/
0 Fri Feb 01 08:00:00 ICT 1980 camundajar/impl/com/fasterxml/uuid/
1224 Fri Feb 01 08:00:00 ICT 1980 camundajar/impl/com/fasterxml/uuid/EgressInterfaceFinder$1.class
1374 Fri Feb 01 08:00:00 ICT 1980 camundajar/impl/com/fasterxml/uuid/EgressInterfaceFinder$2.class
1386 Fri Feb 01 08:00:00 ICT 1980 camundajar/impl/com/fasterxml/uuid/EgressInterfaceFinder$3.class
[...]
```

## Related issues

- https://github.com/camunda/camunda-bpm-platform/issues/5072#issue-2971765725
