### PR TITLE
chore: verify vault secrets after team-scoped AppRole migration

### DIFF
--- a/.github/workflows/VERIFY_VAULT_SECRETS.yml
+++ b/.github/workflows/VERIFY_VAULT_SECRETS.yml
@@ -1,0 +1,45 @@
+name: Verify Vault Secrets
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/VERIFY_VAULT_SECRETS.yml"
+
+jobs:
+  verify-vault-secrets:
+    name: Verify Vault access
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Secrets (zeebe)
+        id: secrets-zeebe
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_USR;
+            secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
+
+      - name: Import Secrets (org)
+        id: secrets-org
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_USR;
+            secret/data/github.com/organizations/camunda MAVEN_CENTRAL_DEPLOYMENT_PSW;
+
+      - name: Verify all secrets loaded
+        run: |
+          echo "✅ All Vault secrets imported successfully"
+          echo "  - zeebe: ARTIFACTS_USR present=${{ steps.secrets-zeebe.outputs.ARTIFACTS_USR != '' }}"
+          echo "  - org: MAVEN_CENTRAL_DEPLOYMENT_USR present=${{ steps.secrets-org.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR != '' }}"


### PR DESCRIPTION
Temporary verification workflow to confirm Vault access works after migration to team-scoped AppRole (zeebe).

Related to camunda/team-infrastructure#867

**This PR will be closed after verification.**