### PR TITLE
chore: switch to Sonatype Central Portal deployment (1.19)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.5.0</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Description

Backport https://github.com/camunda/feel-scala/pull/1012 to 1.18.Backport https://github.com/camunda/feel-scala/pull/1012 to 1.19.