### PR TITLE
feat: add `from base64()` function

### DIFF
--- a/docs/docs/changelog/changelog.md
+++ b/docs/docs/changelog/changelog.md
@@ -10,6 +10,16 @@ This page contains an overview of the released versions and highlights the major
 point of view (i.e. focus on features). The complete changelog, including the patch
 versions, can be found on the [GitHub release page](https://github.com/camunda/feel-scala/releases).
 
+## 1.22
+
+**Built-in functions:**
+
+* New built-in
+  function `from base64()`
+  to decode a Base64 encoded string
+
+See the full changelog [here](https://github.com/camunda/feel-scala/releases/tag/1.22.0).
+
 ## 1.21
 
 <MarkerChangelogVersion versionZeebe="8.9.0" versionC7="not yet" />

--- a/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
+++ b/src/main/scala/org/camunda/feel/impl/builtin/StringBuiltinFunctions.scala
@@ -46,6 +46,7 @@ object StringBuiltinFunctions {
     "trim"             -> List(trimFunction),
     "uuid"             -> List(uuidFunction),
     "to base64"        -> List(toBase64Function),
+    "from base64"      -> List(fromBase64Function),
     "is blank"         -> List(isBlankFunction)
   )
 
@@ -285,6 +286,21 @@ object StringBuiltinFunctions {
       invoke = { case List(ValString(value)) =>
         val bytes = value.getBytes(StandardCharsets.UTF_8)
         ValString(Base64.getEncoder.encodeToString(bytes))
+      }
+    )
+
+  private def fromBase64Function =
+    builtinFunction(
+      params = List("value"),
+      invoke = { case List(ValString(value)) =>
+        Try(Base64.getDecoder.decode(value))
+          .map { bytes =>
+            ValString(new String(bytes, StandardCharsets.UTF_8))
+          }
+          .recover { _ =>
+            ValError(s"Invalid Base64 value '$value'")
+          }
+          .get
       }
     )
 

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -16,8 +16,8 @@
  */
 package org.camunda.feel.impl.builtin
 
+import org.camunda.feel.api.EvaluationFailureType.FUNCTION_INVOCATION_FAILURE
 import org.camunda.feel.impl.{EvaluationResultMatchers, FeelEngineTest}
-import org.camunda.feel.syntaxtree._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -204,7 +204,10 @@ class BuiltinStringFunctionsTest
   }
 
   it should "return null if the value is not a valid base64 string" in {
-    evaluateExpression(""" from base64("!!!") """) should returnNull()
+    evaluateExpression(""" from base64("!!!") """) should (returnNull() and reportFailure(
+      failureType = FUNCTION_INVOCATION_FAILURE,
+      failureMessage = "Failed to invoke function 'from base64': Invalid Base64 value '!!!'"
+    ))
   }
 
   "A is blank() function" should "return true if the string contains only whitespace" in {

--- a/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
+++ b/src/test/scala/org/camunda/feel/impl/builtin/BuiltinStringFunctionsTest.scala
@@ -196,6 +196,17 @@ class BuiltinStringFunctionsTest
     evaluateExpression(""" to base64(value: "Camunda") """) should returnResult("Q2FtdW5kYQ==")
   }
 
+  "A from base64() function" should "return a string decoded from base64" in {
+
+    evaluateExpression(""" from base64("RkVFTA==") """) should returnResult("FEEL")
+
+    evaluateExpression(""" from base64(value: "Q2FtdW5kYQ==") """) should returnResult("Camunda")
+  }
+
+  it should "return null if the value is not a valid base64 string" in {
+    evaluateExpression(""" from base64("!!!") """) should returnNull()
+  }
+
   "A is blank() function" should "return true if the string contains only whitespace" in {
     evaluateExpression(
       expression = """ is blank("") """


### PR DESCRIPTION
## Description

This pull request introduces a new built-in function to decode Base64-encoded strings.

**Testing:**

* Added tests for the `from base64()` function to verify correct decoding and proper handling of invalid Base64 input in `BuiltinStringFunctionsTest`.

## Related issues

closes #1152
