### PR TITLE
Add `from json(string): Any` conversion function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <scala.binary.version>2.13.6</scala.binary.version>
     <version.log4j>2.25.1</version.log4j>
     <version.uuid>5.1.0</version.uuid>
+    <version.jackson>2.19.2</version.jackson>
 
     <plugin.version.shade>3.6.0</plugin.version.shade>
     <plugin.version.gpg>1.6</plugin.version.gpg>
@@ -70,6 +71,12 @@
         <version>${version.log4j}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_3</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -95,6 +102,11 @@
       <groupId>com.fasterxml.uuid</groupId>
       <artifactId>java-uuid-generator</artifactId>
       <version>${version.uuid}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_3</artifactId>
     </dependency>
 
     <dependency>
@@ -177,6 +189,9 @@
               <goal>add-source</goal>
               <goal>compile</goal>
             </goals>
+            <configuration>
+              <addScalacArgs>-Ytasty-reader</addScalacArgs>
+            </configuration>
           </execution>
           <execution>
             <id>scala-test-compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-scala_3</artifactId>
+        <artifactId>jackson-module-scala_2.13</artifactId>
         <version>${version.jackson}</version>
       </dependency>
 
@@ -106,7 +106,7 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-scala_3</artifactId>
+      <artifactId>jackson-module-scala_2.13</artifactId>
     </dependency>
 
     <dependency>
@@ -189,9 +189,6 @@
               <goal>add-source</goal>
               <goal>compile</goal>
             </goals>
-            <configuration>
-              <addScalacArgs>-Ytasty-reader</addScalacArgs>
-            </configuration>
           </execution>
           <execution>
             <id>scala-test-compile</id>

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -314,9 +314,6 @@ class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
       case List(ValNull)         => ValNull
       case List(json: ValString) =>
         Try(Mapper.readValue(json.value, classOf[Any]))
-          .map { value: Any =>
-            valueMapper.toVal(value)
-          }
           .getOrElse {
             ValError(s"Failed to parse JSON from '${json.value}'")
           }

--- a/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ConversionBuiltinFunctions.scala
@@ -44,7 +44,7 @@ import java.time._
 import scala.util.Try
 
 class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
-  val Mapper = JsonMapper
+  private val jsonMapper = JsonMapper
     .builder()
     .addModule(DefaultScalaModule)
     .build()
@@ -313,7 +313,7 @@ class ConversionBuiltinFunctions(valueMapper: ValueMapper) {
     invoke = {
       case List(ValNull)         => ValNull
       case List(json: ValString) =>
-        Try(Mapper.readValue(json.value, classOf[Any]))
+        Try(jsonMapper.readValue(json.value, classOf[Any]))
           .getOrElse {
             ValError(s"Failed to parse JSON from '${json.value}'")
           }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -528,4 +528,54 @@ class BuiltinConversionFunctionsTest
     ) should returnResult(Period.parse("P1Y8M"))
   }
 
+  "A from json(string) function" should "convert a JSON string" in {
+    evaluateExpression(
+      """ from json(value) """,
+      Map("value" -> "{\"a\": 1, \"b\": 2}")
+    ) should returnResult(
+      Map("a" -> 1, "b" -> 2)
+    )
+    evaluateExpression(""" from json("null") """) should returnResult(
+      null
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "1")) should returnResult(
+      1
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "\"a\"")) should returnResult(
+      "a"
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "true")) should returnResult(
+      true
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "[1, 2, 3]")) should returnResult(
+      List(1, 2, 3)
+    )
+    evaluateExpression(
+      """ from json(value) """,
+      Map("value" -> "\"2023-06-14\"")
+    ) should returnResult(
+      "2023-06-14"
+    )
+    evaluateExpression(
+      """ from json(value) """,
+      Map("value" -> "\"14:55:00\"")
+    ) should returnResult(
+      "14:55:00"
+    )
+    evaluateExpression(
+      """ from json(value) """,
+      Map("value" -> "\"2023-06-14T14:55:00\"")
+    ) should returnResult(
+      "2023-06-14T14:55:00"
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "\"P1Y\"")) should returnResult(
+      "P1Y"
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "\"PT2H\"")) should returnResult(
+      "PT2H"
+    )
+    evaluateExpression(""" from json(value) """, Map("value" -> "invalid")) should returnResult(
+      null
+    )
+  }
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -528,54 +528,84 @@ class BuiltinConversionFunctionsTest
     ) should returnResult(Period.parse("P1Y8M"))
   }
 
-  "A from json(string) function" should "convert a JSON string" in {
+  "A from json({...}) function" should "convert a JSON object to a map" in {
     evaluateExpression(
       """ from json(value) """,
       Map("value" -> "{\"a\": 1, \"b\": 2}")
     ) should returnResult(
       Map("a" -> 1, "b" -> 2)
     )
-    evaluateExpression(""" from json("null") """) should returnResult(
-      null
-    )
-    evaluateExpression(""" from json(value) """, Map("value" -> "1")) should returnResult(
-      1
-    )
-    evaluateExpression(""" from json(value) """, Map("value" -> "\"a\"")) should returnResult(
-      "a"
-    )
-    evaluateExpression(""" from json(value) """, Map("value" -> "true")) should returnResult(
-      true
-    )
+  }
+
+  "A from json([...]) function" should "convert a JSON array to a list" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "[1, 2, 3]")) should returnResult(
       List(1, 2, 3)
     )
