### PR TITLE
docs: switch maven central badge to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FEEL Scala
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.camunda.feel/feel-engine/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.camunda.feel/feel-engine)
+[![Maven Central](https://img.shields.io/maven-central/v/org.camunda.feel/feel-engine)](https://mvnrepository.com/artifact/org.camunda.feel/feel-engine)
 
 A parser and interpreter for FEEL that is written in Scala (see [What is FEEL?](https://docs.camunda.io/docs/next/components/modeler/feel/what-is-feel/)).
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

The current Maven Central badge is no longer functional. It appears the Maven Badges Heroku app is no longer active.

This replaces it with the shields.io one and provides a link to the mvnrepository.com artifact for easy navigation.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

no related issue