### PR TITLE
perf: improve list filter by using a Vector rather than a List

### DIFF
--- a/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
+++ b/src/main/scala/org/camunda/feel/impl/interpreter/FeelInterpreter.scala
@@ -304,9 +304,8 @@ class FeelInterpreter(private val valueMapper: ValueMapper) {
       f: T => Either[ValError, R],
       resultMapping: Seq[R] => Val
   ): Val = {
-
     foldEither[T, Seq[R]](
-      Seq.empty,
+      Vector.empty,
       it,
       { case (xs, x) =>
         f(x).map(xs :+ _)

--- a/src/test/scala/org/camunda/feel/impl/interpreter/ListPerformanceTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/interpreter/ListPerformanceTest.scala
@@ -109,7 +109,7 @@ class ListPerformanceTest
     result.success.value should returnResult((1 to listSize).toList)
   }
 
-  "A filter expression" should "handle large lists efficiently" ignore {
+  "A filter expression" should "handle large lists efficiently" in {
     val list = (1 to listSize).toList
 
     val result = Try(evaluateExpression("xs[item > n]", Map("xs" -> list, "n" -> (listSize / 2))))


### PR DESCRIPTION
## Description
Filtering was using `FeelInterpreter.foldEither` which uses foldLeft under the hood which is very inefficient for list.
As a long term solution, we should create a version of `foldEither` which does not use foldLeft, but the current signature makes it impossible without changing it.

