### PR TITLE
perf: improve performance of FeelInterpreter.hasSameType

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -391,7 +391,12 @@ class FeelInterpreter(private val valueMapper: ValueMapper) {
 
   private def isComparable(values: Val*): Boolean = values.forall(_.isComparable)
 
-  private def hasSameType(values: Val*): Boolean = values.map(_.getClass).distinct.size == 1
+  private def hasSameType(values: Val*): Boolean = {
+    values.nonEmpty && {
+      val firstClass = values.head.getClass
+      values.tail.forall(_.getClass == firstClass)
+    }
+  }
 
   // ======== type checks ====================
 


### PR DESCRIPTION
## Description
Avoids creating intermediate collections and uses `.forall`  to verify that the condition holds for all elements of the list.  

