### PR TITLE
[Backport 1.20] perf: revert rootContext to val for performance optimization

### DIFF
--- a/src/main/scala/org/camunda/feel/FeelEngine.scala
+++ b/src/main/scala/org/camunda/feel/FeelEngine.scala
@@ -133,7 +133,7 @@ class FeelEngine(
       s"configuration: $configuration]"
   )
 
-  private def rootContext(): EvalContext = EvalContext.create(
+  private val rootContext: EvalContext = EvalContext.create(
     valueMapper = valueMapper,
     functionProvider = FunctionProvider.CompositeFunctionProvider(
       List(
@@ -330,7 +330,8 @@ class FeelEngine(
   @deprecated def evaluate(expression: ParsedExpression, context: Context): EvaluationResult =
     Try {
       validate(expression) match {
-        case Right(_)      => eval(expression, rootContext().merge(context))
+        case Right(_)      =>
+          eval(expression, EvalContext.empty(valueMapper).merge(rootContext).merge(context))
         case Left(failure) => FailedEvaluationResult(failure = failure)
       }
     }.recover(failure =>


### PR DESCRIPTION
# Description
Backport of #1108 to `1.20`.

relates to #814
original author: @asigner