### PR TITLE
[Backport 1.19] fix: binary breaking change in ValList object

### DIFF
--- a/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
+++ b/src/main/scala/org/camunda/feel/syntaxtree/Val.scala
@@ -323,7 +323,7 @@ case class ValList(itemsAsSeq: Seq[Val]) extends Val {
   def copy(items: List[Val]): ValList = new ValList(items)
 }
 
-object ValList {
+object ValList extends (List[Val] => ValList) {
   def apply(items: List[Val]): ValList = new ValList(items)
   def apply(items: Seq[Val]): ValList  = new ValList(items)
 }


### PR DESCRIPTION
# Description
Backport of #1124 to `1.19`.

relates to 
original author: @entangled90