### PR TITLE
[POC] Add configurable evaluation timeouts in FEEL

### DIFF
--- a/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineApi.scala
@@ -17,10 +17,15 @@
 package org.camunda.feel.api
 
 import org.camunda.feel.FeelEngine
+import org.camunda.feel.FeelEngine.Failure
 import org.camunda.feel.context.Context
+import org.camunda.feel.impl.InterruptibleTimeout
 import org.camunda.feel.impl.interpreter.EvalContext
 import org.camunda.feel.syntaxtree.ParsedExpression
 
+import java.util.concurrent.RejectedExecutionException
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.MapHasAsScala
 
 /** The API to interact with the FEEL engine.
@@ -29,6 +34,56 @@ import scala.jdk.CollectionConverters.MapHasAsScala
   *   the FEEL engine to interact with
   */
 class FeelEngineApi(engine: FeelEngine) {
+
+  // Timeout support is implemented at the API layer (and not in FeelEngine) to keep the core engine
+  // API stable and backward-compatible. A timeout works by evaluating on a worker thread and
+  // interrupting it on expiry; stopping is therefore cooperative.
+
+  private def failedTimedOut(expression: String, timeout: FiniteDuration): EvaluationResult =
+    FailedEvaluationResult(
+      failure = Failure(
+        s"failed to evaluate expression '$expression': evaluation timed out after ${timeout.toMillis}ms"
+      )
+    )
+
+  private def failedInterrupted(expression: String): EvaluationResult =
+    FailedEvaluationResult(
+      failure = Failure(
+        s"failed to evaluate expression '$expression': evaluation interrupted"
+      )
+    )
+
+  private def failedRejected(expression: String): EvaluationResult =
+    FailedEvaluationResult(
+      failure = Failure(
+        s"failed to evaluate expression '$expression': evaluation rejected because the timeout executor is saturated"
+      )
+    )
+
+  private def withTimeout(
+      expression: String,
+      timeout: FiniteDuration
+  )(
+      thunk: => EvaluationResult
+  ): EvaluationResult = {
+    try {
+      // Run evaluation on a worker thread so we can cancel/interrupt it on timeout.
+      // This is cooperative cancellation: evaluation stops promptly only if it reacts to interrupts
+      // (e.g. blocking calls like Thread.sleep, or explicit interrupt checks inside the interpreter).
+      InterruptibleTimeout.run(timeout) {
+        thunk
+      }
+    } catch {
+      case InterruptibleTimeout.TimedOut(_)   => failedTimedOut(expression, timeout)
+      case InterruptibleTimeout.Interrupted() => failedInterrupted(expression)
+      case InterruptibleTimeout.Rejected(_)   => failedRejected(expression)
+      case _: RejectedExecutionException      => failedRejected(expression)
+      case _: InterruptedException            =>
+        // Preserve the caller thread's interrupted status.
+        Thread.currentThread().interrupt()
+        failedInterrupted(expression)
+    }
+  }
 
   // =========== parse expression ===========
 
@@ -82,6 +137,29 @@ class FeelEngineApi(engine: FeelEngine) {
       expression = expression,
       context = context
     )
+
+  /** Evaluates a parsed expression with the given context and a timeout.
+    */
+  def evaluate(
+      expression: ParsedExpression,
+      context: Context,
+      timeout: FiniteDuration
+  ): EvaluationResult =
+    withTimeout(expression.text, timeout) {
+      engine.evaluate(
+        expression = expression,
+        context = context
+      )
+    }
+
+  /** Evaluates a parsed expression with the given context and a timeout.
+    */
+  def evaluate(
+      expression: ParsedExpression,
+      context: Context,
+      timeout: java.time.Duration
+  ): EvaluationResult =
+    evaluate(expression, context, timeout.toMillis.millis)
 
   /** Evaluates a parsed expression with the given context.
     *
@@ -139,6 +217,31 @@ class FeelEngineApi(engine: FeelEngine) {
       expression = expression,
       context = createContextWithInput(context, inputValue)
     )
+
+  /** Evaluates a parsed unary-tests expression with the given input value, context and a timeout.
+    */
+  def evaluateWithInput(
+      expression: ParsedExpression,
+      inputValue: Any,
+      context: Context,
+      timeout: FiniteDuration
+  ): EvaluationResult =
+    withTimeout(expression.text, timeout) {
+      engine.evaluate(
+        expression = expression,
+        context = createContextWithInput(context, inputValue)
+      )
+    }
+
+  /** Evaluates a parsed unary-tests expression with the given input value, context and a timeout.
+    */
+  def evaluateWithInput(
+      expression: ParsedExpression,
+      inputValue: Any,
+      context: Context,
+      timeout: java.time.Duration
+  ): EvaluationResult =
+    evaluateWithInput(expression, inputValue, context, timeout.toMillis.millis)
 
   /** Evaluates a parsed unary-tests expression with the given input value and context.
     *
@@ -209,6 +312,35 @@ class FeelEngineApi(engine: FeelEngine) {
         )
     }
 
+  /** Evaluates an FEEL expression with the given context and a timeout.
+    */
+  def evaluateExpression(
+      expression: String,
+      context: Context,
+      timeout: FiniteDuration
+  ): EvaluationResult =
+    engine.parseExpression(expression = expression) match {
+      case Right(parsedExpression) =>
+        evaluate(
+          expression = parsedExpression,
+          context = context,
+          timeout = timeout
+        )
+      case Left(parseFailure)      =>
+        FailedEvaluationResult(
+          failure = parseFailure
+        )
+    }
+
+  /** Evaluates an FEEL expression with the given context and a timeout.
+    */
+  def evaluateExpression(
+      expression: String,
+      context: Context,
+      timeout: java.time.Duration
+  ): EvaluationResult =
+    evaluateExpression(expression, context, timeout.toMillis.millis)
+
   /** Evaluates an FEEL expression with the given context. This is a shortcut and skips the explicit
     * parsing step before the evaluation.
     *
@@ -273,6 +405,37 @@ class FeelEngineApi(engine: FeelEngine) {
           failure = parseFailure
         )
     }
+
+  /** Evaluates an FEEL unary-tests expression with the given input value, context and a timeout.
+    */
+  def evaluateUnaryTests(
+      expression: String,
+      inputValue: Any,
+      context: Context,
+      timeout: FiniteDuration
+  ): EvaluationResult =
+    engine.parseUnaryTests(expression = expression) match {
+      case Right(parsedExpression) =>
+        evaluate(
+          expression = parsedExpression,
+          context = createContextWithInput(context, inputValue),
+          timeout = timeout
+        )
+      case Left(parseFailure)      =>
+        FailedEvaluationResult(
+          failure = parseFailure
+        )
+    }
+
+  /** Evaluates an FEEL unary-tests expression with the given input value, context and a timeout.
+    */
+  def evaluateUnaryTests(
+      expression: String,
+      inputValue: Any,
+      context: Context,
+      timeout: java.time.Duration
+  ): EvaluationResult =
+    evaluateUnaryTests(expression, inputValue, context, timeout.toMillis.millis)
 
   /** Evaluates an FEEL unary-tests expression with the given input value and context. This is a
     * shortcut and skips the explicit parsing step before the evaluation.

--- a/src/main/scala/org/camunda/feel/api/FeelEngineBuilder.scala
+++ b/src/main/scala/org/camunda/feel/api/FeelEngineBuilder.scala
@@ -23,6 +23,9 @@ import org.camunda.feel.impl.JavaValueMapper
 import org.camunda.feel.valuemapper.{CustomValueMapper, ValueMapper}
 import org.camunda.feel.valuemapper.ValueMapper.CompositeValueMapper
 
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
 /** Builds a new instance of the FEEL engine. Use the setters to customize the engine.
   */
 case class FeelEngineBuilder private (
@@ -73,6 +76,25 @@ case class FeelEngineBuilder private (
       clock = clock
     )
   )
+
+  /** Creates a new engine that applies the given default evaluation timeout.
+    *
+    * The evaluation is run on a separate thread and interrupted on timeout.
+    */
+  def buildWithEvaluationTimeout(timeout: FiniteDuration): FeelEngineApi =
+    new TimedFeelEngineApi(
+      engine = new FeelEngine(
+        functionProvider = functionProvider,
+        valueMapper = valueMapper,
+        configuration = configuration,
+        clock = clock
+      ),
+      timeout = timeout
+    )
+
+  /** Java-friendly overload. */
+  def buildWithEvaluationTimeout(timeout: java.time.Duration): FeelEngineApi =
+    buildWithEvaluationTimeout(timeout.toMillis.millis)
 
 }
 

