### PR TITLE
feat: add `ksuid()` function to generate KSUID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.25.1</version.log4j>
     <version.uuid>5.1.0</version.uuid>
+    <version.ksuid>1.1.3</version.ksuid>
 
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.gpg>1.6</plugin.version.gpg>
@@ -95,6 +96,12 @@
       <groupId>com.fasterxml.uuid</groupId>
       <artifactId>java-uuid-generator</artifactId>
       <version>${version.uuid}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ksuid</groupId>
+      <artifactId>ksuid</artifactId>
+      <version>${version.ksuid}</version>
     </dependency>
 
     <dependency>

--- a/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
@@ -17,17 +17,20 @@
 package org.camunda.feel.impl.builtin
 
 import com.fasterxml.uuid.Generators
+import com.github.ksuid.KsuidGenerator
 import org.camunda.feel.impl.builtin.BuiltinFunction.builtinFunction
 import org.camunda.feel.syntaxtree.{ValBoolean, ValError, ValList, ValNumber, ValString}
 
 import java.util.Base64
 import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
 import java.util.regex.Pattern
 import scala.util.Try
 
 object StringBuiltinFunctions {
 
   private lazy val generator = Generators.timeBasedEpochRandomGenerator()
+  private lazy val ksuidGenerator = new KsuidGenerator(new SecureRandom())
 
   def functions = Map(
     "substring"        -> List(substringFunction, substringFunction3),
@@ -46,7 +49,8 @@ object StringBuiltinFunctions {
     "trim"             -> List(trimFunction),
     "uuid"             -> List(uuidFunction),
     "to base64"        -> List(toBase64Function),
-    "is blank"         -> List(isBlankFunction)
+    "is blank"         -> List(isBlankFunction),
+    "ksuid"            -> List(ksuidFunction)
   )
 
   private def substringFunction = builtinFunction(
@@ -273,7 +277,7 @@ object StringBuiltinFunctions {
 
   private def uuidFunction =
     builtinFunction(
-      params = List(),
+      params = List.empty,
       invoke = { case List() =>
         ValString(generator.generate.toString)
       }
@@ -295,4 +299,11 @@ object StringBuiltinFunctions {
     }
   )
 
+  private def ksuidFunction =
+    builtinFunction(
+      params = List.empty,
+      invoke = { case List() =>
+        ValString(ksuidGenerator.newKsuid().toString)
+      }
+    )
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -223,4 +223,14 @@ class BuiltinStringFunctionsTest
       expression = """ is blank(" hello world ") """
     ) should returnResult(false)
   }
+
+  "A ksuid() function" should "return a string" in {
+
+    evaluateExpression(" ksuid() ").result shouldBe a[String]
+  }
+
+  it should "return a string of length 27" in {
+
+    evaluateExpression(" string length(ksuid()) ") should returnResult(27)
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This function implements the 'ksuid' function which generates a K-Sortable Unique IDentifier. KSUID is a 20-byte identifier: 4 bytes of timestamp + 16 random bytes, encoded as base62.

https://github.com/segmentio/ksuid
https://github.com/ksuid/ksuid 

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #1029.
