### PR TITLE
feat: String templates

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -80,6 +80,18 @@ class FeelInterpreter(private val valueMapper: ValueMapper) {
 
       case range: ConstRange => toRange(range)
 
+      case Template(parts) =>
+        ValString(
+          // evaluate all parts and concatenate them
+          parts
+            .map(eval)
+            .map {
+              case ValString(value) => value
+              case other            => other.toString
+            }
+            .mkString
+        )
+
       // simple unary tests
       case InputEqualTo(x)                              =>
         withVal(getImplicitInputValue, i => checkEquality(i, eval(x)))

--- a/src/main/scala/org/camunda/feel/syntaxtree/Exp.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Exp.scala
@@ -144,3 +144,5 @@ case class Filter(list: Exp, filter: Exp) extends Exp
 case class IterationContext(start: Exp, end: Exp) extends Exp
 
 case class UnaryTestExpression(exp: Exp) extends Exp
+
+case class Template(parts: Seq[Exp]) extends Exp

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -514,7 +514,7 @@ class InterpreterListExpressionTest
 
   it should "compute a long list" in {
     evaluateExpression(
-        """count(for x in 0..1000000 return "Hi there")""",
+      """count(for x in 0..1000000 return "Hi there")"""
     ) should returnResult(1000001)
   }
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/TemplateExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/TemplateExpressionTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.impl.interpreter
+
+import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class TemplateExpressionTest
+    extends AnyFlatSpec
+    with Matchers
+    with FeelEngineTest
+    with EvaluationResultMatchers {
+
+  "A template" should "be a simple string" in {
+
+    evaluateExpression("```Hello friend!```") should returnResult("Hello friend!")
+  }
+
+  it should "contain a variable reference" in {
+
+    evaluateExpression(
+      expression = "```Hello {{name}}```",
+      variables = Map("name" -> "Zee")
+    ) should returnResult("Hello Zee")
+
+    evaluateExpression(
+      expression = "```Hello {{name}}, nice to meet you.```",
+      variables = Map("name" -> "Zee")
+    ) should returnResult("Hello Zee, nice to meet you.")
+  }
+
+  it should "contain an expression" in {
+
+    evaluateExpression(
+      expression = """```Good {{if hour < 12 then "morning" else "afternoon"}}```""",
+      variables = Map("hour" -> 9)
+    ) should returnResult("Good morning")
+
+    evaluateExpression(
+      expression = """```Good {{if hour < 12 then "morning" else "afternoon"}}```""",
+      variables = Map("hour" -> 15)
+    ) should returnResult("Good afternoon")
+  }
+
+  it should "insert the value as a string" in {
+
+    evaluateExpression(
+      expression = """```Value: {{value}}```""",
+      variables = Map("value" -> "FEEL")
+    ) should returnResult("Value: FEEL")
+
+    evaluateExpression(
+      expression = """```Value: {{value}}```""",
+      variables = Map("value" -> 123)
+    ) should returnResult("Value: 123")
+
+    evaluateExpression(
+      expression = """```Value: {{value}}```""",
+      variables = Map("value" -> true)
+    ) should returnResult("Value: true")
+
+    evaluateExpression(
+      expression = """```Value: {{value}}```""",
+      variables = Map("value" -> List(1, 2, 3))
+    ) should returnResult("Value: [1, 2, 3]")
+
+    evaluateExpression(
+      expression = """```Value: {{value}}```""",
+      variables = Map("value" -> Map("a" -> 1, "b" -> 2))
+    ) should returnResult("Value: {a:1, b:2}")
+  }
+
+  it should "contain an conditional section" in {
+
+    evaluateExpression(
+      expression = """```Hello{{#if name = "Zee"}} my friend{{/if}}!```""",
+      variables = Map("name" -> "Zee")
+    ) should returnResult("Hello my friend!")
+
+    evaluateExpression(
+      expression = """```Hello{{#if name = "Zee"}} my friend{{/if}}!```""",
+      variables = Map("name" -> "Joe")
+    ) should returnResult("Hello!")
+  }
+
+  it should "contain a loop section" in {
+
+    evaluateExpression(
+      expression = """```Items:\n{{#loop items}}- {{this}}\n{{/loop}}```""",
+      variables = Map("items" -> List("a", "b", "c"))
+    ) should returnResult("""Items:
+        |- a
+        |- b
+        |- c
+        |""".stripMargin)
+  }
+
+}


### PR DESCRIPTION
## Description

Add support for string templates. Align with the [Feelers](https://github.com/bpmn-io/feelers) library.

* Template syntax: `\```template```\` (tripple backtick)
* Inline expressions `{{variable or express}}`
* Conditional sections `{{#if condition}}here{{/if}}`
* Loops `{{#loop listValue}} Item: {{this}} {{/loop}}`

### Example

Template:

```
```Hello {{user.name}},

We received your order (ID: `{{order.id}}`) with the following items:
{{#loop order.items}}
    - {{this.quantity}}x {{this.name}}
{{/loop}}

Greetings {{department.name}}```
```

Context:

```json
{
  "user": {
    "name": "Zee"
  },
  "order": {
    "id": "c-8",
    "items": [
      {
        "name": "Helmet",
        "quantity": 1
      },
      {
        "name": "Flag",
        "quantity": 1
      },
      {
        "name": "Oxygen tank",
        "quantity": 3
      }
    ]
  },
  "department": {
    "name": "Camunda"
  }
}
```

Result: 

```
Hello Zee,

We received your order (ID: `c-8`) with the following items:
    - 1x Helmet
    - 1x Flag
    - 3x Oxygen tank

Greetings Camunda
```

## Related issues

closes https://github.com/camunda/feel-scala/issues/392