--- a/src/main/scala/org/camunda/feel/api/TimedFeelEngineApi.scala
+++ b/src/main/scala/org/camunda/feel/api/TimedFeelEngineApi.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.api
+
+import org.camunda.feel.FeelEngine
+import org.camunda.feel.context.Context
+import org.camunda.feel.syntaxtree.ParsedExpression
+
+import scala.concurrent.duration.FiniteDuration
+
+/** A FeelEngineApi that applies a default timeout to evaluation entry points.
+  *
+  * This wrapper preserves backward compatibility: existing call-sites can keep using the
+  * non-timeout `evaluate*` methods, while a builder can still provide a default timeout for the API
+  * instance.
+  */
+private[api] final class TimedFeelEngineApi(engine: FeelEngine, timeout: FiniteDuration)
+    extends FeelEngineApi(engine) {
+
+  override def evaluate(expression: ParsedExpression, context: Context): EvaluationResult =
+    super.evaluate(expression, context, timeout)
+
+  override def evaluateWithInput(
+      expression: ParsedExpression,
+      inputValue: Any,
+      context: Context
+  ): EvaluationResult =
+    super.evaluateWithInput(expression, inputValue, context, timeout)
+
+  override def evaluateExpression(expression: String, context: Context): EvaluationResult =
+    super.evaluateExpression(expression, context, timeout)
+
+  override def evaluateUnaryTests(
+      expression: String,
+      inputValue: Any,
+      context: Context
+  ): EvaluationResult =
+    super.evaluateUnaryTests(expression, inputValue, context, timeout)
+}