+  }
+
+  "A from json(null) function" should "return null" in {
+    evaluateExpression(""" from json("null") """) should returnResult(
+      null
+    )
+  }
+
+  "A from json(number) function" should "convert a JSON number to a BigDecimal" in {
+    evaluateExpression(""" from json(value) """, Map("value" -> "1")) should returnResult(
+      1
+    )
+  }
+
+  "A from json(string) function" should "convert a string to a string literal" in {
+    evaluateExpression(""" from json(value) """, Map("value" -> "\"a\"")) should returnResult(
+      "a"
+    )
+
     evaluateExpression(
       """ from json(value) """,
       Map("value" -> "\"2023-06-14\"")
     ) should returnResult(
       "2023-06-14"
     )
+
     evaluateExpression(
       """ from json(value) """,
       Map("value" -> "\"14:55:00\"")
     ) should returnResult(
       "14:55:00"
     )
+
     evaluateExpression(
       """ from json(value) """,
       Map("value" -> "\"2023-06-14T14:55:00\"")
     ) should returnResult(
       "2023-06-14T14:55:00"
     )
+
     evaluateExpression(""" from json(value) """, Map("value" -> "\"P1Y\"")) should returnResult(
       "P1Y"
     )
+
     evaluateExpression(""" from json(value) """, Map("value" -> "\"PT2H\"")) should returnResult(
       "PT2H"
     )
-    evaluateExpression(""" from json(value) """, Map("value" -> "invalid")) should returnResult(
-      null
+  }
+
+  "A from json(boolean) function" should "convert a boolean to a boolean literal" in {
+    evaluateExpression(""" from json(value) """, Map("value" -> "true")) should returnResult(
+      true
+    )
+
+    evaluateExpression(""" from json(value) """, Map("value" -> "false")) should returnResult(
+      false
+    )
+  }
+
+  "A from json(string) function with invalid JSON" should "report the parsing error" in {
+    evaluateExpression(""" from json(value) """, Map("value" -> "invalid")) should (
+      returnNull() and reportFailure(
+        FUNCTION_INVOCATION_FAILURE,
+        "Failed to invoke function 'from json': Failed to parse JSON from 'invalid'"
+      )
     )
   }
 }

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -528,7 +528,7 @@ class BuiltinConversionFunctionsTest
     ) should returnResult(Period.parse("P1Y8M"))
   }
 
-  "A from json({...}) function" should "convert a JSON object to a map" in {
+  "A from json() function" should "convert a JSON object to a context" in {
     evaluateExpression(
       """ from json(value) """,
       Map("value" -> "{\"a\": 1, \"b\": 2}")
@@ -537,25 +537,25 @@ class BuiltinConversionFunctionsTest
     )
   }
 
-  "A from json([...]) function" should "convert a JSON array to a list" in {
+  it should "convert a JSON array to a list" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "[1, 2, 3]")) should returnResult(
       List(1, 2, 3)
     )
   }
 
-  "A from json(null) function" should "return null" in {
+  it should "convert a JSON null value" in {
     evaluateExpression(""" from json("null") """) should returnResult(
       null
     )
   }
 
-  "A from json(number) function" should "convert a JSON number to a BigDecimal" in {
+  it should "convert a JSON number" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "1")) should returnResult(
       1
     )
   }
 
-  "A from json(string) function" should "convert a string to a string literal" in {
+  it should "convert a JSON string" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "\"a\"")) should returnResult(
       "a"
     )
@@ -590,7 +590,7 @@ class BuiltinConversionFunctionsTest
     )
   }
 
-  "A from json(boolean) function" should "convert a boolean to a boolean literal" in {
+  it should "convert a JSON boolean" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "true")) should returnResult(
       true
     )
@@ -600,7 +600,7 @@ class BuiltinConversionFunctionsTest
     )
   }
 
-  "A from json(string) function with invalid JSON" should "report the parsing error" in {
+  it should "return null if the JSON is invalid" in {
     evaluateExpression(""" from json(value) """, Map("value" -> "invalid")) should (
       returnNull() and reportFailure(
         FUNCTION_INVOCATION_FAILURE,


### PR DESCRIPTION
## Description

This PR adds a new `from json(string): Any` built-in conversion function, allowing users to convert stringified-JSON results (very common with agentic orchestration) into objects, such as contexts, lists, strings, etc. This simplifies extracting, transforming, etc., parts from such results.

The tests were largely taken [from this comment](https://github.com/camunda/feel-scala/issues/602#issuecomment-1591197695), major thanks for this :pray: 

One small issue, Jackson requires an additional compiler file, `Ytasty-reader`. I'm a complete Scala noob, so while I could add it and make progress, I cannot speak for its impact and if that's something we want to move forward with: does it mean downstream users also need to add this flag? If so, do we want that?

## Related issues

closes #825 
