### PR TITLE
docs: Playground use new API URL

### DIFF
--- a/docs/docs/playground/playground.mdx
+++ b/docs/docs/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/src/components/FeelPlaygroundVersion.js
+++ b/docs/src/components/FeelPlaygroundVersion.js
@@ -9,7 +9,7 @@ const FeelPlaygroundVersion = ({
   function loadVersion() {
     axios
         .get(
-            "https://feel.upgradingdave.com/api/v1/version",
+            "https://feel-playground.camunda.com/api/v1/version",
             {
               headers: {
                 accept: "*/*",

--- a/docs/src/components/LiveFeel.js
+++ b/docs/src/components/LiveFeel.js
@@ -60,7 +60,7 @@ const LiveFeel = ({
   function evaluate(parsedContext) {
     axios
       .post(
-          "https://feel.upgradingdave.com/api/v1/feel/evaluate",
+          "https://feel-playground.camunda.com/api/v1/feel/evaluate",
         {
           expression: expression,
           context: parsedContext,

--- a/docs/src/components/LiveFeelUnaryTests.js
+++ b/docs/src/components/LiveFeelUnaryTests.js
@@ -71,7 +71,7 @@ const LiveFeelUnaryTests = ({
   function evaluate(parsedContext, parsedInputValue) {
     axios
       .post(
-          "https://feel.upgradingdave.com/api/v1/feel-unary-tests/evaluate",
+          "https://feel-playground.camunda.com/api/v1/feel-unary-tests/evaluate",
         {
           expression: expression,
           inputValue: parsedInputValue,

--- a/docs/versioned_docs/version-1.15/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.15/playground/playground.mdx
@@ -6,10 +6,8 @@ title: Playground for FEEL expressions
 import LiveFeel from "@site/src/components/LiveFeel";
 import dedent from "dedent";
 
-:::danger Work in progress
-The playground is created as part of our Camunda Summer Hack Days project 2022.
-
-It may be broken. But stay tuned for updates!
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
 :::
 
 Use the interactive editor below to evaluate

--- a/docs/versioned_docs/version-1.16/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.16/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/versioned_docs/version-1.17/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.17/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/versioned_docs/version-1.18/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.18/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/versioned_docs/version-1.19/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.19/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/versioned_docs/version-1.20/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.20/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 

--- a/docs/versioned_docs/version-1.21/playground/playground.mdx
+++ b/docs/versioned_docs/version-1.21/playground/playground.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 
 # FEEL Playground
 
+:::tip
+A new version of the FEEL-Scala Playground is available under https://feel-playground.camunda.com/playground.
+:::
+
 Use the interactive editor below to evaluate
 [FEEL expressions](https://docs.camunda.io/docs/components/modeler/feel/language-guide/feel-expressions-introduction/).
 


### PR DESCRIPTION
## Description

Fix the playground by using the new URL: `https://feel-playground.camunda.com/api/*`

Add a note to highlight the new playground frontend: https://feel-playground.camunda.com/playground.

## Related issues

closes https://github.com/camunda-community-hub/feel-scala-playground/issues/140