--- a/src/main/scala/org/camunda/feel/impl/InterruptibleTimeout.scala
+++ b/src/main/scala/org/camunda/feel/impl/InterruptibleTimeout.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.impl
+
+import java.util.concurrent.{
+  Callable,
+  ExecutionException,
+  ExecutorService,
+  Executors,
+  Future,
+  LinkedBlockingQueue,
+  ThreadFactory,
+  ThreadPoolExecutor,
+  TimeUnit,
+  TimeoutException
+}
+import java.util.concurrent.{RejectedExecutionException, SynchronousQueue}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+/** Runs computations on a separate thread and interrupts them on timeout.
+  *
+  * Note: interruption is cooperative. Code stops promptly only if it reacts to interrupts (blocking
+  * calls like Thread.sleep, or explicit interrupt checks).
+  */
+private[feel] object InterruptibleTimeout {
+
+  private val ThreadsProp: String          = "org.camunda.feel.timeout.threads"
+  private val QueueCapacityProp: String    = "org.camunda.feel.timeout.queueCapacity"
+  private val KeepAliveSecondsProp: String = "org.camunda.feel.timeout.keepAliveSeconds"
+
+  final case class TimedOut(timeout: FiniteDuration)
+      extends RuntimeException(s"Evaluation exceeded timeout of ${timeout.toMillis}ms")
+
+  final case class Interrupted() extends RuntimeException("Evaluation thread was interrupted")
+
+  final case class Rejected(message: String) extends RuntimeException(message)
+
+  private val threadFactory: ThreadFactory = new ThreadFactory {
+    private val backing = Executors.defaultThreadFactory()
+
+    override def newThread(r: Runnable): Thread = {
+      val t = backing.newThread(r)
+      t.setName(s"feel-eval-${t.getId}")
+      t.setDaemon(true)
+      t
+    }
+  }
+
+  private def configuredThreads(): Int = {
+    val default = math.max(2, Runtime.getRuntime.availableProcessors())
+    val parsed  = sys.props.get(ThreadsProp).flatMap(v => Try(v.toInt).toOption)
+    parsed.filter(_ > 0).getOrElse(default)
+  }
+
+  private def configuredQueueCapacity(): Int = {
+    val default = 256
+    val parsed  = sys.props.get(QueueCapacityProp).flatMap(v => Try(v.toInt).toOption)
+    parsed.filter(_ >= 0).getOrElse(default)
+  }
+
+  private def configuredKeepAliveSeconds(): Long = {
+    val default = 30L
+    val parsed  = sys.props.get(KeepAliveSecondsProp).flatMap(v => Try(v.toLong).toOption)
+    parsed.filter(_ >= 0).getOrElse(default)
+  }
+
+  /** A bounded executor to avoid unbounded thread growth under load.
+    *
+    * Configurable via system properties:
+    *   - org.camunda.feel.timeout.threads (default: max(2, availableProcessors))
+    *   - org.camunda.feel.timeout.queueCapacity (default: 256, 0 means no queue)
+    *   - org.camunda.feel.timeout.keepAliveSeconds (default: 30)
+    */
+  private lazy val executor: ExecutorService = {
+    val threads          = configuredThreads()
+    val queueCapacity    = configuredQueueCapacity()
+    val keepAliveSeconds = configuredKeepAliveSeconds()
+
+    val queue =
+      if (queueCapacity == 0) new SynchronousQueue[Runnable]()
+      else new LinkedBlockingQueue[Runnable](queueCapacity)
+
+    val pool = new ThreadPoolExecutor(
+      threads,
+      threads,
+      keepAliveSeconds,
+      TimeUnit.SECONDS,
+      queue,
+      threadFactory,
+      new ThreadPoolExecutor.AbortPolicy()
+    )
+    pool.allowCoreThreadTimeOut(keepAliveSeconds > 0)
+    pool
+  }
+
+  def run[A](timeout: FiniteDuration)(thunk: => A): A = {
+    if (timeout.toMillis <= 0) throw TimedOut(timeout)
+
+    val future: Future[A] =
+      try {
+        executor.submit(new Callable[A] {
+          override def call(): A = thunk
+        })
+      } catch {
+        case e: RejectedExecutionException =>
+          // Fail fast on saturation instead of blocking callers indefinitely.
+          throw Rejected(
+            s"Evaluation rejected because the timeout executor is saturated: ${e.getMessage}"
+          )
+      }
+
+    try {
+      future.get(timeout.toMillis, TimeUnit.MILLISECONDS)
+    } catch {
+      case _: TimeoutException =>
+        // Attempt to stop the worker by interrupting the evaluation thread.
+        // This requires cooperative interruption inside the engine/interpreter.
+        future.cancel(true)
+        throw TimedOut(timeout)
+
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        throw Interrupted()
+
+      case e: ExecutionException =>
+        val cause = Option(e.getCause).getOrElse(e)
+        cause match {
+          case re: RuntimeException    => throw re
+          case _: InterruptedException =>
+            Thread.currentThread().interrupt()
+            throw Interrupted()
+          case other                   => throw new RuntimeException(other)
+        }
+    }
+  }
+}

