### PR TITLE
perf: implement indexOf using a mutable builder

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/ListBuiltinFunctions.scala
@@ -385,20 +385,16 @@ class ListBuiltinFunctions(private val valueMapper: ValueMapper) {
       }
     )
 
-  @tailrec
-  private def indexOfList(
-      list: Seq[Val],
-      item: Val,
-      from: Int = 0,
-      indexList: Seq[Int] = Seq()
-  ): Seq[Int] = {
-    val index = list.indexOf(item, from)
-
-    if (index >= 0) {
-      indexOfList(list, item, index + 1, indexList ++ Seq(index + 1))
-    } else {
-      indexList
+  private def indexOfList(list: Seq[Val], item: Val): Seq[Int] = {
+    val builder = Vector.newBuilder[Int]
+    var i       = 1
+    list.foreach { x =>
+      if (valueComparator.equals(x, item)) {
+        builder += i
+      }
+      i += 1
     }
+    builder.result()
   }
 
   private def unionFunction = builtinFunction(

--- a/src/test/scala/org/camunda/feel/impl/interpreter/ListPerformanceTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/ListPerformanceTest.scala
@@ -57,7 +57,7 @@ class ListPerformanceTest
     result.success.value should returnResult((1 to listSize).toVector)
   }
 
-  "An index of function" should "handle large lists with many matches efficiently" ignore {
+  "An index of function" should "handle large lists with many matches efficiently" in {
     // List with repeated value to find multiple indices
     val listOfOnes = List.fill(listSize)(1)
 


### PR DESCRIPTION
## Description

`indexOf` function performance was ~ O(N^2) as it was appending lists, which is inefficient.
I tried another immutable version, but it requires appending to a list and then doing `.reverse` at the end.

Using a mutable builder is faster and results in code that is easier to understand.

A test in `ListPerformanceTest` can be enabled again. 

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->
This was raised in the same incident as 
relates camunda/camunda/issues/41775
