### PR TITLE
perf: revert rootContext to val for performance optimization

### DIFF
--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -133,7 +133,7 @@ class FeelEngine(
       s"configuration: $configuration]"
   )
 
-  private def rootContext(): EvalContext = EvalContext.create(
+  private val rootContext: EvalContext = EvalContext.create(
     valueMapper = valueMapper,
     functionProvider = FunctionProvider.CompositeFunctionProvider(
       List(
@@ -330,7 +330,8 @@ class FeelEngine(
   @deprecated def evaluate(expression: ParsedExpression, context: Context): EvaluationResult =
     Try {
       validate(expression) match {
-        case Right(_)      => eval(expression, rootContext().merge(context))
+        case Right(_)      =>
+          eval(expression, EvalContext.empty(valueMapper).merge(rootContext).merge(context))
         case Left(failure) => FailedEvaluationResult(failure = failure)
       }
     }.recover(failure =>


### PR DESCRIPTION
## Description

We had a noticeable performance degradation when the Feel Engine was upgraded with a Camunda update. After some investigations we found that 851a743c30d2cc2c introduced some overhead for our DMN usage.

Performance improvements when downgrading from 1.17.1 -> 1.16.6(measured on real workload):
- First call: 8.5s → 3.8s (2.2x faster, 55% improvement)
- Warmed call: 6.1s → 1.6s (3.8x faster, 74% improvement)

This MR reverts the rootContext back from a method to an immutable val in FeelEngine to avoid repeated context creation on every evaluation invocation. A fresh, mutable failureCollector is initialized on demand when merging the context.

The fix eliminates redundant creation of:
- BuiltinFunctions instance
- CompositeFunctionProvider
- EvalContext structure

Partly reverts 851a743c30d2cc2c

This performance fix can be back-ported to all releases back to 1.17. 

## Benchmark with [feel-scala-jmh](https://github.com/saig0/feel-scala-jmh)

Against 1.17.7 (https://github.com/saig0/feel-scala-jmh/commit/a910c6aad839eb3baee82512d2ad5361d4ab2f24)
- [benchmark-results-1.17.7-baseline.txt](https://github.com/user-attachments/files/25245102/benchmark-results-1.17.7-baseline.txt)
- [benchmark-results-rootContext-fix-1.17.12-SNAPSHOT.txt](https://github.com/user-attachments/files/25245105/benchmark-results-rootContext-fix-1.17.12-SNAPSHOT.txt)

Against main ([7afa2519c9ab19aea](https://github.com/saig0/feel-scala-jmh/commit/7afa2519c9ab19aeac236fa5e53b1f08f1b2b769))
- [benchmark-results-1.20-baseline.txt](https://github.com/user-attachments/files/25245104/benchmark-results-1.20-baseline.txt)
- [benchmark-results-rootContext-fix-1.21.0-SNAPSHOT.txt](https://github.com/user-attachments/files/25245106/benchmark-results-rootContext-fix-1.21.0-SNAPSHOT.txt)

## Related issues

closes #814
