### PR TITLE
feat: add `to json(any): string` built-in conversion function

### DIFF
--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinConversionFunctionsTest.scala
@@ -608,4 +608,134 @@ class BuiltinConversionFunctionsTest
       )
     )
   }
+
+  "A to json() function" should "convert a string value" in {
+    evaluateExpression(""" to json(x) """, Map("x" -> "hello")) should returnResult(
+      "\"hello\""
+    )
+  }
+
+  it should "convert a number" in {
+    evaluateExpression(""" to json(x) """, Map("x" -> 42)) should returnResult(
+      "42"
+    )
+  }
+
+  it should "convert a boolean" in {
+    evaluateExpression(""" to json(x) """, Map("x" -> true)) should returnResult(
+      "true"
+    )
+  }
+
+  it should "convert a list" in {
+    evaluateExpression(""" to json(x) """, Map("x" -> List("a", "b", "c"))) should returnResult(
+      "[\"a\",\"b\",\"c\"]"
+    )
+  }
+
+  it should "convert a nested list" in {
+    evaluateExpression(""" to json(x) """, Map("x" -> List(List(1, 2), 3))) should returnResult(
+      "[[1,2],3]"
+    )
+  }
+
+  it should "convert a context/map" in {
+    evaluateExpression(
+      """ to json(x) """,
+      Map("x" -> Map("a" -> 1, "b" -> "foo"))
+    ) should returnResult(
+      """{"a":1,"b":"foo"}"""
+    )
+  }
+
+  it should "convert a nested context/map" in {
+    evaluateExpression(
+      """ to json(x) """,
+      Map("x" -> Map("person" -> Map("name" -> "Alice", "age" -> 30)))
+    ) should returnResult(
+      """{"person":{"name":"Alice","age":30}}"""
+    )
+  }
+
+  it should "convert null" in {
+    evaluateExpression(""" to json(null) """) should returnResult(
+      "null"
+    )
+  }
+  it should "convert a date" in {
+    evaluateExpression(""" to json(date("2023-06-14")) """) should returnResult(
+      "\"2023-06-14\""
+    )
+  }
+  it should "convert a time" in {
+    evaluateExpression(""" to json(time(14,55,0)) """) should returnResult(
+      "\"14:55:00\""
+    )
+  }
+
+  it should "convert a date and time" in {
+    evaluateExpression(
+      """ to json(date and time("2023-06-14T14:55:00")) """
+    ) should returnResult(
+      "\"2023-06-14T14:55:00\""
+    )
+  }
+
+  it should "serialize a date value" in {
+    evaluateExpression(""" to json(date("2025-08-13")) """) should returnResult(
+      "\"2025-08-13\""
+    )
+  }
+
+  it should "serialize a time value" in {
+    evaluateExpression(" to json(time(15, 55, 0)) ") should returnResult(
+      "\"15:55:00\""
+    )
+  }
+
+  it should "serialize a date and time value" in {
+    evaluateExpression(""" to json(date and time("2025-08-13T14:55:00")) """) should returnResult(
+      "\"2025-08-13T14:55:00\""
+    )
+  }
+
+  it should "serialize a day-time duration" in {
+    evaluateExpression(""" to json(duration("PT2H30M")) """) should returnResult(
+      "\"PT2H30M\""
+    )
+  }
+
+  it should "serialize a year-month duration" in {
+    evaluateExpression(""" to json(duration("P1Y6M")) """) should returnResult(
+      "\"P1Y6M\""
+    )
+  }
+
+  it should "convert a time with offset" in {
+    evaluateExpression(""" to json(time("14:55:00+02:00")) """) should returnResult(
+      "\"14:55:00+02:00\""
+    )
+  }
+
+  it should "convert a time with timezone" in {
+    evaluateExpression(""" to json(time("14:55:00@Europe/Berlin")) """) should returnResult(
+      "\"14:55:00@Europe/Berlin\""
+    )
+  }
+
+  it should "convert a date and time with offset" in {
+    evaluateExpression(
+      """ to json(date and time("2023-06-14T14:55:00+02:00")) """
+    ) should returnResult(
+      "\"2023-06-14T14:55:00+02:00\""
+    )
+  }
+
+  it should "convert a date and time with timezone" in {
+    evaluateExpression(
+      """ to json(date and time("2023-06-14T14:55:00@Europe/Berlin")) """
+    ) should returnResult(
+      "\"2023-06-14T14:55:00+02:00\""
+    )
+  }
 }

--- a/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/InterpreterListExpressionTest.scala
@@ -514,7 +514,7 @@ class InterpreterListExpressionTest
 
   it should "compute a long list" in {
     evaluateExpression(
-        """count(for x in 0..1000000 return "Hi there")""",
+      """count(for x in 0..1000000 return "Hi there")"""
     ) should returnResult(1000001)
   }
 }


### PR DESCRIPTION

## Description
This PR adds a new built-in FEEL function `to Json(object): string` that performs the inverse of the existing `from Json(json):any` function.  It allows FEEL expressions to serialize values (contexts, lists, primitives, temporal values, and durations) into JSON strings, similar to `JSON.stringify(any)` in JavaScript. This is especially useful for integration scenarios where FEEL values need to be passed to systems expecting JSON.

**Implementation details:**

Introduced helper method `convertToJsonValue(Val)` to recursively map FEEL Val types into JSON-compatible Java/Scala values.

Supports all FEEL data types, including temporal values (ValDate, ValTime, ValDateTime, ValLocalTime, ValLocalDateTime) formatted using ISO-8601 standards.

Durations are serialized using their toString representation.

The resulting JSON string is wrapped in a ValString to be fully FEEL-compatible.

Added safety net to return ValError when serialization fails (though in practice all FEEL types are supported).

I could not create a meaningful test that triggers the `ValError(s"Failed to convert object to JSON: ${obj.getClass.getSimpleName}")` case because all FEEL data types are fully mapped in the `convertToJsonValue(Val)` function. Triggering this branch would require artificially passing in unsupported or non-FEEL types, which isn’t a real usage scenario.

Finally, I’m a complete Scala noob, so I’m happy to hear any suggestions for making the code cleaner or more idiomatic.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #602 