--- a/src/test/scala/org/camunda/feel/api/FeelEngineTimeoutTest.scala
+++ b/src/test/scala/org/camunda/feel/api/FeelEngineTimeoutTest.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.feel.api
+
+import org.camunda.feel.context.{Context, FunctionProvider}
+import org.camunda.feel.syntaxtree.ValFunction
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.duration._
+
+class FeelEngineTimeoutTest extends AnyFlatSpec with Matchers {
+
+  private def sleepFunction(interrupted: AtomicBoolean, sleepMillis: Long): ValFunction =
+    ValFunction(
+      params = List("ms"),
+      invoke = _ => {
+        try {
+          Thread.sleep(sleepMillis)
+          123
+        } catch {
+          case _: InterruptedException =>
+            interrupted.set(true)
+            throw new InterruptedException()
+        }
+      }
+    )
+
+  "The FEEL engine API" should "interrupt evaluation and return a timeout failure" in {
+    val interrupted = new AtomicBoolean(false)
+
+    val functionProvider = FunctionProvider.StaticFunctionProvider(
+      functions = Map("sleep" -> List(sleepFunction(interrupted, sleepMillis = 5_000)))
+    )
+
+    val api = FeelEngineBuilder()
+      .withFunctionProvider(functionProvider)
+      .buildWithEvaluationTimeout(50.millis)
+
+    val result = api.evaluateExpression("sleep(5000)", Context.EmptyContext)
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    val deadline = System.currentTimeMillis() + 1000
+    while (!interrupted.get() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+
+    interrupted.get() shouldBe true
+  }
+
+  it should "support a per-call timeout override" in {
+    val interrupted = new AtomicBoolean(false)
+
+    val functionProvider = FunctionProvider.StaticFunctionProvider(
+      functions = Map("sleep" -> List(sleepFunction(interrupted, sleepMillis = 5_000)))
+    )
+
+    val api = FeelEngineBuilder()
+      .withFunctionProvider(functionProvider)
+      .build()
+
+    val result = api.evaluateExpression("sleep(5000)", Context.EmptyContext, 50.millis)
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    val deadline = System.currentTimeMillis() + 1000
+    while (!interrupted.get() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+
+    interrupted.get() shouldBe true
+  }
+
+  it should "support a java.time.Duration timeout override" in {
+    val interrupted = new AtomicBoolean(false)
+
+    val functionProvider = FunctionProvider.StaticFunctionProvider(
+      functions = Map("sleep" -> List(sleepFunction(interrupted, sleepMillis = 5_000)))
+    )
+
+    val api = FeelEngineBuilder()
+      .withFunctionProvider(functionProvider)
+      .build()
+
+    val result = api.evaluateExpression(
+      "sleep(5000)",
+      Context.EmptyContext,
+      java.time.Duration.ofMillis(50)
+    )
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    val deadline = System.currentTimeMillis() + 1000
+    while (!interrupted.get() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+
+    interrupted.get() shouldBe true
+  }
+
+  it should "not apply a timeout when not configured" in {
+    val interrupted = new AtomicBoolean(false)
+
+    val functionProvider = FunctionProvider.StaticFunctionProvider(
+      functions = Map("sleep" -> List(sleepFunction(interrupted, sleepMillis = 20)))
+    )
+
+    val api = FeelEngineBuilder()
+      .withFunctionProvider(functionProvider)
+      .build()
+
+    val result = api.evaluateExpression("sleep(20)", Context.EmptyContext)
+
+    result.isSuccess shouldBe true
+    result.result shouldBe 123
+    interrupted.get() shouldBe false
+  }
+
+  it should "apply a timeout to evaluateWithInput" in {
+    val interrupted = new AtomicBoolean(false)
+
+    val functionProvider = FunctionProvider.StaticFunctionProvider(
+      functions = Map("sleep" -> List(sleepFunction(interrupted, sleepMillis = 5_000)))
+    )
+
+    val api = FeelEngineBuilder()
+      .withFunctionProvider(functionProvider)
+      .buildWithEvaluationTimeout(50.millis)
+
+    val parseResult = api.parseExpression("sleep(5000)")
+    parseResult.isSuccess shouldBe true
+
+    val result = api.evaluateWithInput(
+      expression = parseResult.parsedExpression,
+      inputValue = 1,
+      context = Context.EmptyContext
+    )
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    val deadline = System.currentTimeMillis() + 1000
+    while (!interrupted.get() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+
+    interrupted.get() shouldBe true
+  }
+
+  it should "time out an evaluation that materializes a huge iteration range" in {
+    val api = FeelEngineBuilder().build()
+
+    // Materializing 1..(2 ** 20) creates a large list and should reliably exceed a small timeout.
+    // This exercises the cooperative interrupt checks added to IterationContext range building.
+    val result = api.evaluateExpression(
+      "for x in 1..(2 ** 20) return x",
+      Context.EmptyContext,
+      20.millis
+    )
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    // Sanity: the API should still be usable after a timeout.
+    api.evaluateExpression("1+1", Context.EmptyContext).result shouldBe 2
+  }
+
+  it should "time out an evaluation that expands a large cartesian product" in {
+    val api = FeelEngineBuilder().build()
+
+    // The cartesian product is expanded eagerly before iterating, so keep the size large enough
+    // to exceed the timeout but not so large that it risks OOM in case of regressions.
+    // This exercises the cooperative interrupt checks added to cartesian product expansion.
+    val result = api.evaluateExpression(
+      "for x in 1..400, y in 1..400 return x + y",
+      Context.EmptyContext,
+      20.millis
+    )
+
+    result.isFailure shouldBe true
+    result.failure.message should include("timed out")
+
+    api.evaluateExpression("2+3", Context.EmptyContext).result shouldBe 5
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR adds an opt-in timeout mechanism for FEEL expression evaluation that interrupts the evaluation thread when a deadline is exceeded and returns a failure result. It’s implemented at the API layer to preserve backward compatibility with the core engine API. To make interruption more responsive in real-world “tight loop” expressions (large ranges / cartesian products), the interpreter now performs periodic interrupt checks in iteration-heavy hotspots. The PR also hardens execution with a bounded thread pool and adds comprehensive tests.

## Key changes

- Adds a reusable timeout runner that evaluates on a worker thread, waits up to a configured timeout, and cancels via interrupt on timeout.
- Extends the public FeelEngineApi with timeout overloads (Scala FiniteDuration and Java Duration) and shared timeout wrapper logic.
- Adds a TimedFeelEngineApi wrapper that applies a default timeout to existing non-timeout API calls (so call sites don’t need to change).
- Extends FeelEngineBuilder with buildWithEvaluationTimeout(...) to conveniently create a timeout-enabled API instance.
- Improves cancellation responsiveness by adding periodic interrupt checkpoints inside interpreter paths that may otherwise run for a long time without hitting an interrupt check.

## Example usage

1. Default timeout via builder (recommended when you want timeouts everywhere)

```
import org.camunda.feel.api.FeelEngineBuilder
import scala.concurrent.duration._

val api = FeelEngineBuilder.newInstance().buildWithEvaluationTimeout(200.millis)

val result = api.evaluateExpression("sleep(500)") // returns a FailedEvaluationResult on timeout
```

2. Per-call timeout override (when you only want timeouts sometimes)

```
import org.camunda.feel.api.FeelEngineBuilder
import scala.concurrent.duration._

val api = FeelEngineBuilder.newInstance().build()

val result = api.evaluateExpression("sleep(500)", 200.millis)
```

## Configuration

The timeout runner’s executor is bounded and configurable via system properties:

```
org.camunda.feel.timeout.threads (pool size)
org.camunda.feel.timeout.queueCapacity
org.camunda.feel.timeout.keepAliveSeconds
```
