### PR TITLE
fix: binary breaking change in ValList object

### DIFF
--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -323,7 +323,7 @@ case class ValList(itemsAsSeq: Seq[Val]) extends Val {
   def copy(items: List[Val]): ValList = new ValList(items)
 }
 
-object ValList {
+object ValList extends (List[Val] => ValList) {
   def apply(items: List[Val]): ValList = new ValList(items)
   def apply(items: Seq[Val]): ValList  = new ValList(items)
 }


### PR DESCRIPTION
## Description

There's a breaking binary change that occurs in the monorepo when dmn version is compiled with a feel-engine version < 1.19.4. The error is the following:
```
IncompatibleClassChange Class org.camunda.feel.syntaxtree.ValList$
does not implement the requested interface scala.Function1
```
I think this was caused by the fact that now there are 2 apply methods.

I'm not sure why Clirr didn't catch this error, maybe with MiMa it would
been have caught
